### PR TITLE
fix: add 'change()' to migration file

### DIFF
--- a/database/migrations/2024_04_09_184714_add_download_name_to_round_maps.php
+++ b/database/migrations/2024_04_09_184714_add_download_name_to_round_maps.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('round_maps', function (Blueprint $table) {
-            $table->string('download_name')->default('map.pk3');
+            $table->string('download_name')->default('map.pk3')->change();
             $table->boolean('external')->default(false);
         });
     }


### PR DESCRIPTION
Migration "2024_04_09_184714_add_download_name_to_round_maps.php" adds to "download_name" column a default value "map.pk3".

Add missing "change()" method.