### PR TITLE
Add Discord render visibility + manual bulk publish controls

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -55,8 +55,9 @@ class Kernel extends ConsoleKernel
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();
 
-        // Auto-publish unlisted videos every 3 weeks on Sunday at 18:00
-        $schedule->command('demome:auto-publish')->withoutOverlapping()->weeklyOn(0, '18:00')->when(fn () => now()->weekOfYear % 3 === 0);
+        // NOTE: Triweekly auto-publish scheduler removed. Bulk publishing is now manual-only
+        // via the per-tier buttons in Filament DemomeControl page. The Python bot's every-4h
+        // deficit check (auto_publish_deficit) still keeps a steady 12 videos/day trickle.
 
         // Rebuild records page cache every 12 hours (full consistency refresh)
         $schedule->command('records:rebuild-cache')->withoutOverlapping()->twiceDaily(6, 18);

--- a/app/Filament/Pages/DemomeControl.php
+++ b/app/Filament/Pages/DemomeControl.php
@@ -28,6 +28,8 @@ class DemomeControl extends Page
     public int $unlistedPage = 1;
     public int $unlistedPerPage = 20;
 
+    public ?string $discordRestartMessageId = null;
+
     public static function canAccess(): bool
     {
         return auth()->user()?->isAdmin() ?? false;
@@ -95,12 +97,69 @@ class DemomeControl extends Page
                 ->where('publish_approved', true)
                 ->whereNull('published_at')
                 ->count(),
-            'next_auto_publish' => $this->getNextBiweeklyPublish(),
-            'last_auto_publish' => SiteSetting::get('demome:last_auto_publish')
-                ? Carbon::parse(SiteSetting::get('demome:last_auto_publish'))
-                : null,
+            'manual_bulk_history' => $this->getManualBulkHistory(),
+            'bulk_tier_buttons' => $this->getBulkTierButtonData(),
             'backlog' => $this->getBacklogStats(),
+            'discordRestartMarker' => SiteSetting::get('demome:discord_restart_from_message_id') ?: null,
         ];
+    }
+
+    private function getBulkTierButtonData(): array
+    {
+        $rows = $this->unlistedBaseQuery()
+            ->selectRaw('COALESCE(quality_tier, 0) as tier, COUNT(*) as cnt')
+            ->groupByRaw('COALESCE(quality_tier, 0)')
+            ->pluck('cnt', 'tier');
+
+        $total = 0;
+        $buttons = [];
+        foreach ($rows as $tier => $cnt) {
+            $total += (int) $cnt;
+            $label = \App\Services\RenderQueueService::TIER_LABELS[(int) $tier] ?? 'Unclassified';
+            $buttons[] = [
+                'tier' => (int) $tier,
+                'label' => $label,
+                'count' => (int) $cnt,
+            ];
+        }
+
+        // Sort by tier number so button order matches TIER_LABELS definition
+        usort($buttons, fn($a, $b) => $a['tier'] <=> $b['tier']);
+
+        array_unshift($buttons, [
+            'tier' => -1, // -1 = ALL sentinel
+            'label' => 'All',
+            'count' => $total,
+        ]);
+
+        return $buttons;
+    }
+
+    private function getManualBulkHistory(): array
+    {
+        $raw = SiteSetting::get('demome:manual_bulk_history');
+        if (!$raw) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_slice($decoded, 0, 3);
+    }
+
+    private function recordManualBulk(string $label, int $count): void
+    {
+        $history = $this->getManualBulkHistory();
+        array_unshift($history, [
+            'ts' => now()->toIso8601String(),
+            'label' => $label,
+            'count' => $count,
+        ]);
+        $history = array_slice($history, 0, 3);
+        SiteSetting::set('demome:manual_bulk_history', json_encode($history));
     }
 
     private function unlistedBaseQuery()
@@ -161,15 +220,6 @@ class DemomeControl extends Page
         }
 
         return (int) ceil($query->count() / $this->unlistedPerPage);
