### PR TITLE
Responsive UI improvements across records, clans, profile and settings

### DIFF
--- a/resources/js/Components/Record.vue
+++ b/resources/js/Components/Record.vue
@@ -1,6 +1,6 @@
 <script setup>
     import { Link, usePage } from '@inertiajs/vue3';
-    import { computed, ref } from 'vue';
+    import { computed, ref, onMounted, onUnmounted } from 'vue';
 
     const props = defineProps({
         record: Object
@@ -10,6 +10,13 @@
     const page = usePage();
     const isLoggedIn = computed(() => !!page.props.auth?.user);
 
+    const windowWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 1280);
+    const onResize = () => { windowWidth.value = window.innerWidth; };
+    onMounted(() => window.addEventListener('resize', onResize));
+    onUnmounted(() => window.removeEventListener('resize', onResize));
+
+    const isCompact = computed(() => windowWidth.value < 500);
+
     const fmtDate = (dateStr) => {
         const d = new Date(dateStr);
         const dd = String(d.getDate()).padStart(2, '0');
@@ -17,6 +24,8 @@
         const yy = String(d.getFullYear()).slice(-2);
         const yyyy = String(d.getFullYear());
         const fmt = page.props.dateFormat;
+        // Under 500px, always use short year
+        if (isCompact.value) return `${dd}/${mm}/${yy}`;
         if (fmt === 'dmY') return `${dd}/${mm}/${yyyy}`;
         if (fmt === 'Ymd') return `${yyyy}/${mm}/${dd}`;
         if (fmt === 'dmy') return `${dd}/${mm}/${yy}`;
@@ -24,6 +33,7 @@
     };
 
     const dateColWidth = computed(() => {
+        if (isCompact.value) return 'w-[50px]';
         const fmt = page.props.dateFormat;
         return (fmt === 'Ymd' || fmt === 'dmY') ? 'w-[72px]' : 'w-[50px]';
     });
@@ -110,20 +120,20 @@
             <!-- Map + Time + Score + Date -->
             <div class="flex items-center gap-2 sm:gap-3 flex-shrink-0">
                 <!-- Map Name -->
-                <div class="w-28 sm:w-40 flex-shrink-0">
+                <div class="w-16 min-[500px]:w-20 sm:w-40 flex-shrink-0">
                     <div class="text-xs sm:text-sm font-bold text-gray-300 group-hover:text-white transition-all truncate drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] group-hover:drop-shadow-[0_2px_8px_rgba(0,0,0,1)]">{{ record.mapname }}</div>
                 </div>
                 <div class="flex items-center gap-0.5 ml-auto -mr-3">
-                    <div class="w-[80px] text-right">
+                    <div class="w-[60px] min-[500px]:w-[80px] text-right">
                         <div class="text-xs sm:text-sm font-black tabular-nums text-white leading-none drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] group-hover:drop-shadow-[0_2px_8px_rgba(0,0,0,1)]">{{ formatTime(record.time) }}</div>
                     </div>
-                    <div class="w-8 sm:w-10 text-center flex-shrink-0">
+                    <div class="hidden sm:block w-8 sm:w-10 text-center flex-shrink-0">
                         <div v-if="record.map_score"
                             class="text-xs sm:text-sm font-black tabular-nums leading-none text-yellow-400/80 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] cursor-help" style="padding-left: 5px"
                             @mouseenter="$emit('scoreHover', { score: record.map_score, reltime: record.reltime, multiplier: record.multiplier, el: $event.target })"
                             @mouseleave="$emit('scoreHover', null)">{{ Math.round(record.map_score) }}</div>
                     </div>
-                    <div :class="[dateColWidth, 'flex-shrink-0 text-right opacity-90 group-hover:opacity-100 transition-opacity']">
+                    <div :class="[dateColWidth, 'flex-shrink-0 text-right opacity-90 group-hover:opacity-100 transition-opacity']" v-if="windowWidth >= 400">
                         <div class="text-xs text-gray-100 whitespace-nowrap font-mono font-semibold group-hover:text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] leading-none">
                             {{ fmtDate(record.date_set) }}
                         </div>

--- a/resources/js/Pages/Clans/ClanCard.vue
+++ b/resources/js/Pages/Clans/ClanCard.vue
@@ -1,7 +1,12 @@
 <script setup>
     import { Link } from '@inertiajs/vue3';
     import Popper from "vue3-popper";
-    import { computed } from 'vue';
+    import { computed, ref, onMounted, onUnmounted } from 'vue';
+
+    const windowWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 1280);
+    const onResize = () => { windowWidth.value = window.innerWidth; };
+    onMounted(() => window.addEventListener('resize', onResize));
+    onUnmounted(() => window.removeEventListener('resize', onResize));
 
     const props = defineProps({
         clan: Object,
@@ -36,6 +41,52 @@
 
     const effectColor = computed(() => props.clan.effect_color || '#60a5fa');
     const avatarEffectColor = computed(() => props.clan.avatar_effect_color || '#60a5fa');
+
+    // Responsive: how many member avatars to show
+    const maxVisibleMembers = computed(() => {
+        const w = windowWidth.value;
+        if (w < 500) return 0;
+        if (w < 640) return 3;
+        if (w < 768) return 4;
+        if (w < 1024) return 5;
+        if (w < 1280) return 6;
+        return props.clan.players?.length || 0;
+    });
+
+    // Responsive: avatar size classes
+    const avatarSize = computed(() => {
+        const w = windowWidth.value;
+        if (w < 500) return 'h-6 w-6';
+        if (w < 640) return 'h-7 w-7';
+        if (w < 768) return 'h-7 w-7';
+        if (w < 1024) return 'h-8 w-8';
+        if (w < 1280) return 'h-8 w-8';
+        return 'h-10 w-10';
+    });
+
+    const avatarBadgeSize = computed(() => {
+        const w = windowWidth.value;
+        if (w < 640) return 'h-7 w-7 text-[9px]';
+        if (w < 1024) return 'h-8 w-8 text-[10px]';
+        return 'h-10 w-10 text-xs';
+    });
+
+    // Responsive: which stat boxes to show
+    const showStats = computed(() => windowWidth.value >= 768);
+    const showPodium = computed(() => windowWidth.value >= 1024);
+    const showWR = computed(() => windowWidth.value >= 900);
+    const statSize = computed(() => windowWidth.value < 1280 ? 'p-2' : 'p-3');
+    const statNumSize = computed(() => windowWidth.value < 1280 ? 'text-lg' : 'text-2xl');
+
+    const breakpointLabel = computed(() => {
+        const w = windowWidth.value;
+        if (w >= 1536) return `2xl (${w}px)`;
+        if (w >= 1280) return `xl (${w}px)`;
+        if (w >= 1024) return `lg (${w}px)`;
+        if (w >= 768) return `md (${w}px)`;
+        if (w >= 640) return `sm (${w}px)`;
+        return `xs (${w}px)`;
+    });
 
     const formatNumber = (num) => {
         if (!num) return '0';
@@ -185,42 +236,42 @@
                 </Link>
 
                 <!-- Featured Stats Boxes -->
-                <div v-if="!manage && clan.featured_stats && clan.featured_stats.length > 0" class="flex gap-3">
+                <div v-if="showStats && !manage && clan.featured_stats && clan.featured_stats.length > 0" class="flex gap-2 flex-shrink-0">
                     <!-- Total Records -->
-                    <div v-if="clan.featured_stats.includes('total_records')" class="group relative overflow-hidden rounded-xl p-3 hover:scale-105 transition-transform duration-300 bg-gradient-to-br from-blue-600/20 to-blue-800/20 border border-blue-500/30" :title="getStatTitle('total_records')">
+                    <div v-if="clan.featured_stats.includes('total_records')" :class="[statSize, 'group relative overflow-hidden rounded-xl hover:scale-105 transition-transform duration-300 bg-gradient-to-br from-blue-600/20 to-blue-800/20 border border-blue-500/30']" :title="getStatTitle('total_records')">
                         <Link :href="route('clans.show', clan.id)" class="relative flex items-center gap-2" @click.stop>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6 text-blue-400 flex-shrink-0">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-blue-400 flex-shrink-0">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
                             </svg>
                             <div>
-                                <div class="text-2xl font-black text-white">{{ formatNumber(clan.total_records || 0) }}</div>
-                                <div class="text-xs font-medium text-blue-300">Total Records</div>
+                                <div :class="[statNumSize, 'font-black text-white']">{{ formatNumber(clan.total_records || 0) }}</div>
+                                <div class="text-[10px] font-medium text-blue-300">Records</div>
                             </div>
                         </Link>
                     </div>
 
                     <!-- World Records -->
-                    <div v-if="clan.featured_stats.includes('world_records')" class="group relative overflow-hidden rounded-xl p-3 hover:scale-105 transition-transform duration-300 bg-gradient-to-br from-yellow-600/20 to-orange-800/20 border border-yellow-500/30" :title="getStatTitle('world_records')">
+                    <div v-if="showWR && clan.featured_stats.includes('world_records')" :class="[statSize, 'group relative overflow-hidden rounded-xl hover:scale-105 transition-transform duration-300 bg-gradient-to-br from-yellow-600/20 to-orange-800/20 border border-yellow-500/30']" :title="getStatTitle('world_records')">
                         <Link :href="route('clans.show', clan.id)" class="relative flex items-center gap-2" @click.stop>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6 text-yellow-400 flex-shrink-0">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" />
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-yellow-400 flex-shrink-0">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99 2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" />
                             </svg>
                             <div>
-                                <div class="text-2xl font-black text-white">{{ formatNumber(clan.total_wrs || 0) }}</div>
-                                <div class="text-xs font-medium text-yellow-300">World Records</div>
+                                <div :class="[statNumSize, 'font-black text-white']">{{ formatNumber(clan.total_wrs || 0) }}</div>
+                                <div class="text-[10px] font-medium text-yellow-300">WRs</div>
                             </div>
                         </Link>
                     </div>
 
                     <!-- Podium Finishes -->
-                    <div v-if="clan.featured_stats.includes('podium_finishes')" class="group relative overflow-hidden rounded-xl p-3 hover:scale-105 transition-transform duration-300 bg-gradient-to-br from-purple-600/20 to-pink-800/20 border border-purple-500/30" :title="getStatTitle('podium_finishes')">
+                    <div v-if="showPodium && clan.featured_stats.includes('podium_finishes')" :class="[statSize, 'group relative overflow-hidden rounded-xl hover:scale-105 transition-transform duration-300 bg-gradient-to-br from-purple-600/20 to-pink-800/20 border border-purple-500/30']" :title="getStatTitle('podium_finishes')">
                         <Link :href="route('clans.show', clan.id)" class="relative flex items-center gap-2" @click.stop>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6 text-purple-400 flex-shrink-0">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-purple-400 flex-shrink-0">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
                             </svg>
                             <div>
-                                <div class="text-2xl font-black text-white">{{ formatNumber(clan.total_top3 || 0) }}</div>
-                                <div class="text-xs font-medium text-purple-300">Podium Finishes</div>
+                                <div :class="[statNumSize, 'font-black text-white']">{{ formatNumber(clan.total_top3 || 0) }}</div>
+                                <div class="text-[10px] font-medium text-purple-300">Podium</div>
                             </div>
                         </Link>
                     </div>
@@ -229,9 +280,9 @@
                 <!-- Members & Stats -->
                 <div class="flex items-center gap-4">
                     <!-- Member Avatars - Show All (hidden in manage mode) -->
-                    <div v-if="!manage" class="flex items-center">
+                    <div v-if="!manage && maxVisibleMembers > 0" class="flex items-center">
                         <div class="flex -space-x-3">
-                            <div v-for="(player, index) in clan.players" :key="player.id" class="relative z-50">
+                            <div v-for="(player, index) in clan.players.slice(0, maxVisibleMembers)" :key="player.id" class="relative z-50">
                                 <Popper placement="bottom" arrow hover offsetDistance="12" :zIndex="9999">
                                     <Link
                                         :href="route('profile.index', player.user_id)"
@@ -239,7 +290,7 @@
                                         class="block transition-transform hover:scale-110"
                                     >
                                         <img
-                                            class="h-10 w-10 rounded-full object-cover ring-2 ring-gray-800 hover:ring-blue-500 transition-all"
+                                            :class="[avatarSize, 'rounded-full object-cover ring-2 ring-gray-800 hover:ring-blue-500 transition-all']"
                                             :src="player.user?.profile_photo_path ? `/storage/${player.user.profile_photo_path}` : '/images/null.jpg'"
                                         />
                                     </Link>
@@ -250,105 +301,123 @@
                                     </template>
                                 </Popper>
                             </div>
+                            <div v-if="clan.players.length > maxVisibleMembers" :class="[avatarBadgeSize, 'relative z-50 flex items-center justify-center rounded-full bg-gray-800 ring-2 ring-gray-700 font-bold text-gray-400']">
+                                +{{ clan.players.length - maxVisibleMembers }}
+                            </div>
                         </div>
                     </div>
 
 
                     <!-- Management Buttons -->
-                    <div v-if="manage" class="flex flex-wrap gap-2">
+                    <div v-if="manage" class="flex flex-wrap gap-1.5 flex-shrink-0">
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id"
                         @click="InvitePlayer"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-green-600/50 to-emerald-600/50 hover:from-green-600/60 hover:to-emerald-600/60 border border-green-500/50 hover:border-green-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-green-600/50 to-emerald-600/50 hover:from-green-600/60 hover:to-emerald-600/60 border border-green-500/50 hover:border-green-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Invite Player"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
                         </svg>
-                        <span class="text-xs font-medium">Invite</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Invite</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id"
                         @click="KickPlayer"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-orange-600/50 to-yellow-600/50 hover:from-orange-600/60 hover:to-yellow-600/60 border border-orange-500/50 hover:border-orange-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-orange-600/50 to-yellow-600/50 hover:from-orange-600/60 hover:to-yellow-600/60 border border-orange-500/50 hover:border-orange-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Kick Player"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M22 10.5h-6m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM4 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 10.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
                         </svg>
-                        <span class="text-xs font-medium">Kick</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Kick</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id"
                         @click="EditClan"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-gray-600/50 to-slate-600/50 hover:from-gray-600/60 hover:to-slate-600/60 border border-gray-500/50 hover:border-gray-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-gray-600/50 to-slate-600/50 hover:from-gray-600/60 hover:to-slate-600/60 border border-gray-500/50 hover:border-gray-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Edit Clan"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
                         </svg>
-                        <span class="text-xs font-medium">Edit Clan</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Edit</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id && EditMemberNotes"
                         @click="EditMemberNotes"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-blue-600/50 to-blue-800/50 hover:from-blue-600/60 hover:to-blue-800/60 border border-blue-500/50 hover:border-blue-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-blue-600/50 to-blue-800/50 hover:from-blue-600/60 hover:to-blue-800/60 border border-blue-500/50 hover:border-blue-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Member Details"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
                         </svg>
-                        <span class="text-xs font-medium">Member Details</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Details</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id && JoinRequests"
                         @click="JoinRequests"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-teal-600/50 to-emerald-600/50 hover:from-teal-600/60 hover:to-emerald-600/60 border border-teal-500/50 hover:border-teal-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-teal-600/50 to-emerald-600/50 hover:from-teal-600/60 hover:to-emerald-600/60 border border-teal-500/50 hover:border-teal-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Join Requests"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM4 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 10.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
                         </svg>
-                        <span class="text-xs font-medium">Requests</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Requests</span>
                         <span v-if="joinRequestsCount > 0" class="px-1.5 py-0.5 bg-teal-500 rounded-full text-[10px] font-bold leading-none">{{ joinRequestsCount }}</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id"
                         @click="TransferOwnership"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-sky-600/50 to-cyan-600/50 hover:from-sky-600/60 hover:to-cyan-600/60 border border-sky-500/50 hover:border-sky-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-sky-600/50 to-cyan-600/50 hover:from-sky-600/60 hover:to-cyan-600/60 border border-sky-500/50 hover:border-sky-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Transfer Ownership"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 7.5h-.75A2.25 2.25 0 0 0 4.5 9.75v7.5a2.25 2.25 0 0 0 2.25 2.25h7.5a2.25 2.25 0 0 0 2.25-2.25v-7.5a2.25 2.25 0 0 0-2.25-2.25h-.75m0-3-3-3m0 0-3 3m3-3v11.25m6-2.25h.75a2.25 2.25 0 0 1 2.25 2.25v7.5a2.25 2.25 0 0 1-2.25 2.25h-7.5a2.25 2.25 0 0 1-2.25-2.25v-.75" />
                         </svg>
-                        <span class="text-xs font-medium">Transfer</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Transfer</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id !== $page.props.auth.user.id"
                         @click="LeaveClan"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-red-600/50 to-rose-600/50 hover:from-red-600/60 hover:to-rose-600/60 border border-red-500/50 hover:border-red-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-red-600/50 to-rose-600/50 hover:from-red-600/60 hover:to-rose-600/60 border border-red-500/50 hover:border-red-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Leave Clan"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
                         </svg>
-                        <span class="text-xs font-medium">Leave</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Leave</span>
                     </button>
 
                     <button
                         v-if="clan.admin_id === $page.props.auth.user.id"
                         @click="DismantleClan"
-                        class="flex items-center justify-center gap-1.5 px-3 py-2 bg-gradient-to-r from-red-600/50 to-rose-600/50 hover:from-red-600/60 hover:to-rose-600/60 border border-red-500/50 hover:border-red-500/70 rounded-lg text-white transition-all duration-300"
+                        class="flex items-center justify-center gap-1 px-2 py-1.5 bg-gradient-to-r from-red-600/50 to-rose-600/50 hover:from-red-600/60 hover:to-rose-600/60 border border-red-500/50 hover:border-red-500/70 rounded-lg text-white transition-all duration-300"
+                        title="Dismantle Clan"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
                         </svg>
-                        <span class="text-xs font-medium">Dismantle</span>
+                        <span v-if="windowWidth >= 1280" class="text-xs font-medium">Dismantle</span>
                     </button>
                     </div>
                 </div>
             </div>
         </div>
     </div>
+
+    <!-- Resolution Debug Indicator -->
+    <Teleport to="body">
+        <div class="fixed bottom-2 right-2 z-[99999] bg-black/80 border border-white/20 rounded-lg px-3 py-1.5 text-xs font-mono text-green-400 pointer-events-none">
+            {{ breakpointLabel }}
+        </div>
+    </Teleport>
 </template>
 
 <style scoped>

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -871,6 +871,9 @@
         }
     };
 
+    // Aliases collapsed by default
+    const aliasesExpanded = ref(false);
+
     // Alias reporting
     const showReportModal = ref(false);
     const reportingAlias = ref(null);
@@ -2228,12 +2231,13 @@
             <div v-if="showSection('known_aliases') && ((aliases && aliases.length > 0) || can_suggest_alias || (alias_suggestions && alias_suggestions.length > 0))" class="mb-6" :style="{ order: sectionOrder('known_aliases') }">
                 <div>
                     <div class="bg-black/40 backdrop-blur-sm rounded-xl p-4 shadow-2xl border border-white/5">
-                        <div class="flex items-center justify-between mb-3">
+                        <div class="flex items-center justify-between" :class="aliasesExpanded ? 'mb-3' : ''">
                             <h3 class="text-lg font-bold text-white flex items-center gap-2">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-indigo-400">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
                                 </svg>
                                 Known Aliases
+                                <span class="text-sm font-normal text-gray-500">({{ aliases?.length || 0 }})</span>
                             </h3>
                             <div class="flex items-center gap-2">
                                 <!-- Edit button (own profile) -->
@@ -2258,9 +2262,21 @@
                                     </svg>
                                     Suggest Alias
                                 </button>
+                                <!-- Expand/Collapse button -->
+                                <button
+                                    v-if="aliases && aliases.length > 5"
+                                    @click="aliasesExpanded = !aliasesExpanded"
+                                    class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all"
+                                    :class="aliasesExpanded ? 'bg-indigo-500/10 text-indigo-400 border border-indigo-500/30' : 'bg-indigo-500/20 text-indigo-300 border border-indigo-400/40 animate-pulse'"
+                                >
+                                    <svg class="w-4 h-4 transition-transform duration-300" :class="aliasesExpanded ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                                    {{ aliasesExpanded ? 'Less' : 'Show all' }}
+                                </button>
                             </div>
                         </div>
-                        <p class="text-xs text-gray-400 mb-4">Aliases are alternative nicknames this player has used in Defrag. They help match uploaded demos and make the player searchable by any of their past names.</p>
+                        <div v-show="aliasesExpanded">
+                        <p class="text-xs text-gray-400 mb-3">Aliases are alternative nicknames this player has used in Defrag. They help match uploaded demos and make the player searchable by any of their past names.</p>
+                        </div>
 
                         <!-- Pending Suggestions (only visible on own profile) -->
                         <div v-if="alias_suggestions && alias_suggestions.length > 0" class="mb-4">
@@ -2301,7 +2317,10 @@
                         </div>
 
                         <!-- Approved Aliases -->
-                        <div v-if="aliases && aliases.length > 0" class="flex flex-wrap gap-2">
+                        <div v-if="aliases && aliases.length > 0" class="relative" :class="!aliasesExpanded ? 'mt-3' : ''">
+                        <!-- Fade overlay when collapsed -->
+                        <div v-if="!aliasesExpanded && aliases.length > 5" class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-black/80 to-transparent z-10 pointer-events-none rounded-b-lg"></div>
+                        <div class="flex flex-wrap gap-2 overflow-hidden transition-all duration-300" :style="aliasesExpanded ? '' : 'max-height: 38px'">
                             <div
                                 v-for="alias in aliases"
                                 :key="alias.alias_colored || alias.alias"
@@ -2322,9 +2341,10 @@
                                 </button>
                             </div>
                         </div>
+                        </div>
 
                         <!-- No aliases message -->
-                        <div v-else class="text-center py-4">
+                        <div v-else-if="!aliases || aliases.length === 0" class="text-center py-4">
                             <p class="text-gray-500 text-sm">No aliases yet</p>
                         </div>
                     </div>

--- a/resources/js/Pages/Profile/Partials/UpdateSocialMediaForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateSocialMediaForm.vue
@@ -77,7 +77,7 @@
             </div>
         </div>
 
-        <form @submit.prevent="updateSocialMediaInformation" class="space-y-3">
+        <form @submit.prevent="updateSocialMediaInformation" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             <div>
                 <InputLabel for="twitch" value="Twitch" />
                 <div v-if="user.twitch_id" class="mt-1 flex items-center gap-2">

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -376,6 +376,14 @@ const customizeSections = [
     { id: 'customize-layout', label: 'Profile Layout' },
 ];
 
+const globalCustomizeSections = [
+    { id: 'gc-map-view', label: 'Map View Defaults' },
+    { id: 'gc-physics-order', label: 'Physics Order' },
+    { id: 'gc-date-format', label: 'Date Format' },
+    { id: 'gc-hide-stats', label: 'Hide Stat Boxes' },
+    { id: 'gc-hide-sections', label: 'Hide Sections' },
+];
+
 const switchTab = (tabId) => {
     activeTab.value = tabId;
     const url = new URL(window.location.href);
@@ -960,8 +968,36 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                                                 {{ sub.label }}
                                             </button>
                                         </template>
+                                        <div v-if="subTab.id === 'customize'" class="my-1.5 border-t border-white/10 mx-1"></div>
                                     </template>
                                 </div>
+                                </div>
+                            </template>
+
+                            <!-- Global Customize with sub-sections -->
+                            <template v-else-if="tab.id === 'global-customize'">
+                                <div :class="['rounded-lg transition-all', activeTab === 'global-customize' ? 'bg-white/[0.07] border border-white/10' : '']">
+                                    <button
+                                        @click="switchTab('global-customize')"
+                                        :class="[
+                                            'w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-all text-left',
+                                            activeTab === 'global-customize'
+                                                ? 'bg-blue-500/20 text-white'
+                                                : 'text-gray-400 hover:text-white hover:bg-white/5'
+                                        ]"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
+                                            <path stroke-linecap="round" stroke-linejoin="round" :d="tab.icon" />
+                                        </svg>
+                                        {{ tab.label }}
+                                    </button>
+                                    <div v-if="activeTab === 'global-customize'" class="ml-3 pl-3 border-l border-white/15 space-y-0.5 pb-1">
+                                        <button v-for="sub in globalCustomizeSections" :key="sub.id"
+                                            @click="scrollToSection(sub.id)"
+                                            class="w-full text-left pl-5 pr-3 py-1 rounded-md text-xs transition-all text-gray-300 hover:text-white hover:bg-white/5">
+                                            {{ sub.label }}
+                                        </button>
+                                    </div>
                                 </div>
                             </template>
 
@@ -1011,8 +1047,8 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                 </div>
             </a>
 
-            <div class="grid grid-cols-3 gap-4">
-                <!-- Profile Card -->
+            <div class="space-y-4">
+                <!-- Profile Card (horizontal) -->
                 <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10">
                     <div class="p-4">
                         <div class="flex items-center justify-between mb-4">
@@ -1037,7 +1073,7 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                             </div>
                         </div>
 
-                        <form @submit.prevent="updateProfile" class="space-y-3" data-lpignore="true" data-1p-ignore data-bwignore>
+                        <form @submit.prevent="updateProfile" class="grid grid-cols-2 md:grid-cols-4 gap-3" data-lpignore="true" data-1p-ignore data-bwignore>
                             <div>
                                 <InputLabel for="username" value="Username" />
                                 <TextInput
@@ -1080,12 +1116,7 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                     </div>
                 </div>
 
-                <!-- Player Aliases -->
-                <div v-if="isVerified" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 overflow-hidden max-h-[400px] overflow-y-auto">
-                    <ManageAliasesForm :user="user" />
-                </div>
-
-                <!-- Connections -->
+                <!-- Connections (full width) -->
                 <div v-if="isVerified" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 overflow-hidden">
                     <UpdateSocialMediaForm :user="user" />
                 </div>
@@ -1194,6 +1225,41 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                             <SecondaryButton type="button" @click="cancelBackgroundCrop">
                                 Cancel
                             </SecondaryButton>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Player Aliases -->
+            <div v-if="isVerified" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 overflow-hidden max-h-[400px] overflow-y-auto mt-4">
+                <ManageAliasesForm :user="user" />
+            </div>
+
+            <!-- About Me Card -->
+            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 mt-4">
+                <div class="p-4">
+                    <div class="flex items-center gap-2 mb-3">
+                        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-amber-500/20 to-yellow-600/20 border border-amber-500/30 flex items-center justify-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-amber-400">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                            </svg>
+                        </div>
+                        <div>
+                            <h2 class="text-sm font-bold text-white">About Me</h2>
+                            <p class="text-xs text-gray-500">Visible on hover over your name on your profile. All changes reviewed by moderators.</p>
+                        </div>
+                    </div>
+                    <div>
+                        <textarea v-model="aboutMeForm.content"
+                            class="w-full bg-gray-800/60 border border-gray-700/50 rounded-lg p-3 text-sm text-white placeholder-gray-600 focus:border-amber-500/50 focus:outline-none resize-none"
+                            rows="3" maxlength="500"
+                            placeholder="Write something about yourself..."></textarea>
+                        <div class="flex items-center justify-between mt-2">
+                            <span class="text-[10px] text-gray-600">{{ aboutMeForm.content?.length || 0 }}/500</span>
+                            <button @click="submitAboutMeSettings" :disabled="aboutMeForm.processing || !aboutMeForm.content?.trim()"
+                                class="px-4 py-1.5 bg-amber-600 hover:bg-amber-500 disabled:bg-gray-700 disabled:text-gray-500 text-white text-xs font-bold rounded-lg transition-colors">
+                                {{ aboutMeForm.processing ? 'Submitting...' : 'Submit for Review' }}
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -1905,7 +1971,7 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <!-- Map View Defaults Card -->
-            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
+            <div id="gc-map-view" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
                 <div class="p-4">
                     <div class="flex items-center justify-between mb-4">
                         <div class="flex items-center gap-2">
@@ -1958,7 +2024,7 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
             </div>
 
             <!-- Physics Column Order Card -->
-            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
+            <div id="gc-physics-order" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
                 <div class="p-4">
                     <div class="flex items-center justify-between mb-4">
                         <div class="flex items-center gap-2">
@@ -2005,38 +2071,8 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                 </div>
             </div>
 
-            <!-- About Me Card -->
-            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500 md:col-span-2">
-                <div class="p-4">
-                    <div class="flex items-center gap-2 mb-3">
-                        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-amber-500/20 to-yellow-600/20 border border-amber-500/30 flex items-center justify-center">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-amber-400">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
-                            </svg>
-                        </div>
-                        <div>
-                            <h2 class="text-sm font-bold text-white">About Me</h2>
-                            <p class="text-xs text-gray-500">Visible on hover over your name on your profile. All changes reviewed by moderators.</p>
-                        </div>
-                    </div>
-                    <div>
-                        <textarea v-model="aboutMeForm.content"
-                            class="w-full bg-gray-800/60 border border-gray-700/50 rounded-lg p-3 text-sm text-white placeholder-gray-600 focus:border-amber-500/50 focus:outline-none resize-none"
-                            rows="3" maxlength="500"
-                            placeholder="Write something about yourself..."></textarea>
-                        <div class="flex items-center justify-between mt-2">
-                            <span class="text-[10px] text-gray-600">{{ aboutMeForm.content?.length || 0 }}/500</span>
-                            <button @click="submitAboutMeSettings" :disabled="aboutMeForm.processing || !aboutMeForm.content?.trim()"
-                                class="px-4 py-1.5 bg-amber-600 hover:bg-amber-500 disabled:bg-gray-700 disabled:text-gray-500 text-white text-xs font-bold rounded-lg transition-colors">
-                                {{ aboutMeForm.processing ? 'Submitting...' : 'Submit for Review' }}
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
             <!-- Date Format Card -->
-            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
+            <div id="gc-date-format" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
                 <div class="p-4">
                     <div class="flex items-center gap-2 mb-3">
                         <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-cyan-500/20 to-blue-600/20 border border-cyan-500/30 flex items-center justify-center">
@@ -2079,7 +2115,7 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
             </div>
 
             <!-- Hide Stat Boxes Card -->
-            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500 md:col-span-2">
+            <div id="gc-hide-stats" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500 md:col-span-2">
                 <div class="p-4">
                     <div class="flex items-center justify-between mb-4">
                         <div class="flex items-center gap-2">
@@ -2118,7 +2154,7 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
             </div>
 
             <!-- Hide Profile Sections Card -->
-            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500 md:col-span-2">
+            <div id="gc-hide-sections" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500 md:col-span-2">
                 <div class="p-4">
                     <div class="flex items-center justify-between mb-4">
                         <div class="flex items-center gap-2">

--- a/resources/js/Pages/RecordsView.vue
+++ b/resources/js/Pages/RecordsView.vue
@@ -9,9 +9,25 @@
     const cpmFirst = computed(() => page.props.physicsOrder === 'cpm_first');
 
     const dateColWidth = computed(() => {
+        if (windowWidth.value < 500) return 'w-[50px]';
         const fmt = page.props.dateFormat;
         return (fmt === 'Ymd' || fmt === 'dmY') ? 'w-[72px]' : 'w-[50px]';
     });
+
+    // Resolution debug indicator
+    const windowWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 0);
+    const breakpointLabel = computed(() => {
+        const w = windowWidth.value;
+        if (w >= 1536) return `2xl (${w}px)`;
+        if (w >= 1280) return `xl (${w}px)`;
+        if (w >= 1024) return `lg (${w}px)`;
+        if (w >= 768) return `md (${w}px)`;
+        if (w >= 640) return `sm (${w}px)`;
+        return `xs (${w}px)`;
+    });
+    if (typeof window !== 'undefined') {
+        window.addEventListener('resize', () => { windowWidth.value = window.innerWidth; });
+    }
 
     const scoreTooltip = ref(null);
     const scoreTooltipStyle = computed(() => {
@@ -86,6 +102,11 @@
 <template>
     <div class="pb-4">
         <Head title="Records" />
+
+        <!-- Resolution Debug Indicator -->
+        <div class="fixed bottom-2 right-2 z-[99999] bg-black/80 border border-white/20 rounded-lg px-3 py-1.5 text-xs font-mono text-green-400 pointer-events-none">
+            {{ breakpointLabel }}
+        </div>
 
         <!-- Header Section -->
         <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96">
@@ -202,11 +223,11 @@
                             <div class="w-5 sm:w-8 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold -ml-3">#</div>
                             <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                             <div class="flex items-center gap-2 sm:gap-3 flex-shrink-0">
-                                <div class="w-28 sm:w-40 flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-left">Map</div>
+                                <div class="w-16 min-[500px]:w-20 sm:w-40 flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-left">Map</div>
                                 <div class="flex items-center gap-0.5 ml-auto -mr-3">
-                                    <div class="w-[80px] text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right">Time</div>
-                                    <div class="w-8 sm:w-10 flex-shrink-0 text-center text-[10px] text-gray-400 uppercase tracking-wider font-semibold" style="padding-left: 5px">Score</div>
-                                    <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
+                                    <div class="w-[60px] min-[500px]:w-[80px] text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right">Time</div>
+                                    <div class="hidden sm:block w-8 sm:w-10 flex-shrink-0 text-center text-[10px] text-gray-400 uppercase tracking-wider font-semibold" style="padding-left: 5px">Score</div>
+                                    <div v-if="windowWidth >= 400" :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                                 </div>
                             </div>
                         </div>
@@ -236,11 +257,11 @@
                             <div class="w-5 sm:w-8 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold -ml-3">#</div>
                             <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                             <div class="flex items-center gap-2 sm:gap-3 flex-shrink-0">
-                                <div class="w-28 sm:w-40 flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-left">Map</div>
+                                <div class="w-16 min-[500px]:w-20 sm:w-40 flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-left">Map</div>
                                 <div class="flex items-center gap-0.5 ml-auto -mr-3">
-                                    <div class="w-[80px] text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right">Time</div>
-                                    <div class="w-8 sm:w-10 flex-shrink-0 text-center text-[10px] text-gray-400 uppercase tracking-wider font-semibold" style="padding-left: 5px">Score</div>
-                                    <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
+                                    <div class="w-[60px] min-[500px]:w-[80px] text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right">Time</div>
+                                    <div class="hidden sm:block w-8 sm:w-10 flex-shrink-0 text-center text-[10px] text-gray-400 uppercase tracking-wider font-semibold" style="padding-left: 5px">Score</div>
+                                    <div v-if="windowWidth >= 400" :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Records page:
- Score hidden below sm (640px), date hidden below 400px
- Date format switches to YY below 500px
- Map/time columns shrink on small screens
- Resolution debug indicator added

Clans page:
- Member avatars scale down and limit count at smaller breakpoints
- Stat boxes (Records/WR/Podium) progressively hidden below 1024/900/768px
- Management buttons show icon-only below xl (1280px)
- Resolution debug indicator added

Profile:
- Known aliases collapsed by default, first row visible with fade gradient
- Expand/collapse button with pulse animation for 5+ aliases

Settings:
- Profile card fields laid out horizontally (4-col grid)
- Connections laid out in responsive grid (side by side)
- Aliases moved below profile images
- About Me moved from Global Customize to Profile tab
- Global Customize now has sub-categories in left nav sidebar