### PR TITLE
Development fix

### DIFF
--- a/local_devel/start_local_server.sh
+++ b/local_devel/start_local_server.sh
@@ -27,9 +27,7 @@ cp -v ./local_devel/.env.local_devel .env
 cp -v ./local_devel/docker-compose.yml.local_devel docker-compose.yml
 
 # Build and start Sail
-composer update laravel/sail
-./vendor/bin/sail build --no-cache
-./vendor/bin/sail up -d
+composer update laravel/sail --no-autoloader --no-scripts
 
 # Hotfix of incompatible packages pestphp vs termwind
 # Check if required tools are installed
@@ -39,12 +37,16 @@ command -v patch >/dev/null 2>&1 || { echo "Error: patch is required but not ins
 PATCH_TARGET_FILE="./vendor/nunomaduro/termwind/src/HtmlRenderer.php"
 PATCH_FILE="./local_devel/termwind_HtmlRenderer.patch"
 PATCH_FROM_CRC="3545166925"
-CURRENT_CRC=$(cksum "$TARGET_FILE" | awk '{print toupper($1)}')
+CURRENT_CRC=$(cksum "$PATCH_TARGET_FILE" | awk '{print toupper($1)}')
 
 if [ "$CURRENT_CRC" = "$PATCH_FROM_CRC" ]; then
     echo "Hotfixing nunomaduro/termwind..."
     patch "$PATCH_TARGET_FILE" < "$PATCH_FILE"
 fi
+
+composer dump-autoload
+./vendor/bin/sail build --no-cache
+./vendor/bin/sail up -d
 
 # Wait for Sail to start
 sleep 5

--- a/local_devel/start_local_server.sh
+++ b/local_devel/start_local_server.sh
@@ -31,6 +31,21 @@ composer update laravel/sail
 ./vendor/bin/sail build --no-cache
 ./vendor/bin/sail up -d
 
+# Hotfix of incompatible packages pestphp vs termwind
+# Check if required tools are installed
+command -v cksum >/dev/null 2>&1 || { echo "Error: cksum is required but not installed."; exit 1; }
+command -v patch >/dev/null 2>&1 || { echo "Error: patch is required but not installed."; exit 1; }
+
+PATCH_TARGET_FILE="./vendor/nunomaduro/termwind/src/HtmlRenderer.php"
+PATCH_FILE="./local_devel/termwind_HtmlRenderer.patch"
+PATCH_FROM_CRC="3545166925"
+CURRENT_CRC=$(cksum "$TARGET_FILE" | awk '{print toupper($1)}')
+
+if [ "$CURRENT_CRC" = "$PATCH_FROM_CRC" ]; then
+    echo "Hotfixing nunomaduro/termwind..."
+    patch "$PATCH_TARGET_FILE" < "$PATCH_FILE"
+fi
+
 # Wait for Sail to start
 sleep 5
 

--- a/local_devel/start_local_server.sh
+++ b/local_devel/start_local_server.sh
@@ -27,7 +27,11 @@ cp -v ./local_devel/.env.local_devel .env
 cp -v ./local_devel/docker-compose.yml.local_devel docker-compose.yml
 
 # Build and start Sail
-composer update laravel/sail --no-autoloader --no-scripts
+SAIL_NO_CACHE=false
+COMPOSER_OUTPUT=$(composer update laravel/sail --no-autoloader --no-scripts 2>&1)
+if echo "$COMPOSER_OUTPUT" | grep -q "Upgrading laravel/sail"; then
+    SAIL_NO_CACHE=true
+fi
 
 # Hotfix of incompatible packages pestphp vs termwind
 # Check if required tools are installed
@@ -45,7 +49,12 @@ if [ "$CURRENT_CRC" = "$PATCH_FROM_CRC" ]; then
 fi
 
 composer dump-autoload
-./vendor/bin/sail build --no-cache
+
+if SAIL_NO_CACHE; then
+    ./vendor/bin/sail build --no-cache
+else
+    ./vendor/bin/sail build
+fi
 ./vendor/bin/sail up -d
 
 # Wait for Sail to start

--- a/local_devel/start_local_server.sh
+++ b/local_devel/start_local_server.sh
@@ -49,6 +49,7 @@ if [ "$CURRENT_CRC" = "$PATCH_FROM_CRC" ]; then
 fi
 
 composer dump-autoload
+composer run-script post-update-cmd
 
 if SAIL_NO_CACHE; then
     ./vendor/bin/sail build --no-cache

--- a/local_devel/termwind_HtmlRenderer.patch
+++ b/local_devel/termwind_HtmlRenderer.patch
@@ -1,0 +1,17 @@
+--- ./HtmlRenderer.php	2023-02-08 02:06:31.000000000 +0100
++++ ./HtmlRenderer-fixed.php	2025-05-14 13:43:09.684174148 +0200
+@@ -35,7 +35,13 @@
+             return Termwind::span($html);
+         }
+ 
+-        $html = '<?xml encoding="UTF-8">'.trim($html);
++        $html = trim($html);
++
++        if(strpos($html, '<body') === false){
++            $html = '<body>'.$html.'</body>';
++        }
++
++        $html = '<?xml encoding="UTF-8">'.$html;
+         $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS | LIBXML_NOXMLDECL);
+ 
+         /** @var DOMNode $body */


### PR DESCRIPTION
The latest versions of packages pestphp/pest and nunomaduro/termwind defined in composer.json are incompatible, this is hotfix for that issue. Proper way would be updating major version of one of these to make them compatible again without the need of hotfix, but that require dealing with breaking changes.

Also there is added condition to not rebuild sail container every time the start_local_server.sh script is executed (aka use cache).