-    }
-
-    private function getNextBiweeklyPublish(): Carbon
-    {
-        $next = Carbon::now()->next(Carbon::SUNDAY)->setTime(18, 0);
-        while ($next->weekOfYear % 3 !== 0) {
-            $next->addWeek();
-        }
-        return $next;
     }
 
     private function getBacklogStats(): array
@@ -289,9 +339,102 @@ class DemomeControl extends Page
 
         $breakdown = collect($tierCounts)->map(fn($c, $l) => "{$c}x {$l}")->join(', ');
 
+        $this->recordManualBulk("Mix 12 ({$breakdown})", $batch->count());
+
         Notification::make()
             ->title("Publish Queued: {$batch->count()} videos")
             ->body("Mix: {$breakdown}")
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Bulk-approve every unlisted auto-rendered video matching a specific quality tier.
+     * tier === -1 means "all tiers" (everything unlisted). This bypasses the rotation
+     * mix and is intended for manual curation - admin picks which bucket to drain.
+     */
+    public function bulkPublishTier(int $tier): void
+    {
+        $query = $this->unlistedBaseQuery();
+
+        if ($tier === 0) {
+            $query->where(function ($q) {
+                $q->whereNull('quality_tier')->orWhere('quality_tier', 0);
+            });
+            $label = 'Unclassified';
+        } elseif ($tier === -1) {
+            $label = 'All';
+        } else {
+            $query->where('quality_tier', $tier);
+            $label = \App\Services\RenderQueueService::TIER_LABELS[$tier] ?? "Tier {$tier}";
+        }
+
+        $count = (clone $query)->count();
+
+        if ($count === 0) {
+            Notification::make()
+                ->title('Nothing to Publish')
+                ->body("No unlisted videos in category: {$label}")
+                ->warning()
+                ->send();
+            return;
+        }
+
+        // Mark every matching video for publishing. Python bot will pick these up via
+        // get_videos_to_publish() on its next run and transition them unlisted -> public.
+        $query->update(['publish_approved' => true]);
+
+        $this->recordManualBulk($label, $count);
+
+        // Invalidate the unlisted stats cache so the UI immediately reflects the change.
+        \Illuminate\Support\Facades\Cache::forget('demome:control_stats');
+
+        Notification::make()
+            ->title("Bulk Publish Queued: {$count} videos")
+            ->body("Category: {$label}. Python bot will publish them on next cycle.")
+            ->success()
+            ->send();
+    }
+
+    public function setDiscordRestartMarker(): void
+    {
+        $id = trim((string) $this->discordRestartMessageId);
+
+        if ($id === '') {
+            SiteSetting::set('demome:discord_restart_from_message_id', '');
+            Notification::make()
+                ->title('Discord Restart Marker Cleared')
+                ->body('Demome will continue normally from the last scraped message.')
+                ->success()
+                ->send();
+            return;
+        }
+
+        if (!preg_match('/^\d{10,25}$/', $id)) {
+            Notification::make()
+                ->title('Invalid Message ID')
+                ->body('Discord snowflake IDs are numeric (10-25 digits).')
+                ->danger()
+                ->send();
+            return;
+        }
+
+        SiteSetting::set('demome:discord_restart_from_message_id', $id);
+
+        Notification::make()
+            ->title('Discord Restart Marker Set')
+            ->body("On next demome startup it will rescan Discord from message ID {$id} onwards.")
+            ->success()
+            ->send();
+    }
+
+    public function clearDiscordRestartMarker(): void
+    {
+        SiteSetting::set('demome:discord_restart_from_message_id', '');
+        $this->discordRestartMessageId = null;
+
+        Notification::make()
+            ->title('Discord Restart Marker Cleared')
             ->success()
             ->send();
     }

--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -316,6 +316,43 @@ class DemomeController extends Controller
         // Use metadata from the processed demo
         $recordId = $demo->record_id;
 
