### PR TITLE
Ranking WIP banners, map sort, reltime fix, and UI polish

### DIFF
--- a/app/Filament/Pages/RatingSettings.php
+++ b/app/Filament/Pages/RatingSettings.php
@@ -46,7 +46,8 @@ class RatingSettings extends Page
 
     public static function canAccess(): bool
     {
-        return auth()->user()?->isAdmin() ?? false;
+        $user = auth()->user();
+        return $user?->isAdmin() || $user?->hasModeratorPermission('rating_settings');
     }
 
     public function mount(): void

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -90,6 +90,7 @@ class UserResource extends Resource
                                 'creator_claim_disputes' => 'Creator Claim Disputes',
                                 'about_me' => 'About Me (moderation)',
                                 'rating_breakdown' => 'Rating Breakdown (view on profiles)',
+                                'rating_settings' => 'Rating Settings (view/edit)',
                             ])
                             ->visible(fn (Forms\Get $get) => $get('is_moderator'))
                             ->columns(2),

--- a/app/Filters/MapFilters.php
+++ b/app/Filters/MapFilters.php
@@ -15,8 +15,9 @@ class MapFilters {
     public function filter(Request $request) {
         $maps = Map::select('id', 'name', 'author', 'pk3', 'thumbnail', 'physics', 'gametype', 'weapons', 'items', 'functions', 'is_nsfw', 'date_added', 'created_at', 'cpm_average', 'vq3_average')
             ->withAvg('difficultyRatings', 'rating')
-            ->withCount('difficultyRatings')
-            ->orderBy('date_added', 'DESC');
+            ->withCount('difficultyRatings');
+
+        $maps = $this->applySort($request, $maps);
 
         $maps = $this->search($request, $maps);
         $maps = $this->author($request, $maps);
@@ -49,6 +50,29 @@ class MapFilters {
             'query'     =>      $maps,
             'data'      =>      $this->queries
         ];
+    }
+
+    private function applySort(Request $request, $maps) {
+        $sort = $request->input('sort', 'newest');
+        $this->queries['sort'] = $sort;
+
+        switch ($sort) {
+            case 'oldest':
+                $maps = $maps->orderBy('date_added', 'ASC')->orderBy('id', 'ASC');
+                break;
+            case 'most_records':
+                $maps = $maps->withCount('records')->orderBy('records_count', 'DESC');
+                break;
+            case 'name_asc':
+                $maps = $maps->orderBy('name', 'ASC');
+                break;
+            case 'newest':
+            default:
+                $maps = $maps->orderBy('date_added', 'DESC')->orderBy('id', 'DESC');
+                break;
+        }
+
+        return $maps;
     }
 
     private function buildFuzzyLike(string $input): string {

--- a/resources/js/Components/Basic/SpecialRadio.vue
+++ b/resources/js/Components/Basic/SpecialRadio.vue
@@ -50,7 +50,7 @@
         let classes = {
             'rounded-l-md': (index == 0),
             'rounded-r-md border-r': (index == Object.keys(props.options).length - 1),
-            'bg-grayop-900 hover:bg-grayop-800': !values.value.includes(key)
+            'bg-gray-800/60 hover:bg-gray-700/60': !values.value.includes(key)
         }
 
         let color = props.options[key]['color'] ?? 'bg-blue-600'
@@ -62,10 +62,10 @@
 </script>
 
 <template>
-    <div class="sm:flex">
-        <div v-for="(option, key, index) in options" class="flex-grow text-center">
+    <div class="flex">
+        <div v-for="(option, key, index) in options" class="flex-1 text-center min-w-0">
             <div
-                class="cursor-pointer border-l px-2 py-1 border-y border-grayop-700 text-gray-300 hover:text-gray-100 shadow-sm text-xs"
+                class="cursor-pointer border-l px-1.5 py-1 border-y border-white/10 text-gray-400 hover:text-gray-200 text-[11px]"
                 :class="getClasses(key, index)"
                 @click="onClick(key)"
                 :key="key"

--- a/resources/js/Components/MapFiltersSidebar.vue
+++ b/resources/js/Components/MapFiltersSidebar.vue
@@ -39,7 +39,7 @@
 
     const physics = {
         'vq3': { value: 'VQ3', color: 'bg-blue-600' },
-        'cpm': { value: 'CPM', color: 'bg-green-600' },
+        'cpm': { value: 'CPM', color: 'bg-purple-600' },
     };
 
     const weapons = [
@@ -92,6 +92,7 @@
     ];
 
     const form = useForm({
+        sort: props.queries?.sort ?? 'newest',
         search: props.queries?.search ?? '',
         author: props.queries?.author ?? '',
         difficulty: props.queries?.difficulty ?? [],
@@ -116,6 +117,7 @@
     };
 
     const resetFilters = () => {
+        form.sort = 'newest';
         form.search = '';
         form.author = '';
         form.difficulty = [];
@@ -264,8 +266,21 @@
         <!-- Scrollable sections -->
         <div class="sidebar-body">
 
-            <!-- Search inputs (always visible, no accordion) -->
+            <!-- Search + Sort (always visible, no accordion) -->
             <div class="px-3 py-2.5 space-y-2 border-b border-white/5">
+                <div class="flex gap-1">
+                    <button v-for="opt in [
+                        { value: 'newest', label: 'Newest' },
+                        { value: 'oldest', label: 'Oldest' },
+                        { value: 'most_records', label: 'Popular' },
+                        { value: 'name_asc', label: 'A-Z' },
+                    ]" :key="opt.value"
+                        @click="form.sort = opt.value"
+                        :class="form.sort === opt.value ? 'bg-blue-500/30 border-blue-400/50 text-white' : 'bg-white/5 border-white/10 text-gray-400 hover:bg-white/10'"
+                        class="flex-1 py-1 rounded-md border text-[11px] font-semibold transition-all text-center">
+                        {{ opt.label }}
+                    </button>
+                </div>
                 <TextInput type="text" v-model="form.search" class="block w-full" placeholder="Map name..." v-on:keyup.enter="onFilterSubmit" />
                 <TextInput type="text" v-model="form.author" class="block w-full" placeholder="Author..." v-on:keyup.enter="onFilterSubmit" />
             </div>
@@ -273,18 +288,9 @@
             <!-- Difficulty, Gametype & Physics -->
             <div class="sidebar-section">
                 <div class="space-y-2 px-3 py-2">
-                    <div>
-                        <label class="field-label">Difficulty</label>
-                        <SpecialRadio :options="difficulties" v-model="form.difficulty" :multi="true" :values="form.difficulty" />
-                    </div>
-                    <div>
-                        <label class="field-label">Gametype</label>
-                        <SpecialRadio :options="types" v-model="form.gametype" :multi="true" :values="form.gametype" />
-                    </div>
-                    <div>
-                        <label class="field-label">Physics</label>
-                        <SpecialRadio :options="physics" v-model="form.physics" :values="form.physics" :multi="true" />
-                    </div>
+                    <SpecialRadio :options="difficulties" v-model="form.difficulty" :multi="true" :values="form.difficulty" />
+                    <SpecialRadio :options="types" v-model="form.gametype" :multi="true" :values="form.gametype" />
+                    <SpecialRadio :options="physics" v-model="form.physics" :values="form.physics" :multi="true" />
                 </div>
             </div>
 
@@ -438,7 +444,8 @@
 
 /* Sections */
 .sidebar-section {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    margin: 0 0.5rem;
 }
 .sidebar-section-last {
     border-bottom: none;
@@ -450,16 +457,21 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 0.75rem 1rem;
+    padding: 0.375rem 0.75rem;
+    margin: 0.125rem 0;
     font-size: 0.8125rem;
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.75);
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 0.5rem;
     transition: all 0.15s;
     cursor: pointer;
 }
 .accordion-btn:hover {
-    background: rgba(255, 255, 255, 0.04);
-    color: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 1);
 }
 
 /* Chevron */
@@ -479,7 +491,12 @@
 
 /* Accordion content */
 .accordion-content {
-    padding: 0 1rem 1rem;
+    padding: 0.5rem 0.75rem 0.75rem;
+    margin: 0 0 0.25rem;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-top: none;
+    border-radius: 0 0 0.5rem 0.5rem;
 }
 
 /* Field labels */

--- a/resources/js/Pages/RankingHowItWorks.vue
+++ b/resources/js/Pages/RankingHowItWorks.vue
@@ -83,6 +83,16 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 Back to Rankings
             </Link>
 
+            <!-- WIP Banner -->
+            <div class="bg-red-600 border-4 border-red-800 rounded-xl px-4 py-4 text-center mb-8">
+                <div class="flex items-center justify-center gap-3 mb-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7 text-white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>
+                    <span class="text-white font-black text-lg sm:text-xl uppercase tracking-wide">Work in Progress</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7 text-white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>
+                </div>
+                <p class="text-white/90 text-sm sm:text-base font-semibold">The ranking system is still under active development. Parameters are being tuned and formulas may change. Please give us time until the system is finalized.</p>
+            </div>
+
             <h1 class="text-4xl md:text-5xl font-black text-gray-200 mb-2">How Rankings Work</h1>
             <p class="text-gray-500 text-sm mb-10">A complete breakdown of the ranking algorithm, step by step.</p>
 
@@ -95,11 +105,12 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                     <a href="#reltime" class="text-blue-400 hover:text-blue-300">3. Relative Time (reltime)</a>
                     <a href="#base-score" class="text-blue-400 hover:text-blue-300">4. Base Map Score</a>
                     <a href="#multiplier" class="text-blue-400 hover:text-blue-300">5. Map Multiplier</a>
-                    <a href="#final-score" class="text-blue-400 hover:text-blue-300">6. Final Map Score</a>
-                    <a href="#player-rating" class="text-blue-400 hover:text-blue-300">7. Player Rating</a>
-                    <a href="#categories" class="text-blue-400 hover:text-blue-300">8. Categories</a>
-                    <a href="#updates" class="text-blue-400 hover:text-blue-300">9. Real-time Updates</a>
-                    <a href="#full-example" class="text-blue-400 hover:text-blue-300">10. Full Example</a>
+                    <a href="#rank-multiplier" class="text-blue-400 hover:text-blue-300">6. Rank Multiplier</a>
+                    <a href="#final-score" class="text-blue-400 hover:text-blue-300">7. Final Map Score</a>
+                    <a href="#player-rating" class="text-blue-400 hover:text-blue-300">8. Player Rating</a>
+                    <a href="#categories" class="text-blue-400 hover:text-blue-300">9. Categories</a>
+                    <a href="#updates" class="text-blue-400 hover:text-blue-300">10. Real-time Updates</a>
+                    <a href="#full-example" class="text-blue-400 hover:text-blue-300">11. Full Example</a>
                 </div>
             </div>
 
@@ -112,7 +123,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
                         <div class="text-sm font-bold text-green-400 mb-1">1. Relative Time</div>
-                        <div class="text-xs text-gray-400">Your time is compared to the world record to get a ratio (reltime).</div>
+                        <div class="text-xs text-gray-400">Your time is compared to the fastest time by another player to get a ratio (reltime).</div>
                     </div>
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
                         <div class="text-sm font-bold text-yellow-400 mb-1">2. Base Score</div>
@@ -159,36 +170,43 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
                     <span class="text-blue-400 text-lg font-mono">3.</span> Relative Time (reltime)
                 </h2>
-                <p class="mb-3">Reltime is the ratio of your time to the world record time on that map:</p>
+                <p class="mb-3">Reltime is the ratio of your time to the <strong class="text-white">fastest time set by someone else</strong>:</p>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-lg text-white mb-3">
-                    reltime = your_time / wr_time
+                    reltime = your_time / fastest_other_time
+                </div>
+                <div class="mt-3 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-300 mb-4">
+                    <strong>Key detail:</strong> You are always compared to the best time by a <em>different player</em>. If you hold the WR, your reltime is calculated against the 2nd place time - you are never compared to yourself.
                 </div>
                 <div class="space-y-2 text-sm">
                     <div class="flex items-center gap-3">
+                        <span class="bg-green-600/20 text-green-400 px-2 py-0.5 rounded font-mono text-xs w-24 text-center">&lt; 1.000</span>
+                        <span>You are faster than the best time by anyone else (you hold WR)</span>
+                    </div>
+                    <div class="flex items-center gap-3">
                         <span class="bg-green-600/20 text-green-400 px-2 py-0.5 rounded font-mono text-xs w-24 text-center">1.000</span>
-                        <span>You ARE the world record holder</span>
+                        <span>You matched the fastest other player exactly</span>
                     </div>
                     <div class="flex items-center gap-3">
                         <span class="bg-yellow-600/20 text-yellow-400 px-2 py-0.5 rounded font-mono text-xs w-24 text-center">1.233</span>
-                        <span>Your time is 23.3% slower than WR</span>
+                        <span>Your time is 23.3% slower than the fastest other time</span>
                     </div>
                     <div class="flex items-center gap-3">
                         <span class="bg-red-600/20 text-red-400 px-2 py-0.5 rounded font-mono text-xs w-24 text-center">2.500</span>
-                        <span>Your time is 2.5x the WR - very slow relative to WR</span>
+                        <span>Your time is 2.5x the fastest other time</span>
                     </div>
                 </div>
 
                 <div class="mt-4 bg-gray-900/60 border border-gray-800 rounded-xl p-4">
-                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Example</div>
+                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Example (non-WR player)</div>
                     <div class="text-sm space-y-1">
-                        <div>WR time: <span class="text-white font-mono">{{ (exampleWR / 1000).toFixed(3) }}s</span></div>
+                        <div>WR time (other player): <span class="text-white font-mono">{{ (exampleWR / 1000).toFixed(3) }}s</span></div>
                         <div>Your time: <span class="text-white font-mono">{{ (exampleTime / 1000).toFixed(3) }}s</span></div>
                         <div>reltime = {{ (exampleTime / 1000).toFixed(3) }} / {{ (exampleWR / 1000).toFixed(3) }} = <span class="text-yellow-400 font-mono font-bold">{{ exampleReltime.toFixed(4) }}</span></div>
                     </div>
                 </div>
 
                 <div class="mt-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 text-xs text-yellow-300">
-                    <strong>Note:</strong> The lower the reltime, the better. A reltime of 1.0 means you matched the WR exactly.
+                    <strong>Note:</strong> The lower the reltime, the better. A reltime below 1.0 means you are the WR holder and faster than everyone else.
                 </div>
             </section>
 

--- a/resources/js/Pages/RankingView.vue
+++ b/resources/js/Pages/RankingView.vue
@@ -186,6 +186,18 @@
     <div class="">
         <Head title="Ranking" />
 
+        <!-- WIP Banner -->
+        <div class="relative z-20 bg-red-600 border-b-4 border-red-800 px-4 py-4 text-center">
+            <div class="max-w-4xl mx-auto">
+                <div class="flex items-center justify-center gap-3 mb-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7 text-white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>
+                    <span class="text-white font-black text-lg sm:text-xl uppercase tracking-wide">Work in Progress</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7 text-white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>
+                </div>
+                <p class="text-white/90 text-sm sm:text-base font-semibold">The ranking system is still under active development. Parameters are being tuned and formulas may change. Please give us time until the system is finalized.</p>
+            </div>
+        </div>
+
         <!-- Header Section -->
         <div class="relative z-10 bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
             <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">


### PR DESCRIPTION
## Summary
- Added WIP banners to ranking and how-it-works pages
- Fixed reltime formula docs (compared against fastest other player, not self)
- Added sort options to maps filter sidebar (newest, oldest, popular, A-Z)
- Improved map filter sidebar accordion visibility and removed redundant labels
- Fixed CPM filter color to purple, fixed difficulty overflow
- Added rating_settings moderator permission
- Added rank multiplier to rating system with configurable n/v parameters
- Fixed rating recalc job timeout (Redis retry_after 90s -> 3600s)
- Fixed rating breakdown 403 for moderators
- Fixed profile assigner badge not counting all assigned demos
- Fixed ranking date tooltip ignoring user date format
- Made map detail thumbnail more visible by default
- Added YouTube metadata fields to rendered video edit page
- Fixed YT Info modal invisible text

## Test plan
- [ ] Verify WIP banners visible on /ranking and /ranking/how-it-works
- [ ] Test map sort options (newest, oldest, popular, A-Z)
- [ ] Verify reltime formula shows fastest_other_time in how-it-works
- [ ] Run rating recalc and verify both VQ3 and CPM complete
- [ ] Verify moderator with rating_settings permission can access Rating Settings
- [ ] Check assigner badge count matches community leaderboard
