### PR TITLE
Add rank multiplier to rating system and fix multiple issues

### DIFF
--- a/app/Filament/Pages/RatingSettings.php
+++ b/app/Filament/Pages/RatingSettings.php
@@ -30,6 +30,7 @@ class RatingSettings extends Page
     public string $min_top1_time = '';
     public string $max_tied_wr_players = '';
     public string $rank_exponent = '';
+    public string $rank_v = '';
     public string $min_total_records = '';
 
     // Recalc controls
@@ -40,7 +41,7 @@ class RatingSettings extends Page
         'cfg_a', 'cfg_b', 'cfg_m', 'cfg_v', 'cfg_q', 'cfg_d',
         'mult_l', 'mult_n',
         'min_map_players', 'min_top1_time', 'max_tied_wr_players',
-        'rank_exponent', 'min_total_records',
+        'rank_exponent', 'rank_v', 'min_total_records',
     ];
 
     public static function canAccess(): bool
@@ -101,9 +102,9 @@ class RatingSettings extends Page
             return;
         }
 
-        // Clear previous log
-        Cache::forget('rating_recalc:log');
-        Cache::forget('rating_recalc:status');
+        // Set status immediately so UI starts polling
+        Cache::put('rating_recalc:log', ['[' . now()->format('H:i:s') . '] Dispatched, waiting for worker...'], 86400);
+        Cache::put('rating_recalc:status', 'running', 86400);
 
         RunRatingsRecalcJob::dispatch($this->selectedPhysics, $this->selectedCategories);
 