+        // Prefer updating an existing Discord placeholder created by start-discord-render
+        // (status=rendering or uploading) linked to this demo, to preserve timeline + avoid duplicates.
+        $video = RenderedVideo::where('demo_id', $demo->id)
+            ->where('source', 'discord')
+            ->whereIn('status', ['rendering', 'uploading'])
+            ->whereNull('youtube_video_id')
+            ->orderBy('id', 'desc')
+            ->first();
+
+        if ($video) {
+            $video->update([
+                'status' => 'completed',
+                'map_name' => $demo->map_name ?? $video->map_name,
+                'player_name' => $demo->player_name ?? $video->player_name,
+                'physics' => $demo->physics ?? $video->physics,
+                'time_ms' => $demo->time_ms ?? $video->time_ms,
+                'gametype' => $demo->gametype ?? $video->gametype,
+                'record_id' => $recordId,
+                'youtube_url' => $validated['youtube_url'],
+                'youtube_video_id' => $youtubeVideoId,
+                'render_duration_seconds' => $validated['render_duration_seconds'] ?? $video->render_duration_seconds,
+                'video_file_size' => $validated['video_file_size'] ?? $video->video_file_size,
+                'is_visible' => true,
+                'published_at' => now(),
+                'publish_approved' => true,
+                'failure_reason' => null,
+            ]);
+
+            Log::info('reportByHash: updated existing Discord placeholder', [
+                'video_id' => $video->id,
+                'demo_id' => $demo->id,
+            ]);
+
+            return response()->json(['success' => true, 'id' => $video->id, 'updated' => true]);
+        }
+
+        // No placeholder found - create fresh record (backward compat for legacy / missed start calls)
         $video = RenderedVideo::create([
             'map_name' => $demo->map_name,
             'player_name' => $demo->player_name,
@@ -346,6 +383,92 @@ class DemomeController extends Controller
         ]);
 
         return response()->json(['success' => true, 'id' => $video->id]);
+    }
+
+    /**
+     * Create a RenderedVideo placeholder at the START of a Discord render so it's
+     * visible in the admin panel as 'rendering' immediately (before upload completes).
+     * Bot calls this right before launching oDFe. On success, reportByHash updates it
+     * to 'completed'. On crash/Ctrl+C, bot calls /fail/{id} to mark it as failed.
+     */
+    public function startDiscordRender(Request $request)
+    {
+        $validated = $request->validate([
+            'md5_hash' => 'required|string|size:32',
+            'requested_by' => 'nullable|string',
+        ]);
+
+        $demo = UploadedDemo::where('file_hash', $validated['md5_hash'])
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        if (!$demo) {
+            Log::warning('startDiscordRender: no demo found for hash', ['md5_hash' => $validated['md5_hash']]);
+            return response()->json(['success' => false, 'error' => 'No demo found for this hash'], 404);
+        }
+
+        // If there's already a rendering placeholder for this demo, reuse it (bot retry scenario).
+        $existing = RenderedVideo::where('demo_id', $demo->id)
+            ->where('source', 'discord')
+            ->whereIn('status', ['rendering', 'uploading'])
+            ->whereNull('youtube_video_id')
+            ->orderBy('id', 'desc')
+            ->first();
+
+        if ($existing) {
+            $existing->update([
+                'status' => 'rendering',
+                'updated_at' => now(),
+            ]);
+            return response()->json(['success' => true, 'id' => $existing->id, 'reused' => true]);
+        }
+
+        $video = RenderedVideo::create([
+            'map_name' => $demo->map_name,
+            'player_name' => $demo->player_name,
+            'physics' => $demo->physics,
+            'time_ms' => $demo->time_ms,
+            'gametype' => $demo->gametype,
+            'record_id' => $demo->record_id,
+            'demo_id' => $demo->id,
+            'source' => 'discord',
+            'requested_by' => $validated['requested_by'] ?? null,
+            'status' => 'rendering',
+            'priority' => 3,
+            'is_visible' => false,
+            'user_id' => $demo->user_id,
+        ]);
+
+        Log::info('startDiscordRender: created placeholder', [
+            'video_id' => $video->id,
+            'demo_id' => $demo->id,
+            'map_name' => $demo->map_name,
+        ]);
+
+        return response()->json(['success' => true, 'id' => $video->id]);
+    }
+
+    /**
+     * Return the one-shot "restart Discord scraping from message X" marker set by
+     * an admin in Filament, and clear it. Bot calls this on startup and, if a value
+     * comes back, resets its local channels.last_scraped_message_id to that value
+     * before scraping Discord for the next batch of demos.
+     */
+    public function discordRestartMarker()
+    {
+        $key = 'demome:discord_restart_from_message_id';
+        $value = SiteSetting::get($key);
+
+        if (!$value) {
+            return response()->json(['message_id' => null]);
+        }
+
+        // One-shot: clear it so the bot doesn't keep re-applying on every startup.
+        SiteSetting::set($key, '');
+
+        Log::info('discordRestartMarker: consumed marker', ['message_id' => $value]);
+
+        return response()->json(['message_id' => (string) $value]);
     }
 
     public function uploadDemo(Request $request)

