### PR TITLE
Fix Discord render 500 + prioritize Discord in queue + UI polish

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -364,7 +364,7 @@ class DemomeController extends Controller
             'source' => 'discord',
             'requested_by' => $validated['requested_by'] ?? null,
             'status' => 'completed',
-            'priority' => 3,
+            'priority' => 1,
             'demo_url' => 'discord://' . $demo->id,
             'demo_filename' => $demo->original_filename,
             'youtube_url' => $validated['youtube_url'],
@@ -458,7 +458,10 @@ class DemomeController extends Controller
             'source' => 'discord',
             'requested_by' => $validated['requested_by'] ?? null,
             'status' => 'rendering',
-            'priority' => 3,
+            // Discord demos are user-requested on-demand, so they're P1 (highest).
+            // This is cosmetic for admin panel display; Discord renders never go
+            // through the queue endpoint that actually orders by priority.
+            'priority' => 1,
             // demo_url is NOT NULL in the schema but Discord demos don't have a URL
             // (they were uploaded directly). Use a placeholder that identifies the source.
             'demo_url' => 'discord://' . $demo->id,

--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -354,8 +354,8 @@ class DemomeController extends Controller
 
         // No placeholder found - create fresh record (backward compat for legacy / missed start calls)
         $video = RenderedVideo::create([
-            'map_name' => $demo->map_name,
-            'player_name' => $demo->player_name,
+            'map_name' => $demo->map_name ?? 'Unknown',
+            'player_name' => $demo->player_name ?? 'Unknown',
             'physics' => $demo->physics,
             'time_ms' => $demo->time_ms,
             'gametype' => $demo->gametype,
@@ -365,6 +365,8 @@ class DemomeController extends Controller
             'requested_by' => $validated['requested_by'] ?? null,
             'status' => 'completed',
             'priority' => 3,
+            'demo_url' => 'discord://' . $demo->id,
+            'demo_filename' => $demo->original_filename,
             'youtube_url' => $validated['youtube_url'],
             'youtube_video_id' => $youtubeVideoId,
             'render_duration_seconds' => $validated['render_duration_seconds'] ?? null,
@@ -396,6 +398,14 @@ class DemomeController extends Controller
         $validated = $request->validate([
             'md5_hash' => 'required|string|size:32',
             'requested_by' => 'nullable|string',
+            // Metadata from bot (synchronously parsed via DemoCleaner3 in upload-demo).
+            // Needed because ProcessDemoJob runs async and demo->map_name may still be null
+            // when start-discord-render is called milliseconds after upload-demo.
+            'map_name' => 'nullable|string',
+            'player_name' => 'nullable|string',
+            'physics' => 'nullable|string',
+            'time_ms' => 'nullable|integer',
+            'gametype' => 'nullable|string',
         ]);
 
         $demo = UploadedDemo::where('file_hash', $validated['md5_hash'])
@@ -406,6 +416,14 @@ class DemomeController extends Controller
             Log::warning('startDiscordRender: no demo found for hash', ['md5_hash' => $validated['md5_hash']]);
             return response()->json(['success' => false, 'error' => 'No demo found for this hash'], 404);
         }
+
+        // Merge bot-provided metadata with demo fields (demo fields may still be null
+        // if ProcessDemoJob hasn't finished yet). Provide hard fallbacks for NOT NULL cols.
+        $mapName = $validated['map_name'] ?? $demo->map_name ?? 'Pending';
+        $playerName = $validated['player_name'] ?? $demo->player_name ?? 'Pending';
+        $physics = $validated['physics'] ?? $demo->physics;
+        $timeMs = $validated['time_ms'] ?? $demo->time_ms;
+        $gametype = $validated['gametype'] ?? $demo->gametype;
 
         // If there's already a rendering placeholder for this demo, reuse it (bot retry scenario).
         $existing = RenderedVideo::where('demo_id', $demo->id)
@@ -418,23 +436,33 @@ class DemomeController extends Controller
         if ($existing) {
             $existing->update([
                 'status' => 'rendering',
+                'map_name' => $mapName,
+                'player_name' => $playerName,
+                'physics' => $physics,
+                'time_ms' => $timeMs,
+                'gametype' => $gametype,
+                'failure_reason' => null,
                 'updated_at' => now(),
             ]);
             return response()->json(['success' => true, 'id' => $existing->id, 'reused' => true]);
         }
 
         $video = RenderedVideo::create([
-            'map_name' => $demo->map_name,
-            'player_name' => $demo->player_name,
-            'physics' => $demo->physics,
-            'time_ms' => $demo->time_ms,
-            'gametype' => $demo->gametype,
+            'map_name' => $mapName,
+            'player_name' => $playerName,
+            'physics' => $physics,
+            'time_ms' => $timeMs,
+            'gametype' => $gametype,
             'record_id' => $demo->record_id,
             'demo_id' => $demo->id,
             'source' => 'discord',
             'requested_by' => $validated['requested_by'] ?? null,
             'status' => 'rendering',
             'priority' => 3,
+            // demo_url is NOT NULL in the schema but Discord demos don't have a URL
+            // (they were uploaded directly). Use a placeholder that identifies the source.
+            'demo_url' => 'discord://' . $demo->id,
+            'demo_filename' => $demo->original_filename,
             'is_visible' => false,
             'user_id' => $demo->user_id,
         ]);
@@ -442,7 +470,7 @@ class DemomeController extends Controller
         Log::info('startDiscordRender: created placeholder', [
             'video_id' => $video->id,
             'demo_id' => $demo->id,
-            'map_name' => $demo->map_name,
+            'map_name' => $mapName,
         ]);
 
         return response()->json(['success' => true, 'id' => $video->id]);
@@ -453,6 +481,11 @@ class DemomeController extends Controller
      * an admin in Filament, and clear it. Bot calls this on startup and, if a value
      * comes back, resets its local channels.last_scraped_message_id to that value
      * before scraping Discord for the next batch of demos.
+     *
+     * The admin types the message ID they want re-processed. Discord's `after` query
+     * is exclusive (returns messages with ID > after), so to make that target message
+     * actually included we return (snowflake - 1) as the rewind target. Snowflake IDs
+     * are 63-bit and fit in a native PHP int on 64-bit platforms.
      */
     public function discordRestartMarker()
     {
@@ -466,9 +499,19 @@ class DemomeController extends Controller
         // One-shot: clear it so the bot doesn't keep re-applying on every startup.
         SiteSetting::set($key, '');
 
-        Log::info('discordRestartMarker: consumed marker', ['message_id' => $value]);
+        // Make the stored ID inclusive: subtract 1 so Discord's exclusive `after`
+        // parameter returns the target message itself on the next scrape.
+        $rewindTarget = (string) ((int) $value - 1);
 
-        return response()->json(['message_id' => (string) $value]);
+        Log::info('discordRestartMarker: consumed marker', [
+            'stored_message_id' => $value,
+            'rewind_target' => $rewindTarget,
+        ]);
+
+        return response()->json([
+            'message_id' => $rewindTarget,
+            'original' => (string) $value,
+        ]);
     }
 
     public function uploadDemo(Request $request)

--- a/resources/views/filament/pages/demome-control.blade.php
+++ b/resources/views/filament/pages/demome-control.blade.php
@@ -233,7 +233,9 @@
                     type="text"
                     wire:model="discordRestartMessageId"
                     placeholder="Discord message ID (e.g. 1492601473450774711)"
-                    class="flex-1 px-3 py-2 bg-gray-800 rounded text-sm font-mono text-gray-300 border border-gray-700 focus:border-primary-500 focus:outline-none"
+                    style="flex: 1; padding: 8px 12px; background: #1f2937; color: #e5e7eb; border: 1px solid #374151; border-radius: 6px; font-size: 13px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; outline: none;"
+                    onfocus="this.style.borderColor='#ea580c'"
+                    onblur="this.style.borderColor='#374151'"
                 />
                 <x-filament::button wire:click="setDiscordRestartMarker" color="warning" icon="heroicon-o-arrow-uturn-left">
                     Set Marker


### PR DESCRIPTION
Follow-up fixes to the Discord render visibility PR (#prev). Addresses three real bugs discovered during first live test:

1. **`start-discord-render` returned 500** on every call because `rendered_videos` has NOT NULL constraints on `map_name` / `player_name` / `demo_url`, but the endpoint was invoked milliseconds after `upload-demo` — before `ProcessDemoJob` had populated the `UploadedDemo` metadata. Same latent bug also broke `reportByHash` create fallback: every legacy Discord render has silently 500'd for months (bot logs a warning and continues, so the admin panel never got the record).

2. **Discord restart marker was exclusive** — admin typed the ID of the message they wanted re-processed but Discord's `after` query is `> X`, skipping the target. User experienced this with message `1492475439866712225`.

3. **Discord Restart Marker input was invisible** — Filament's global input CSS reset overrode the Tailwind `bg-gray-800` / `text-gray-300` classes, leaving white-on-white text.

4. **Discord renders had priority 3** (normal) instead of 1 (WR / highest). Cosmetic for queue ordering (Discord renders bypass the queue) but misleading in the admin panel.

## Changes

**`startDiscordRender`**
- Accepts `map_name` / `player_name` / `physics` / `time_ms` / `gametype` in the request body so the bot can pass metadata it already got synchronously from `upload-demo`
- Falls back to `$demo->map_name` / `'Pending'` so NOT NULL is always satisfied
- Sets `demo_url = 'discord://<demo_id>'` (Discord demos have no real URL) and `demo_filename = $demo->original_filename`
- `priority = 1`
- Placeholder reuse path also refreshes metadata + clears `failure_reason`

**`reportByHash`**
- Fallback create path gets the same `demo_url` / `demo_filename` placeholders + `priority = 1`
- Fixes the latent bug that has been silently dropping all Discord render records for the past few months

**`discordRestartMarker`**
- Returns `(snowflake - 1)` so Discord's exclusive `after` parameter rewinds to a position where the target message itself is included
- Response now includes both `message_id` (rewind target) and `original` (what admin typed) for logging
- 63-bit snowflakes fit in native PHP int on 64-bit, no bcmath needed

**Discord Restart Marker input**
- Replaced Tailwind class-based styling with inline `style="..."` + `onfocus`/`onblur` handlers to bypass Filament's input reset

## Test plan
- [ ] Trigger a Discord render, verify admin panel shows it in P1 bucket with `rendering` status
- [ ] Verify no 500 in Laravel logs during `start-discord-render`
- [ ] Set a Discord Restart Marker to the exact ID of a known Discord message, verify demome's next scrape includes that message (not just the one after)
- [ ] Verify Discord Restart Marker input text is clearly visible before typing, while typing, and after blur
- [ ] Check that a failed Discord render creates a `failed` row in `rendered_videos` (no silent drop)