@@ -198,7 +199,8 @@ class RatingSettings extends Page
                 'min_total_records' => 'Min records before penalty applies',
             ],
             'Rank Multiplier' => [
-                'rank_exponent' => 'Exponent for rank-based multiplier',
+                'rank_exponent' => 'Steepness exponent (n)',
+                'rank_v' => 'Total players modifier (v)',
             ],
         ];
     }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1232,7 +1232,9 @@ class ProfileController extends Controller {
 
     public function ratingBreakdown(Request $request, $mddId, $physics)
     {
-        if (!$request->user()?->isAdmin()) {
+        $user = $request->user();
+        $canView = $user?->admin || ($user?->is_moderator && is_array($user->moderator_permissions) && in_array('rating_breakdown', $user->moderator_permissions));
+        if (!$canView) {
             abort(403);
         }
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -66,7 +66,7 @@ return [
             'driver' => 'redis',
             'connection' => 'default',
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => 90,
+            'retry_after' => 3600,
             'block_for' => null,
             'after_commit' => false,
         ],

--- a/config/ratings.php
+++ b/config/ratings.php
@@ -18,6 +18,7 @@ $defaults = [
     'min_top1_time' => 500,
     'max_tied_wr_players' => 3,
     'rank_exponent' => 1.5,
+    'rank_v' => 2.0,
     'min_total_records' => 10,
 ];
 
@@ -40,5 +41,6 @@ return [
     'min_top1_time' => (int) ($db['min_top1_time'] ?? $defaults['min_top1_time']),
     'max_tied_wr_players' => (int) ($db['max_tied_wr_players'] ?? $defaults['max_tied_wr_players']),
     'rank_exponent' => (float) ($db['rank_exponent'] ?? $defaults['rank_exponent']),
+    'rank_v' => (float) ($db['rank_v'] ?? $defaults['rank_v']),
     'min_total_records' => (int) ($db['min_total_records'] ?? $defaults['min_total_records']),
 ];

--- a/database/migrations/2026_04_05_181242_add_rank_v_to_rating_settings.php
+++ b/database/migrations/2026_04_05_181242_add_rank_v_to_rating_settings.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('rating_settings')->insertOrIgnore([
+            'key' => 'rank_v',
+            'value' => '2.0',
+            'description' => 'Rank multiplier total_players modifier (v)',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('rating_settings')->where('key', 'rank_v')->delete();
+    }
+};

--- a/database/migrations/2026_04_05_181444_add_rank_multiplier_to_player_map_scores.php
+++ b/database/migrations/2026_04_05_181444_add_rank_multiplier_to_player_map_scores.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('player_map_scores', function (Blueprint $table) {
+            $table->double('rank_multiplier')->default(1.0)->after('multiplier');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_map_scores', function (Blueprint $table) {
+            $table->dropColumn('rank_multiplier');
+        });
+    }
+};

--- a/resources/js/Components/Rating.vue
+++ b/resources/js/Components/Rating.vue
@@ -131,7 +131,7 @@
                 :style="{ left: dateTooltipPos.x + 15 + 'px', top: dateTooltipPos.y - 40 + 'px' }"
             >
                 <div class="bg-gray-900 border border-white/10 text-gray-200 rounded-lg px-3 py-1.5 shadow-2xl text-xs font-semibold whitespace-nowrap">
-                    <span class="text-gray-500">Last Active:</span> {{ new Date(rating.last_activity).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' }) }}
+                    <span class="text-gray-500">Last Active:</span> {{ fmtDate(rating.last_activity) }}
                 </div>
             </div>
         </Teleport>

--- a/resources/js/Pages/RankingHowItWorks.vue
+++ b/resources/js/Pages/RankingHowItWorks.vue
@@ -10,6 +10,16 @@ const CFG_Q = 0.5;
 const CFG_D = 0.02;
 const MULT_L = 1.0;
 const MULT_N = 2.0;
+const RANK_N = 1.5;
+const RANK_V = 2.0;
+
+function calcRankMultiplier(totalPlayers, yourRank) {
+    if (totalPlayers <= 1 || yourRank === 0) return 1.0;
+    const numerator = (totalPlayers * RANK_V) - yourRank;
+    const denominator = (totalPlayers * RANK_V) - 1;
+    if (denominator <= 0) return 1.0;
+    return Math.pow(Math.max(numerator / denominator, 0), RANK_N);
+}
 
 function calcMapScore(reltime) {
     return 1000 * (CFG_A + (-CFG_A / Math.pow(1 + CFG_Q * Math.exp(-CFG_B * (reltime - CFG_M)), 1 / CFG_V)));
@@ -48,6 +58,11 @@ const exampleFinalScore = exampleBaseScore * exampleMultiplier;
 const exampleSmallMap = calcMultiplier(4, 13);
 const exampleMedMap = calcMultiplier(13, 13);
 const exampleBigMap = calcMultiplier(50, 13);
+
+const exampleRankMult1 = calcRankMultiplier(50, 1);
+const exampleRankMult5 = calcRankMultiplier(50, 5);
+const exampleRankMult25 = calcRankMultiplier(50, 25);
+const exampleRankMult50 = calcRankMultiplier(50, 50);
 
 const exampleScores = [850, 780, 720, 650, 600, 550, 500, 480, 420, 380, 350, 300];
 const exampleRating = calcPlayerRating(exampleScores);
@@ -305,30 +320,66 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 </div>
             </section>
 
-            <!-- 6. Final Score -->
-            <section id="final-score" class="mb-12">
+            <!-- 6. Rank Multiplier -->
+            <section id="rank-multiplier" class="mb-12">
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
-                    <span class="text-blue-400 text-lg font-mono">6.</span> Final Map Score
+                    <span class="text-blue-400 text-lg font-mono">6.</span> Rank Multiplier
                 </h2>
-                <p class="mb-3">The final score for each record is simply:</p>
-                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-lg text-white mb-3">
-                    final_score = base_score * multiplier
+                <p class="mb-3">Your rank on each map further scales your score. Higher ranks earn a bigger multiplier:</p>
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-sm text-white mb-3 overflow-x-auto">
+                    rank_mult = (((total_players * v) - your_rank) / ((total_players * v) - 1)) ^ n
+                </div>
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
+                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Current parameters</div>
+                    <div class="text-sm space-y-1">
+                        <div><span class="text-gray-400">n (steepness):</span> <span class="text-white font-mono">{{ RANK_N }}</span></div>
+                        <div><span class="text-gray-400">v (total_players modifier):</span> <span class="text-white font-mono">{{ RANK_V }}</span></div>
+                    </div>
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
-                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Example (25 players, VQ3 overall median = 13)</div>
+                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Example: 50 players on a map</div>
+                    <div class="space-y-2">
+                        <div v-for="[rank, label] in [[1, 'Rank #1 (WR)'], [5, 'Rank #5'], [25, 'Rank #25'], [50, 'Rank #50 (last)']]" :key="rank">
+                            <div class="flex justify-between items-center text-sm mb-1">
+                                <span>{{ label }}</span>
+                                <span class="font-mono font-bold" :class="calcRankMultiplier(50, rank) > 0.8 ? 'text-green-400' : calcRankMultiplier(50, rank) > 0.5 ? 'text-yellow-400' : 'text-red-400'">{{ (calcRankMultiplier(50, rank) * 100).toFixed(1) }}%</span>
+                            </div>
+                            <div class="w-full bg-gray-800 rounded-full h-2">
+                                <div class="h-2 rounded-full" :class="calcRankMultiplier(50, rank) > 0.8 ? 'bg-green-500' : calcRankMultiplier(50, rank) > 0.5 ? 'bg-yellow-500' : 'bg-red-500'" :style="`width: ${calcRankMultiplier(50, rank) * 100}%`"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="mt-3 bg-purple-500/10 border border-purple-500/20 rounded-lg p-3 text-xs text-purple-300">
+                    <strong>Why?</strong> Two players on the same map with similar times could have very different ranks. The rank multiplier ensures that actually beating more players gives a bigger reward, not just having a fast time.
+                </div>
+            </section>
+
+            <!-- 7. Final Score -->
+            <section id="final-score" class="mb-12">
+                <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
+                    <span class="text-blue-400 text-lg font-mono">7.</span> Final Map Score
+                </h2>
+                <p class="mb-3">The final score for each record combines all multipliers:</p>
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-lg text-white mb-3">
+                    final_score = base_score * map_multiplier * rank_multiplier
+                </div>
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
+                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Example (25 players, rank #3, VQ3 overall median = 13)</div>
                     <div class="text-sm space-y-1">
                         <div>Your reltime: <span class="text-white font-mono">{{ exampleReltime.toFixed(4) }}</span></div>
                         <div>Base score: <span class="text-white font-mono">{{ exampleBaseScore.toFixed(1) }}</span></div>
                         <div>Map multiplier (25 players): <span class="text-white font-mono">{{ exampleMultiplier.toFixed(4) }}</span> ({{ (exampleMultiplier * 100).toFixed(1) }}%)</div>
-                        <div class="pt-1 border-t border-gray-800">Final score: {{ exampleBaseScore.toFixed(1) }} * {{ exampleMultiplier.toFixed(4) }} = <span class="text-green-400 font-mono font-bold">{{ exampleFinalScore.toFixed(1) }}</span></div>
+                        <div>Rank multiplier (rank #3 of 25): <span class="text-white font-mono">{{ calcRankMultiplier(25, 3).toFixed(4) }}</span> ({{ (calcRankMultiplier(25, 3) * 100).toFixed(1) }}%)</div>
+                        <div class="pt-1 border-t border-gray-800">Final score: {{ exampleBaseScore.toFixed(1) }} * {{ exampleMultiplier.toFixed(4) }} * {{ calcRankMultiplier(25, 3).toFixed(4) }} = <span class="text-green-400 font-mono font-bold">{{ (exampleBaseScore * exampleMultiplier * calcRankMultiplier(25, 3)).toFixed(1) }}</span></div>
                     </div>
                 </div>
             </section>
 
-            <!-- 7. Player Rating -->
+            <!-- 8. Player Rating -->
             <section id="player-rating" class="mb-12">
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
-                    <span class="text-blue-400 text-lg font-mono">7.</span> Player Rating
+                    <span class="text-blue-400 text-lg font-mono">8.</span> Player Rating
                 </h2>
                 <p class="mb-3">A player's overall rating is calculated from all their map scores using <strong class="text-white">exponential weighting</strong>:</p>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-sm text-white mb-3 overflow-x-auto">
@@ -378,7 +429,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
             <!-- 8. Categories -->
             <section id="categories" class="mb-12">
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
-                    <span class="text-blue-400 text-lg font-mono">8.</span> Categories
+                    <span class="text-blue-400 text-lg font-mono">9.</span> Categories
                 </h2>
                 <p class="mb-3">Rankings are calculated separately for each category. A map belongs to a category based on its weapons and features:</p>
                 <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
@@ -427,7 +478,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
             <!-- 9. Updates -->
             <section id="updates" class="mb-12">
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
-                    <span class="text-blue-400 text-lg font-mono">9.</span> Real-time Updates
+                    <span class="text-blue-400 text-lg font-mono">10.</span> Real-time Updates
                 </h2>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 space-y-3">
                     <div class="flex items-start gap-3">
@@ -458,7 +509,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
             <!-- 10. Full Example -->
             <section id="full-example" class="mb-12">
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
-                    <span class="text-blue-400 text-lg font-mono">10.</span> Full Walkthrough Example
+                    <span class="text-blue-400 text-lg font-mono">11.</span> Full Walkthrough Example
                 </h2>
                 <p class="mb-3 text-sm">Let's follow a complete calculation for a player with a record on "run_example" (VQ3 Overall):</p>
 

--- a/resources/views/filament/pages/rating-settings.blade.php
+++ b/resources/views/filament/pages/rating-settings.blade.php
@@ -24,18 +24,14 @@
                 <div style="display: flex; flex-direction: column; gap: 16px;">
                     @foreach($left as $groupName)
                         @if(isset($groups[$groupName]))
-                            @php $isDisabled = $groupName === 'Rank Multiplier'; @endphp
-                            <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-4" @if($isDisabled) style="opacity: 0.4; pointer-events: none;" @endif>
-                                <h3 style="font-size: 11px; font-weight: 800; color: {{ $isDisabled ? '#6b7280' : '#ea580c' }}; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 10px;">
+                            <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 p-4">
+                                <h3 style="font-size: 11px; font-weight: 800; color: #ea580c; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 10px;">
                                     {{ $groupName }}
-                                    @if($isDisabled)
-                                        <span style="font-weight: 400; font-size: 10px; color: #6b7280; text-transform: none; letter-spacing: 0;"> - not yet implemented</span>
-                                    @endif
                                 </h3>
                                 @foreach($groups[$groupName] as $key => $label)
                                     <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px;">
                                         <code style="width: 130px; font-size: 11px; color: #9ca3af; flex-shrink: 0;">{{ $key }}</code>
-                                        <input type="text" wire:model.blur="{{ $key }}" @if($isDisabled) disabled @endif onkeydown="if(!/[0-9.\-\b]|Tab|ArrowLeft|ArrowRight|Delete|Backspace/.test(event.key))event.preventDefault()" oninput="this.value=this.value.replace(/[^0-9.\-]/g,'')" style="background: #111; color: #fff; width: 80px; padding: 4px 8px; font-size: 13px; font-family: monospace; border: 1px solid #444; border-radius: 6px; flex-shrink: 0;" />
+                                        <input type="text" wire:model.blur="{{ $key }}" onkeydown="if(!/[0-9.\-\b]|Tab|ArrowLeft|ArrowRight|Delete|Backspace/.test(event.key))event.preventDefault()" oninput="this.value=this.value.replace(/[^0-9.\-]/g,'')" style="background: #111; color: #fff; width: 80px; padding: 4px 8px; font-size: 13px; font-family: monospace; border: 1px solid #444; border-radius: 6px; flex-shrink: 0;" />
                                         <span style="font-size: 11px; color: #6b7280;">{{ $label }}</span>
                                     </div>
                                 @endforeach

--- a/rust-rating-service/src/main.rs
+++ b/rust-rating-service/src/main.rs
@@ -23,6 +23,8 @@ struct RatingConfig {
     cfg_d: f64,
     mult_l: f64,
     mult_n: f64,
+    rank_n: f64,
+    rank_v: f64,
 }
 
 impl RatingConfig {
@@ -54,6 +56,8 @@ impl RatingConfig {
             cfg_d: get_f64("cfg_d", 0.02),
             mult_l: get_f64("mult_l", 1.0),
             mult_n: get_f64("mult_n", 2.0),
+            rank_n: get_f64("rank_exponent", 1.5),
+            rank_v: get_f64("rank_v", 2.0),
         }
     }
 }
@@ -76,6 +80,7 @@ struct ProcessedRecord {
     reltime: f64,
     map_score: f64,
     multiplier: f64,
+    rank_multiplier: f64,
     is_outlier: bool,
 }
 
@@ -130,6 +135,22 @@ fn find_normal_cluster_start(_times: &[i32]) -> usize {
 
 fn calculate_map_score(reltime: f64, cfg: &RatingConfig) -> f64 {
     1000.0 * (cfg.cfg_a + (-cfg.cfg_a / (1.0 + cfg.cfg_q * (-cfg.cfg_b * (reltime - cfg.cfg_m)).exp()).powf(1.0 / cfg.cfg_v)))
+}
+
+/// Rank-based multiplier: rewards higher ranks on a map.
+/// rank_multiplier = (((total_players * v) - your_rank) / ((total_players * v) - 1)) ^ n
+fn calculate_rank_multiplier(total_players: usize, your_rank: usize, cfg: &RatingConfig) -> f64 {
+    if cfg.rank_n == 0.0 || cfg.rank_v == 0.0 || total_players <= 1 || your_rank == 0 {
+        return 1.0;
+    }
+    let tp = total_players as f64;
+    let rank = your_rank as f64;
+    let numerator = (tp * cfg.rank_v) - rank;
+    let denominator = (tp * cfg.rank_v) - 1.0;
+    if denominator <= 0.0 {
+        return 1.0;
+    }
+    (numerator / denominator).max(0.0).powf(cfg.rank_n)
 }
 
 /// Map score multiplier based on number of records/players on given map.
@@ -242,13 +263,19 @@ fn process_map_records(records: &[Record], stats: &MapStats, category_median: f6
         let base_score = calculate_map_score(reltime, cfg);
         // Apply map multiplier based on number of records/players on given map
         let multiplier = calculate_map_multiplier(stats.total_participators, category_median, cfg);
-        let map_score = base_score * multiplier;
+
+        // Apply rank multiplier: find player's rank on this map (1-indexed)
+        let your_rank = times.iter().position(|&t| t == record.time).map(|p| p + 1).unwrap_or(stats.total_participators);
+        let rank_mult = calculate_rank_multiplier(stats.total_participators, your_rank, cfg);
+
+        let map_score = base_score * multiplier * rank_mult;
 
         Some(ProcessedRecord {
             record: record.clone(),
             reltime,
             map_score,
             multiplier,
+            rank_multiplier: rank_mult,
             is_outlier: is_in_outlier_group,
         })
     }).collect()
@@ -336,7 +363,7 @@ fn save_map_scores(conn: &mut PooledConn, processed: &[ProcessedRecord], physics
         let mut values: Vec<String> = Vec::new();
         for rec in chunk {
             values.push(format!(
-                "({}, {}, '{}', '{}', '{}', {}, {}, {}, {}, {}, NOW(), NOW())",
+                "({}, {}, '{}', '{}', '{}', {}, {}, {}, {}, {}, {}, NOW(), NOW())",
                 rec.record.mdd_id,
                 rec.record.user_id.map_or("NULL".to_string(), |id| id.to_string()),
                 rec.record.mapname.replace("'", "''"),
@@ -346,12 +373,13 @@ fn save_map_scores(conn: &mut PooledConn, processed: &[ProcessedRecord], physics
                 rec.reltime,
                 rec.map_score,
                 rec.multiplier,
+                rec.rank_multiplier,
                 if rec.is_outlier { 1 } else { 0 },
             ));
         }
 
         let query = format!(
-            "INSERT INTO player_map_scores (mdd_id, user_id, mapname, physics, mode, time, reltime, map_score, multiplier, is_outlier, created_at, updated_at) VALUES {} ON DUPLICATE KEY UPDATE time=VALUES(time), reltime=VALUES(reltime), map_score=VALUES(map_score), multiplier=VALUES(multiplier), is_outlier=VALUES(is_outlier), user_id=VALUES(user_id), updated_at=NOW()",
+            "INSERT INTO player_map_scores (mdd_id, user_id, mapname, physics, mode, time, reltime, map_score, multiplier, rank_multiplier, is_outlier, created_at, updated_at) VALUES {} ON DUPLICATE KEY UPDATE time=VALUES(time), reltime=VALUES(reltime), map_score=VALUES(map_score), multiplier=VALUES(multiplier), rank_multiplier=VALUES(rank_multiplier), is_outlier=VALUES(is_outlier), user_id=VALUES(user_id), updated_at=NOW()",
             values.join(",")
         );
 
@@ -847,8 +875,8 @@ fn main() -> Result<()> {
 
     // Load rating config from database (rating_settings table)
     let cfg = RatingConfig::from_db(&mut conn);
-    println!("Config: D={}, A={}, B={}, M={}, V={}, Q={}, MULT_L={}, MULT_N={}, min_players={}, min_time={}, max_tied_wr={}, min_records={}",
-        cfg.cfg_d, cfg.cfg_a, cfg.cfg_b, cfg.cfg_m, cfg.cfg_v, cfg.cfg_q, cfg.mult_l, cfg.mult_n,
+    println!("Config: D={}, A={}, B={}, M={}, V={}, Q={}, MULT_L={}, MULT_N={}, RANK_N={}, RANK_V={}, min_players={}, min_time={}, max_tied_wr={}, min_records={}",
+        cfg.cfg_d, cfg.cfg_a, cfg.cfg_b, cfg.cfg_m, cfg.cfg_v, cfg.cfg_q, cfg.mult_l, cfg.mult_n, cfg.rank_n, cfg.rank_v,
         cfg.min_map_total_participators, cfg.min_top1_time, cfg.max_tied_wr_players, cfg.min_total_records);
 
     // Load maps for category filtering


### PR DESCRIPTION
## Summary
- Implemented rank multiplier formula `(((tp*v - rank) / (tp*v - 1))^n)` in Rust rating service with configurable n (steepness) and v (total_players modifier) parameters
- Added `rank_v` DB setting, `rank_multiplier` column to player_map_scores, and enabled Rank Multiplier section in admin panel
- Added Rank Multiplier section with visual examples to "How Rankings Work" page
- Fixed Redis `retry_after` from 90s to 3600s (was killing long-running rating recalc jobs)
- Fixed rating breakdown endpoint returning 403 for moderators with `rating_breakdown` permission
- Fixed recalc UI not showing "Running" state immediately after dispatch
- Fixed ranking date tooltip ignoring user's global date format preference
- Added YouTube metadata fields (title/description/tags) to rendered video edit page and fixed invisible text in YT Info modal

## Test plan
- [ ] Run rating recalc from admin panel - verify both VQ3 and CPM complete without timeout
- [ ] Verify rank multiplier values in player_map_scores table after recalc
- [ ] Test setting rank_exponent=0 or rank_v=0 disables rank multiplier (returns 1.0)
- [ ] Verify moderator with rating_breakdown permission can view rating breakdown on profiles
- [ ] Check ranking dates respect user's date format setting (including tooltip)
- [ ] Test YT Info modal shows readable text and tags on rendered videos list