--- a/resources/views/filament/pages/demome-control.blade.php
+++ b/resources/views/filament/pages/demome-control.blade.php
@@ -139,7 +139,7 @@
             </div>
         </x-filament::section>
 
-        {{-- Today + Auto-Publish --}}
+        {{-- Today + Last manual bulks --}}
         <x-filament::section>
             <x-slot name="heading">Today & Publishing</x-slot>
             <div class="space-y-2 text-sm">
@@ -147,18 +147,20 @@
                 <div class="flex justify-between"><span class="text-gray-500">Gameplay</span><span class="text-gray-300">{{ $backlog['today_gameplay_hours'] }}h</span></div>
                 <div class="flex justify-between"><span class="text-gray-500">Render time</span><span class="text-gray-300">{{ $backlog['today_render_hours'] }}h</span></div>
                 <div class="pt-2 border-t border-gray-700/50 space-y-1">
-                    <div class="flex items-center justify-between">
-                        <span class="text-gray-500">Next auto-publish</span>
-                        <span class="text-gray-300 text-xs">{{ $next_auto_publish->format('D M j, H:i') }}</span>
-                    </div>
-                    @if($last_auto_publish)
-                        <div class="flex items-center justify-between">
-                            <span class="text-gray-500">Last</span>
-                            <span class="text-gray-300 text-xs">{{ $last_auto_publish->format('D M j, H:i') }}</span>
+                    <div class="text-gray-500 text-xs uppercase tracking-wider mb-1">Last manual bulks</div>
+                    @forelse($manual_bulk_history as $entry)
+                        <div class="flex items-center justify-between gap-2">
+                            <span class="text-gray-300 text-xs truncate">{{ $entry['label'] }}</span>
+                            <span class="text-gray-500 text-xs whitespace-nowrap">
+                                {{ \Carbon\Carbon::parse($entry['ts'])->format('M j, H:i') }}
+                                <span class="text-primary-400 font-medium ml-1">({{ $entry['count'] }})</span>
+                            </span>
                         </div>
-                    @endif
+                    @empty
+                        <div class="text-gray-600 text-xs italic">No manual bulk runs yet</div>
+                    @endforelse
                     @if($publishing_count > 0)
-                        <div class="flex items-center justify-between">
+                        <div class="flex items-center justify-between pt-2 border-t border-gray-700/30 mt-2">
                             <span class="text-gray-500">Awaiting demome</span>
                             <x-filament::badge color="warning">{{ $publishing_count }}</x-filament::badge>
                         </div>
@@ -168,12 +170,79 @@
         </x-filament::section>
     </div>
 
+    {{-- Row 2.5: Manual Bulk Publish (per-tier) --}}
+    <x-filament::section class="mt-4">
+        <x-slot name="heading">Manual Bulk Publish</x-slot>
+        <x-slot name="description">
+            Mark every unlisted auto-rendered video in a given category as approved for publishing.
+            Demome bot will transition them from unlisted to public on its next run.
+            Use this for manual curation - the triweekly automatic bulk has been disabled.
+        </x-slot>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+            @foreach($bulk_tier_buttons as $btn)
+                @php
+                    $isAll = $btn['tier'] === -1;
+                    $disabled = $btn['count'] === 0;
+                    $confirm = "Mark {$btn['count']} unlisted videos in '{$btn['label']}' for publishing?";
+                @endphp
+                <x-filament::button
+                    wire:click="bulkPublishTier({{ $btn['tier'] }})"
+                    wire:confirm="{{ $confirm }}"
+                    :color="$isAll ? 'danger' : 'success'"
+                    :disabled="$disabled"
+                    icon="heroicon-o-eye"
+                    class="w-full"
+                >
+                    {{ $btn['label'] }} ({{ $btn['count'] }})
+                </x-filament::button>
+            @endforeach
+        </div>
+    </x-filament::section>
+
     {{-- Row 3: API Token (compact) --}}
     <x-filament::section class="mt-4">
         <x-slot name="heading">API Token</x-slot>
         <div class="flex items-center gap-4">
             <code class="flex-1 px-3 py-2 bg-gray-800 rounded text-sm font-mono text-gray-300 break-all select-all">{{ $apiToken ?: 'Not set' }}</code>
             {{ $this->regenerateTokenAction }}
+        </div>
+    </x-filament::section>
+
+    {{-- Row 3.5: Discord restart marker --}}
+    <x-filament::section class="mt-4">
+        <x-slot name="heading">Discord Restart Marker</x-slot>
+        <x-slot name="description">
+            Force demome to rescan Discord starting from a specific message ID on its next startup.
+            Useful when a render crashed without writing anything and the bot has already advanced past it.
+            The marker is one-shot: it is consumed by demome on startup and cleared automatically.
+        </x-slot>
+        <div class="space-y-3">
+            @if($discordRestartMarker)
+                <div class="flex items-center justify-between p-2 bg-yellow-900/20 border border-yellow-800/50 rounded">
+                    <div class="text-sm">
+                        <span class="text-gray-400">Pending marker:</span>
+                        <code class="ml-2 text-yellow-300 font-mono">{{ $discordRestartMarker }}</code>
+                    </div>
+                    <x-filament::button wire:click="clearDiscordRestartMarker" size="sm" color="danger" icon="heroicon-o-x-mark">
+                        Clear
+                    </x-filament::button>
+                </div>
+            @endif
+            <div class="flex items-center gap-3">
+                <input
+                    type="text"
+                    wire:model="discordRestartMessageId"
+                    placeholder="Discord message ID (e.g. 1492601473450774711)"
+                    class="flex-1 px-3 py-2 bg-gray-800 rounded text-sm font-mono text-gray-300 border border-gray-700 focus:border-primary-500 focus:outline-none"
+                />
+                <x-filament::button wire:click="setDiscordRestartMarker" color="warning" icon="heroicon-o-arrow-uturn-left">
+                    Set Marker
+                </x-filament::button>
+            </div>
+            <div class="text-xs text-gray-500">
+                Demome will re-scrape the Discord channel(s) for messages with ID &gt; this value on next startup.
+                Set the message ID to one <strong>just before</strong> the message you want reprocessed.
+            </div>
         </div>
     </x-filament::section>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,6 +34,8 @@ Route::prefix('demome')->middleware('demome.token')->withoutMiddleware('throttle
     Route::post('/heartbeat', [\App\Http\Controllers\Api\DemomeController::class, 'heartbeat']);
     Route::post('/report', [\App\Http\Controllers\Api\DemomeController::class, 'report']);
     Route::post('/report-by-hash', [\App\Http\Controllers\Api\DemomeController::class, 'reportByHash']);
+    Route::post('/start-discord-render', [\App\Http\Controllers\Api\DemomeController::class, 'startDiscordRender']);
+    Route::get('/discord-restart-marker', [\App\Http\Controllers\Api\DemomeController::class, 'discordRestartMarker']);
     Route::post('/upload-demo', [\App\Http\Controllers\Api\DemomeController::class, 'uploadDemo']);
     Route::get('/download-demo/{demo}', [\App\Http\Controllers\Api\DemomeController::class, 'downloadDemo']);
     Route::get('/videos-to-publish', [\App\Http\Controllers\Api\DemomeController::class, 'videosToPublish']);


### PR DESCRIPTION
## Summary
- Discord renders now create a `RenderedVideo` placeholder with `status=rendering` the moment the bot picks them up, so the admin panel shows in-progress and failed Discord renders instead of only successful ones.
- `/api/demome/report-by-hash` prefers updating the existing placeholder over creating a duplicate, preserving the timeline and `failure_reason`.
- New one-shot "rescan Discord from message ID X" marker lets an admin rewind demome's Discord watermark from Filament when a render crashes without writing any state.
- Triweekly `demome:auto-publish` cron removed. Replaced by per-tier manual bulk publish buttons in `DemomeControl` admin page (All / Online WR / Offline ≤ WR / Online Top 2-10 / Offline ≤ 10% / Online Rank 11+ / Offline ≤ 50% / Longer / Very long / Unclassified, each with dynamic count and wire:confirm gate).
- "Next auto-publish / Last" row replaced by "Last manual bulks" — last 3 runs with label + timestamp + count.

## New API endpoints
- `POST /api/demome/start-discord-render` — called by demome before launching oDFe, creates a `rendering` placeholder linked by `demo_id`, reuses existing rendering placeholder on retry.
- `GET /api/demome/discord-restart-marker` — called by demome on startup, returns the admin-set snowflake ID and clears it (one-shot).

## Behaviour changes
- **Discord renders**: `reportByHash` now searches for an existing placeholder before creating. If found, updates to `completed` with the YouTube URL. If not found, falls back to creating a fresh record (backward compat for legacy reports without `start-discord-render`).
- **Triweekly cron**: `$schedule->command('demome:auto-publish')->weeklyOn(0, '18:00')->when(weekOfYear % 3 === 0)` was removed. The `demome:auto-publish` Artisan command itself remains for manual invocation but is no longer scheduled. Python bot's every-4h `auto_publish_deficit()` still maintains the 12/day publish trickle.
- **Manual bulk publish**: `bulkPublishTier(int $tier)` bypasses rotation/mix and dumps the entire tier bucket into `publish_approved=true` in a single `UPDATE`. Intended for explicit admin curation only.

## Test plan
- [ ] Pull the matching demome-bot commit, trigger a Discord render, verify the admin panel shows it with `rendering` status before upload finishes
- [ ] Kill demome mid-render, verify the RenderedVideo becomes `failed` with `KeyboardInterrupt: interrupted` reason (or similar)
- [ ] Successful Discord render verifies the placeholder was updated to `completed` with YouTube URL (no duplicate row)
- [ ] Open DemomeControl, set a Discord Restart Marker with a known message ID, restart demome, verify it rewinds the watermark and re-processes that message (check logs for "Applied Discord restart marker: rewound N channel(s)")
- [ ] Clear marker via the Clear button, verify banner disappears
- [ ] Click "Manual Bulk Publish → Offline ≤ WR (70)" (or whichever small bucket exists), confirm the dialog, verify notification shows count + label, verify the "Last manual bulks" list adds the new entry, verify Python bot picks up the approved videos on next poll
- [ ] Click "All" on a tiny count, verify mix is bypassed (all tiers eligible at once)
- [ ] Invalid snowflake ID in Discord Restart Marker input shows danger notification
- [ ] Check that `php artisan schedule:list` no longer shows `demome:auto-publish`
