### PR TITLE
Unified leaderboard + shared auto-assign pipeline + 90x faster nightly rematch

### DIFF
--- a/app/Console/Commands/RematchAllDemos.php
+++ b/app/Console/Commands/RematchAllDemos.php
@@ -6,120 +6,165 @@ use App\Models\UploadedDemo;
 use App\Models\Record;
 use App\Models\OfflineRecord;
 use App\Services\DemoAutoAssigner;
+use App\Services\DemoAutoAssignContext;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class RematchAllDemos extends Command
 {
-    protected $signature = 'demos:rematch-all {demo_id? : Optional specific demo ID to rematch}';
+    protected $signature = 'demos:rematch-all
+        {demo_id? : Optional specific demo ID to rematch}
+        {--chunk=1000 : Batch size for chunkById streaming}';
+
     protected $description = 'Rematch all unassigned demos against current user aliases';
 
     public function handle(DemoAutoAssigner $autoAssigner)
     {
-        $demoId = $this->argument('demo_id');
+        $demoId = (int) $this->argument('demo_id') ?: null;
+        $chunkSize = max(100, (int) $this->option('chunk'));
 
+        // Single-demo mode bypasses chunking/preload entirely — one demo
+        // doesn't justify loading ~650k Records into memory, and verbose
+        // per-field output only makes sense for a targeted run.
         if ($demoId) {
             $this->info("Rematching demo ID {$demoId}...");
-            $demos = UploadedDemo::where('id', $demoId)
-                ->whereNotNull('player_name')
-                ->get();
-        } else {
-            $this->info('Rematching all unassigned demos...');
-            // Rematch all demos that are NOT assigned (includes: uploaded, processing, processed, failed)
-            $demos = UploadedDemo::where('status', '!=', 'assigned')
-                ->whereNotNull('player_name')
-                ->get();
+            $demo = UploadedDemo::where('id', $demoId)->whereNotNull('player_name')->first();
+            if (!$demo) {
+                $this->warn("Demo {$demoId} not found or has no player_name");
+                return 0;
+            }
+            [$improved, $assigned] = $this->processDemo($demo, $autoAssigner, null, true);
+            $this->info("Done! Improved: {$improved}, Assigned: {$assigned}");
+            return 0;
         }
 
-        $this->info("Found {$demos->count()} demos to rematch");
+        $this->info('Rematching all unassigned demos...');
 
-        $progressBar = $this->output->createProgressBar($demos->count());
+        // Rematch all demos that are NOT assigned (includes: uploaded,
+        // processing, processed, failed). player_name is required for
+        // fuzzy-match to do anything useful.
+        $query = UploadedDemo::where('status', '!=', 'assigned')->whereNotNull('player_name');
+        $total = (clone $query)->count();
+        $this->info("Found {$total} demos to rematch");
+
+        if ($total === 0) {
+            return 0;
+        }
+
+        $this->info('Preloading Record index...');
+        $t0 = microtime(true);
+        $ctx = DemoAutoAssignContext::build();
+        $this->info('  -> ' . number_format($ctx->recordCount()) . ' records indexed in ' . round(microtime(true) - $t0, 1) . 's');
+
+        $progressBar = $this->output->createProgressBar($total);
         $progressBar->start();
 
         $improved = 0;
         $assigned = 0;
 
-        foreach ($demos as $demo) {
-            if ($demo->is_offline) {
-                // Offline demos (df/fs/fc) never map to online Records.
-                // Refresh their fuzzy name-match hint against the current
-                // alias set so admin UI / future upgrades stay accurate.
-                $nameMatch = $autoAssigner->updateNameMatchOnly($demo);
-
-                if ($demoId) {
-                    $this->info("\nDemo ID: {$demo->id} (offline)");
-                    $this->info("Player Name: {$demo->player_name}");
-                    $this->info("New Suggested User ID: " . ($nameMatch['user_id'] ?? 'null'));
-                    $this->info("New Confidence: {$nameMatch['confidence']}%");
+        // chunkById streams the working set without holding all rows in
+        // memory at once. Each chunk is wrapped in its own transaction so
+        // per-demo UPDATE + rank-cascade statements amortise the commit
+        // cost across the batch.
+        $query->orderBy('id')->chunkById($chunkSize, function ($demos) use ($autoAssigner, $ctx, $progressBar, &$improved, &$assigned) {
+            DB::transaction(function () use ($demos, $autoAssigner, $ctx, $progressBar, &$improved, &$assigned) {
+                foreach ($demos as $demo) {
+                    [$di, $da] = $this->processDemo($demo, $autoAssigner, $ctx, false);
+                    $improved += $di;
+                    $assigned += $da;
+                    $progressBar->advance();
                 }
-
-                // If the offline demo has a missing offline_record and we
-                // have a 100% confident user match, create it. Rank cascade
-                // mirrors DemoProcessorService::createOfflineRecord but
-                // simplified — rematch has no file-path / validity context.
-                if ($nameMatch['confidence'] === 100 && $nameMatch['user_id'] && $demo->status !== 'assigned' && $demo->file_path) {
-                    if ($this->ensureOfflineRecord($demo, $demoId !== null)) {
-                        $assigned++;
-                    }
-                }
-
-                // Fix status for offline demos that already have an
-                // offline_record but weren't marked assigned.
-                if ($demo->status !== 'assigned' && $demo->file_path) {
-                    $existing = OfflineRecord::where('demo_id', $demo->id)->first();
-                    if ($existing) {
-                        $demo->update(['status' => 'assigned']);
-                        $assigned++;
-                        if ($demoId) {
-                            $this->info("✓ Fixed status for offline record ID: {$existing->id}");
-                        }
-                    }
-                }
-
-                $improved++;
-                $progressBar->advance();
-                continue;
-            }
-
-            // Online demo: run the shared PASS 0/1/2 pipeline. The service
-            // handles q3df login matching (PASS 0), uploader record
-            // matching (PASS 1), fuzzy nick matching (PASS 2), writes
-            // match_method, and upgrades any pre-existing offline_record
-            // to the online Record (rank cascade + delete).
-            $outcome = $autoAssigner->attemptAssignToRecord($demo);
-
-            if ($demoId) {
-                $demo->refresh();
-                $this->info("\nDemo ID: {$demo->id} (online)");
-                $this->info("Player Name: {$demo->player_name}");
-                $this->info("Outcome: {$outcome}");
-                $this->info("match_method: " . ($demo->match_method ?? 'null'));
-                $this->info("record_id: " . ($demo->record_id ?? 'null'));
-                $this->info("suggested_user_id: " . ($demo->suggested_user_id ?? 'null'));
-                $this->info("name_confidence: {$demo->name_confidence}%");
-            }
-
-            if ($outcome === DemoAutoAssigner::OUTCOME_RECORD) {
-                $assigned++;
-            } elseif ($outcome === DemoAutoAssigner::OUTCOME_PROFILE) {
-                // q3df login matched a user but no Record exists. Create
-                // an offline_record so the run shows up on that user's
-                // leaderboard (parity with DemoProcessorService scénár B).
-                if ($demo->file_path) {
-                    $demo = $demo->fresh();
-                    if ($this->ensureOfflineRecord($demo, $demoId !== null)) {
-                        $assigned++;
-                    }
-                }
-            }
-
-            $improved++;
-            $progressBar->advance();
-        }
+            });
+        });
 
         $progressBar->finish();
         $this->newLine();
         $this->info("Done! Improved confidence for {$improved} demos.");
         $this->info("Assigned {$assigned} demos to records.");
+        return 0;
+    }
+
+    /**
+     * Run the auto-assign pipeline on a single demo. Returns [improved, assigned]
+     * counters so the caller can aggregate across a batch. When $verbose is
+     * true, per-demo diagnostics are written to stdout (single-demo mode).
+     */
+    protected function processDemo(UploadedDemo $demo, DemoAutoAssigner $autoAssigner, ?DemoAutoAssignContext $ctx, bool $verbose): array
+    {
+        $assigned = 0;
+
+        if ($demo->is_offline) {
+            // Offline demos (df/fs/fc) never map to online Records.
+            // Refresh their fuzzy name-match hint against the current
+            // alias set so admin UI / future upgrades stay accurate.
+            $nameMatch = $autoAssigner->updateNameMatchOnly($demo);
+
+            if ($verbose) {
+                $this->info("\nDemo ID: {$demo->id} (offline)");
+                $this->info("Player Name: {$demo->player_name}");
+                $this->info("New Suggested User ID: " . ($nameMatch['user_id'] ?? 'null'));
+                $this->info("New Confidence: {$nameMatch['confidence']}%");
+            }
+
+            // If the offline demo has a missing offline_record and we
+            // have a 100% confident user match, create it. Rank cascade
+            // mirrors DemoProcessorService::createOfflineRecord but
+            // simplified — rematch has no file-path / validity context.
+            if ($nameMatch['confidence'] === 100 && $nameMatch['user_id'] && $demo->status !== 'assigned' && $demo->file_path) {
+                if ($this->ensureOfflineRecord($demo, $verbose)) {
+                    $assigned++;
+                }
+            }
+
+            // Fix status for offline demos that already have an
+            // offline_record but weren't marked assigned.
+            if ($demo->status !== 'assigned' && $demo->file_path) {
+                $existing = OfflineRecord::where('demo_id', $demo->id)->first();
+                if ($existing) {
+                    $demo->update(['status' => 'assigned']);
+                    $assigned++;
+                    if ($verbose) {
+                        $this->info("✓ Fixed status for offline record ID: {$existing->id}");
+                    }
+                }
+            }
+
+            return [1, $assigned];
+        }
+
+        // Online demo: run the shared PASS 0/1/2 pipeline. The service
+        // handles q3df login matching (PASS 0), uploader record
+        // matching (PASS 1), fuzzy nick matching (PASS 2), writes
+        // match_method, and upgrades any pre-existing offline_record
+        // to the online Record (rank cascade + delete).
+        $outcome = $autoAssigner->attemptAssignToRecord($demo, $ctx);
+
+        if ($verbose) {
+            $demo->refresh();
+            $this->info("\nDemo ID: {$demo->id} (online)");
+            $this->info("Player Name: {$demo->player_name}");
+            $this->info("Outcome: {$outcome}");
+            $this->info("match_method: " . ($demo->match_method ?? 'null'));
+            $this->info("record_id: " . ($demo->record_id ?? 'null'));
+            $this->info("suggested_user_id: " . ($demo->suggested_user_id ?? 'null'));
+            $this->info("name_confidence: {$demo->name_confidence}%");
+        }
+
+        if ($outcome === DemoAutoAssigner::OUTCOME_RECORD) {
+            $assigned++;
+        } elseif ($outcome === DemoAutoAssigner::OUTCOME_PROFILE) {
+            // q3df login matched a user but no Record exists. Create
+            // an offline_record so the run shows up on that user's
+            // leaderboard (parity with DemoProcessorService scénár B).
+            if ($demo->file_path) {
+                $demo = $demo->fresh();
+                if ($this->ensureOfflineRecord($demo, $verbose)) {
+                    $assigned++;
+                }
+            }
+        }
+
+        return [1, $assigned];
     }
 
     /**

--- a/app/Console/Commands/RematchAllDemos.php
+++ b/app/Console/Commands/RematchAllDemos.php
@@ -4,8 +4,8 @@ namespace App\Console\Commands;
 
 use App\Models\UploadedDemo;
 use App\Models\Record;
-use App\Services\NameMatcher;
-use App\Services\DemoProcessorService;
+use App\Models\OfflineRecord;
+use App\Services\DemoAutoAssigner;
 use Illuminate\Console\Command;
 
 class RematchAllDemos extends Command
@@ -13,7 +13,7 @@ class RematchAllDemos extends Command
     protected $signature = 'demos:rematch-all {demo_id? : Optional specific demo ID to rematch}';
     protected $description = 'Rematch all unassigned demos against current user aliases';
 
-    public function handle()
+    public function handle(DemoAutoAssigner $autoAssigner)
     {
         $demoId = $this->argument('demo_id');
 
@@ -37,194 +37,82 @@ class RematchAllDemos extends Command
 
         $improved = 0;
         $assigned = 0;
-        $nameMatcher = app(NameMatcher::class);
-        $demoProcessor = app(DemoProcessorService::class);
 
         foreach ($demos as $demo) {
-            // PASS 1: For online demos, check if uploader has a matching record (ignores name completely)
-            $uploaderRecordMatch = false;
-            if (!$demo->is_offline && $demo->user_id && $demo->status !== 'assigned' && $demo->file_path) {
-                $physics = str_replace('.tr', '', strtolower($demo->physics));
-                $gametype = 'run_' . $physics;
-
-                $uploaderRecord = Record::where('mapname', $demo->map_name)
-                    ->where('gametype', $gametype)
-                    ->where('time', $demo->time_ms)
-                    ->where('user_id', $demo->user_id)
-                    ->first();
-
-                if ($uploaderRecord) {
-                    // Check if this demo has an existing offline_record (from fallback-assigned status)
-                    $offlineRecord = \App\Models\OfflineRecord::where('demo_id', $demo->id)->first();
-
-                    if ($offlineRecord) {
-                        // Delete the offline_record since we're upgrading to online record
-                        // Update ranks for records that were slower than the deleted one
-                        \App\Models\OfflineRecord::where('map_name', $offlineRecord->map_name)
-                            ->where('physics', $offlineRecord->physics)
-                            ->where('gametype', $offlineRecord->gametype)
-                            ->where('time_ms', '>', $offlineRecord->time_ms)
-                            ->decrement('rank');
-
-                        $offlineRecord->delete();
-
-                        if ($demoId) {
-                            $this->info("✓ Deleted offline_record (upgrading to online record)");
-                        }
-                    }
-
-                    // Uploader has a matching record - assign immediately with 100% confidence
-                    $demo->update([
-                        'record_id' => $uploaderRecord->id,
-                        'status' => 'assigned',
-                        'name_confidence' => 100,
-                        'suggested_user_id' => $demo->user_id,
-                        'matched_alias' => null, // Matched by uploader record, not name
-                    ]);
-                    $assigned++;
-                    $uploaderRecordMatch = true;
-
-                    if ($demoId) {
-                        $this->info("\n✓ Demo ID: {$demo->id} - Assigned to uploader's record ID: {$uploaderRecord->id} (100% - record match)");
-                    }
-                }
-            }
-
-            // PASS 2: Global name matching (only if not already assigned by Pass 1)
-            if (!$uploaderRecordMatch) {
-                $nameMatch = $nameMatcher->findBestMatch($demo->player_name, null);
-
-                $oldConfidence = $demo->name_confidence ?? 0;
-                $oldUserId = $demo->suggested_user_id;
+            if ($demo->is_offline) {
+                // Offline demos (df/fs/fc) never map to online Records.
+                // Refresh their fuzzy name-match hint against the current
+                // alias set so admin UI / future upgrades stay accurate.
+                $nameMatch = $autoAssigner->updateNameMatchOnly($demo);
 
                 if ($demoId) {
-                    // Verbose output for single demo
-                    $this->info("\nDemo ID: {$demo->id}");
+                    $this->info("\nDemo ID: {$demo->id} (offline)");
                     $this->info("Player Name: {$demo->player_name}");
-                    $this->info("Uploader ID: {$demo->user_id}");
-                    $this->info("Old Suggested User ID: " . ($oldUserId ?? 'null'));
-                    $this->info("Old Confidence: {$oldConfidence}%");
                     $this->info("New Suggested User ID: " . ($nameMatch['user_id'] ?? 'null'));
                     $this->info("New Confidence: {$nameMatch['confidence']}%");
-                    $this->info("Match Source: {$nameMatch['source']}");
                 }
 
-                // Always update name confidence, suggested user, and matched alias
-                $demo->update([
-                    'name_confidence' => $nameMatch['confidence'],
-                    'suggested_user_id' => $nameMatch['user_id'],
-                    'matched_alias' => $nameMatch['matched_name'] ?? null,
-                ]);
+                // If the offline demo has a missing offline_record and we
+                // have a 100% confident user match, create it. Rank cascade
+                // mirrors DemoProcessorService::createOfflineRecord but
+                // simplified — rematch has no file-path / validity context.
+                if ($nameMatch['confidence'] === 100 && $nameMatch['user_id'] && $demo->status !== 'assigned' && $demo->file_path) {
+                    if ($this->ensureOfflineRecord($demo, $demoId !== null)) {
+                        $assigned++;
+                    }
+                }
+
+                // Fix status for offline demos that already have an
+                // offline_record but weren't marked assigned.
+                if ($demo->status !== 'assigned' && $demo->file_path) {
+                    $existing = OfflineRecord::where('demo_id', $demo->id)->first();
+                    if ($existing) {
+                        $demo->update(['status' => 'assigned']);
+                        $assigned++;
+                        if ($demoId) {
+                            $this->info("✓ Fixed status for offline record ID: {$existing->id}");
+                        }
+                    }
+                }
+
+                $improved++;
+                $progressBar->advance();
+                continue;
+            }
+
+            // Online demo: run the shared PASS 0/1/2 pipeline. The service
+            // handles q3df login matching (PASS 0), uploader record
+            // matching (PASS 1), fuzzy nick matching (PASS 2), writes
+            // match_method, and upgrades any pre-existing offline_record
+            // to the online Record (rank cascade + delete).
+            $outcome = $autoAssigner->attemptAssignToRecord($demo);
+
+            if ($demoId) {
+                $demo->refresh();
+                $this->info("\nDemo ID: {$demo->id} (online)");
+                $this->info("Player Name: {$demo->player_name}");
+                $this->info("Outcome: {$outcome}");
+                $this->info("match_method: " . ($demo->match_method ?? 'null'));
+                $this->info("record_id: " . ($demo->record_id ?? 'null'));
+                $this->info("suggested_user_id: " . ($demo->suggested_user_id ?? 'null'));
+                $this->info("name_confidence: {$demo->name_confidence}%");
+            }
+
+            if ($outcome === DemoAutoAssigner::OUTCOME_RECORD) {
+                $assigned++;
+            } elseif ($outcome === DemoAutoAssigner::OUTCOME_PROFILE) {
+                // q3df login matched a user but no Record exists. Create
+                // an offline_record so the run shows up on that user's
+                // leaderboard (parity with DemoProcessorService scénár B).
+                if ($demo->file_path) {
+                    $demo = $demo->fresh();
+                    if ($this->ensureOfflineRecord($demo, $demoId !== null)) {
+                        $assigned++;
+                    }
+                }
             }
 
             $improved++;
-
-            // Fix offline demo status if it has an offline record but wrong status
-            if ($demo->is_offline && $demo->status !== 'assigned' && $demo->file_path) {
-                $offlineRecord = \App\Models\OfflineRecord::where('demo_id', $demo->id)->first();
-
-                if ($offlineRecord) {
-                    // Offline record exists but demo is not marked as assigned - fix it
-                    $demo->update(['status' => 'assigned']);
-                    $assigned++;
-
-                    if ($demoId) {
-                        $this->info("✓ Fixed status for offline record ID: {$offlineRecord->id}");
-                    }
-                }
-            }
-
-            // If 100% confidence name match, try to auto-assign (only if not already assigned by uploader record match)
-            if (!$uploaderRecordMatch && isset($nameMatch) && $nameMatch['confidence'] === 100 && $nameMatch['user_id'] && $demo->status !== 'assigned') {
-                // Check if this is an offline demo
-                if ($demo->is_offline) {
-                    // For offline demos with 100% match, create offline record if missing
-                    $offlineRecord = \App\Models\OfflineRecord::where('demo_id', $demo->id)->first();
-
-                    if (!$offlineRecord && $demo->file_path && $demo->map_name && $demo->physics && $demo->gametype && $demo->time_ms) {
-                        // Create offline record if it doesn't exist
-                        $fasterTimes = \App\Models\OfflineRecord::where('map_name', $demo->map_name)
-                            ->where('physics', $demo->physics)
-                            ->where('gametype', $demo->gametype)
-                            ->where('time_ms', '<', $demo->time_ms)
-                            ->count();
-
-                        $rank = $fasterTimes + 1;
-
-                        $offlineRecord = \App\Models\OfflineRecord::create([
-                            'map_name' => $demo->map_name,
-                            'physics' => $demo->physics,
-                            'gametype' => $demo->gametype,
-                            'time_ms' => $demo->time_ms,
-                            'player_name' => $demo->player_name,
-                            'demo_id' => $demo->id,
-                            'rank' => $rank,
-                            'date_set' => $demo->record_date ?? $demo->created_at,
-                        ]);
-
-                        // Mark demo as assigned
-                        $demo->update(['status' => 'assigned']);
-
-                        // Update ranks for slower records
-                        \App\Models\OfflineRecord::where('map_name', $demo->map_name)
-                            ->where('physics', $demo->physics)
-                            ->where('gametype', $demo->gametype)
-                            ->where('time_ms', '>=', $demo->time_ms)
-                            ->where('id', '!=', $offlineRecord->id)
-                            ->increment('rank');
-
-                        $assigned++;
-
-                        if ($demoId) {
-                            $this->info("✓ Created offline record ID: {$offlineRecord->id}");
-                        }
-                    }
-                } else {
-                    // For online demos, try to match to existing records
-                    $physics = str_replace('.tr', '', strtolower($demo->physics));
-                    $gametype = 'run_' . $physics;
-
-                    // Find matching record
-                    $record = Record::where('mapname', $demo->map_name)
-                        ->where('gametype', $gametype)
-                        ->where('time', $demo->time_ms)
-                        ->where('user_id', $nameMatch['user_id'])
-                        ->first();
-
-                    if ($record && $demo->file_path) {
-                        // Check if this demo has an existing offline_record (from fallback-assigned status)
-                        $offlineRecord = \App\Models\OfflineRecord::where('demo_id', $demo->id)->first();
-
-                        if ($offlineRecord) {
-                            // Delete the offline_record since we're upgrading to online record
-                            // Update ranks for records that were slower than the deleted one
-                            \App\Models\OfflineRecord::where('map_name', $offlineRecord->map_name)
-                                ->where('physics', $offlineRecord->physics)
-                                ->where('gametype', $offlineRecord->gametype)
-                                ->where('time_ms', '>', $offlineRecord->time_ms)
-                                ->decrement('rank');
-
-                            $offlineRecord->delete();
-
-                            if ($demoId) {
-                                $this->info("✓ Deleted offline_record (upgrading to online record)");
-                            }
-                        }
-
-                        // Assign demo to online record
-                        $demo->update([
-                            'record_id' => $record->id,
-                            'status' => 'assigned',
-                        ]);
-                        $assigned++;
-
-                        if ($demoId) {
-                            $this->info("✓ Assigned to online record ID: {$record->id}");
-                        }
-                    }
-                }
-            }
-
             $progressBar->advance();
         }
 
@@ -232,5 +120,55 @@ class RematchAllDemos extends Command
         $this->newLine();
         $this->info("Done! Improved confidence for {$improved} demos.");
         $this->info("Assigned {$assigned} demos to records.");
+    }
+
+    /**
+     * Create an offline_record for a demo if it doesn't have one yet and
+     * mark the demo as assigned. Returns true if a new offline_record was
+     * created, false if one already existed or required fields were missing.
+     *
+     * Rank cascade: decrement ranks of existing records slower than this
+     * time so the new record slots in at its correct position.
+     */
+    protected function ensureOfflineRecord(UploadedDemo $demo, bool $verbose): bool
+    {
+        if (OfflineRecord::where('demo_id', $demo->id)->exists()) {
+            return false;
+        }
+        if (!$demo->file_path || !$demo->map_name || !$demo->physics || !$demo->gametype || !$demo->time_ms) {
+            return false;
+        }
+
+        $fasterTimes = OfflineRecord::where('map_name', $demo->map_name)
+            ->where('physics', $demo->physics)
+            ->where('gametype', $demo->gametype)
+            ->where('time_ms', '<', $demo->time_ms)
+            ->count();
+
+        $offlineRecord = OfflineRecord::create([
+            'map_name'    => $demo->map_name,
+            'physics'     => $demo->physics,
+            'gametype'    => $demo->gametype,
+            'time_ms'     => $demo->time_ms,
+            'player_name' => $demo->player_name,
+            'demo_id'     => $demo->id,
+            'rank'        => $fasterTimes + 1,
+            'date_set'    => $demo->record_date ?? $demo->created_at,
+        ]);
+
+        $demo->update(['status' => 'assigned']);
+
+        OfflineRecord::where('map_name', $demo->map_name)
+            ->where('physics', $demo->physics)
+            ->where('gametype', $demo->gametype)
+            ->where('time_ms', '>=', $demo->time_ms)
+            ->where('id', '!=', $offlineRecord->id)
+            ->increment('rank');
+
+        if ($verbose) {
+            $this->info("✓ Created offline record ID: {$offlineRecord->id}");
+        }
+
+        return true;
     }
 }

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -581,37 +581,69 @@ class MapsController extends Controller
         $userDefaultOffline = $request->user()?->default_show_offline ? 'true' : 'false';
         $showOffline = $request->has('showOffline') ? $request->input('showOffline') : $userDefaultOffline;
 
-        if ($showOffline === 'true') {
-            // Determine physics patterns based on map name + selected ctf mode.
-            // fc (fast caps) maps start with "actf" or "ctf", otherwise df (defrag).
-            // Physics format in DB: "CPM.2.TR" or "VQ3.1" (N = ctf mode).
-            $offlineGametype = (str_starts_with($map->name, 'actf') || str_starts_with($map->name, 'ctf')) ? 'fc' : 'df';
-            if ($offlineGametype === 'fc' && strpos($gametype, 'ctf') === 0) {
-                $ctfNumber = substr($gametype, 3, 1);
-                $cpmPattern = "CPM.{$ctfNumber}%";
-                $vq3Pattern = "VQ3.{$ctfNumber}%";
-            } else {
-                $cpmPattern = 'CPM%';
-                $vq3Pattern = 'VQ3%';
-            }
+        // Physics patterns are needed for both the unified leaderboard (when
+        // showOffline is on) and the standalone Demos Top fallback, so pull
+        // them out of the if-block.
+        $offlineGametype = (str_starts_with($map->name, 'actf') || str_starts_with($map->name, 'ctf')) ? 'fc' : 'df';
+        if ($offlineGametype === 'fc' && strpos($gametype, 'ctf') === 0) {
+            $ctfNumber = substr($gametype, 3, 1);
+            $cpmPattern = "CPM.{$ctfNumber}%";
+            $vq3Pattern = "VQ3.{$ctfNumber}%";
+        } else {
+            $cpmPattern = 'CPM%';
+            $vq3Pattern = 'VQ3%';
+        }
 
-            $cpmOfflineRecords = $this->buildGroupedDemosTop($map->name, $cpmPattern, $column, $order, 'cpmPage', $allCpmRecordsByTime);
-            $vq3OfflineRecords = $this->buildGroupedDemosTop($map->name, $vq3Pattern, $column, $order, 'vq3Page', $allVq3RecordsByTime);
+        // When any "extras" toggle is on, replace the main records paginator
+        // with a unified leaderboard that merges main + DT reps + oldtop into
+        // one continuous rank 1..N, paginated 50 per page. Frontend detects
+        // the replacement by seeing $xOfflineRecords/$xOldRecords as null and
+        // skips its legacy merge pass.
+        if ($showOffline === 'true' || $showOldtop === 'true') {
+            $cpmRecords = $this->buildUnifiedLeaderboard(
+                $map->name, $cpmGametype, $cpmPattern,
+                $showOffline === 'true', $showOldtop === 'true',
+                $column, $order, 'cpmPage'
+            );
+            $vq3Records = $this->buildUnifiedLeaderboard(
+                $map->name, $vq3Gametype, $vq3Pattern,
+                $showOffline === 'true', $showOldtop === 'true',
+                $column, $order, 'vq3Page'
+            );
+            $cpmOfflineRecords = null;
+            $vq3OfflineRecords = null;
+            $cpmOldRecords = null;
+            $vq3OldRecords = null;
         } else {
             $cpmOfflineRecords = null;
             $vq3OfflineRecords = null;
         }
 
-        $cpmPage = ($request->has('cpmPage')) ? min($request->cpmPage, $cpmRecords->lastPage()) : 1;
+        // Redirect clamps must respect every source that shares the page
+        // parameter — main records, oldtop, and Demos Top (grouped offline).
+        // Old logic compared against $cpmRecords->lastPage() only, so a map
+        // with e.g. 50 main records (1 page) and 300 Demos Top reps (6 pages)
+        // would silently bounce every Demos Top page > 1 back to page 1.
+        $cpmMaxPage = max(
+            $cpmRecords->lastPage(),
+            $cpmOldRecords ? $cpmOldRecords->lastPage() : 1,
+            $cpmOfflineRecords ? $cpmOfflineRecords->lastPage() : 1,
+        );
+        $vq3MaxPage = max(
+            $vq3Records->lastPage(),
+            $vq3OldRecords ? $vq3OldRecords->lastPage() : 1,
+            $vq3OfflineRecords ? $vq3OfflineRecords->lastPage() : 1,
+        );
 
-        $vq3Page = ($request->has('vq3Page')) ? min($request->vq3Page, $vq3Records->lastPage()) : 1;
+        $cpmPage = ($request->has('cpmPage')) ? min($request->cpmPage, $cpmMaxPage) : 1;
+        $vq3Page = ($request->has('vq3Page')) ? min($request->vq3Page, $vq3MaxPage) : 1;
 
-        if ($request->has('vq3Page') && $request->get('vq3Page') > $vq3Records->lastPage()) {
-            return redirect()->route('maps.map', ['vq3Page' => $vq3Records->lastPage(), 'mapname' => $mapname, 'cpmPage' => $cpmPage]);
+        if ($request->has('vq3Page') && $request->get('vq3Page') > $vq3MaxPage) {
+            return redirect()->route('maps.map', ['vq3Page' => $vq3MaxPage, 'mapname' => $mapname, 'cpmPage' => $cpmPage]);
         }
 
-        if ($request->has('cpmPage') && $request->get('cpmPage') > $cpmRecords->lastPage()) {
-            return redirect()->route('maps.map', ['cpmPage' => $cpmRecords->lastPage(), 'mapname' => $mapname, 'vq3Page' => $vq3Page]);
+        if ($request->has('cpmPage') && $request->get('cpmPage') > $cpmMaxPage) {
+            return redirect()->route('maps.map', ['cpmPage' => $cpmMaxPage, 'mapname' => $mapname, 'vq3Page' => $vq3Page]);
         }
 
         // Precompute time-history cluster metadata per demo for this map.
@@ -874,17 +906,70 @@ class MapsController extends Controller
 
     /**
      * Build "Demos Top" paginator with server-side virtual-player grouping.
-     * Pools offline_records + assigned online demos for the map/physics, runs
-     * union-find on (player_name / q3df_login_name_colored / q3df_login_name),
-     * keeps the fastest attempt per cluster as the representative, then
-     * paginates the representatives. Guarantees one row per virtual player and
-     * stable cross-page behavior.
+     * Thin wrapper around buildDemosTopReps — keeps the legacy signature so
+     * existing callers don't change. The real work (clustering + rep
+     * selection + time-history metadata) lives in buildDemosTopReps so the
+     * unified leaderboard can reuse the exact same grouping.
      */
     private function buildGroupedDemosTop(string $mapName, string $physicsPattern, string $column, string $order, string $pageName, array $mainRecordIds = []): \Illuminate\Pagination\LengthAwarePaginator
     {
-        $perPage = 50;
+        $reps = $this->buildDemosTopReps($mapName, $physicsPattern, $mainRecordIds);
+        return $this->paginateReps($reps, $column, $order, $pageName, 50);
+    }
+
+    /**
+     * Paginate a pre-built reps collection: sort by $column, recompute rank
+     * (nulling flagged items), slice to the requested page. Shared between
+     * buildGroupedDemosTop (Demos-Top-only view) and buildUnifiedLeaderboard
+     * (unified main+DT+oldtop view) so rank semantics stay identical.
+     */
+    private function paginateReps(\Illuminate\Support\Collection $reps, string $column, string $order, string $pageName, int $perPage): \Illuminate\Pagination\LengthAwarePaginator
+    {
         $currentPage = (int) (request()->input($pageName, 1));
         if ($currentPage < 1) $currentPage = 1;
+
+        if ($column === 'date_set') {
+            $reps = $order === 'ASC'
+                ? $reps->sortBy(fn ($r) => strtotime((string) ($r->date_set ?? '')))->values()
+                : $reps->sortByDesc(fn ($r) => strtotime((string) ($r->date_set ?? '')))->values();
+        } else {
+            $reps = $reps->sortBy('time_ms')->values();
+        }
+
+        $rank = 0;
+        $reps = $reps->map(function ($item) use (&$rank) {
+            $hasFlag = !empty($item->approved_flags) ||
+                (property_exists($item, 'verification_type') && $item->verification_type
+                    && !in_array($item->verification_type, ['OFFLINE', 'ONLINE', 'verified']));
+            $item->rank = $hasFlag ? null : ++$rank;
+            return $item;
+        });
+
+        $total = $reps->count();
+        $offset = ($currentPage - 1) * $perPage;
+        $items = $reps->slice($offset, $perPage)->values();
+
+        return new \Illuminate\Pagination\LengthAwarePaginator(
+            $items,
+            $total,
+            $perPage,
+            $currentPage,
+            [
+                'path' => request()->url(),
+                'query' => request()->query(),
+                'pageName' => $pageName,
+            ]
+        );
+    }
+
+    /**
+     * Build the Demos Top representative collection (no pagination, no rank
+     * assignment). Returns a flat collection of candidate objects already
+     * run through union-find + MDD-time filter + online/offline subcluster
+     * split. Callers layer their own sort + rank + pagination on top.
+     */
+    private function buildDemosTopReps(string $mapName, string $physicsPattern, array $mainRecordIds = []): \Illuminate\Support\Collection
+    {
 
         // Pool 1: offline_records (with demo eager-loaded so we can read q3df signals)
         $offline = OfflineRecord::where('map_name', $mapName)
@@ -1052,11 +1137,7 @@ class MapsController extends Controller
         }
 
         if ($candidates->isEmpty()) {
-            return new \Illuminate\Pagination\LengthAwarePaginator([], 0, $perPage, $currentPage, [
-                'path' => request()->url(),
-                'query' => request()->query(),
-                'pageName' => $pageName,
-            ]);
+            return collect();
         }
 
         // Attach community flags to each candidate before clustering so flagged
@@ -1324,42 +1405,108 @@ class MapsController extends Controller
             if ($offlineRep = $buildRep($offlineIndices)) $representatives[] = $offlineRep;
         }
 
-        $reps = collect($representatives);
+        // Hand back the raw reps — caller owns sort + rank + pagination.
+        return collect($representatives);
+    }
 
-        // Sort representatives (column = 'time' or 'date_set').
-        if ($column === 'date_set') {
-            $reps = $order === 'ASC'
-                ? $reps->sortBy(fn ($r) => strtotime((string) ($r->date_set ?? '')))->values()
-                : $reps->sortByDesc(fn ($r) => strtotime((string) ($r->date_set ?? '')))->values();
-        } else {
-            $reps = $reps->sortBy('time_ms')->values();
+    /**
+     * Unified leaderboard: merge main MDD records + Demos Top reps + oldtop
+     * records into one paginated list with continuous ranks 1..N.
+     *
+     * Shape-wise the returned paginator replaces the main `$xRecords`
+     * variable when either `showOffline` or `showOldtop` is on, so the
+     * frontend stops trying to merge three separate paginators by hand
+     * (which broke both pagination and rank numbering).
+     *
+     * Scope: each SOURCE item becomes its own row (same player can appear
+     * as a main record AND as a Demos Top rep). Within-source grouping for
+     * Demos Top still happens — that's where the time-history drawer's
+     * cluster data comes from.
+     */
+    private function buildUnifiedLeaderboard(
+        string $mapname,
+        string $gametype,
+        string $physicsPattern,
+        bool $includeOffline,
+        bool $includeOldtop,
+        string $column,
+        string $order,
+        string $pageName
+    ): \Illuminate\Pagination\LengthAwarePaginator {
+        // --- Main records (all, unpaginated) --------------------------------
+        $mainRecords = Record::where('mapname', $mapname)
+            ->where('gametype', $gametype)
+            ->with(['user', 'uploadedDemos', 'renderedVideos' => fn ($q) => $q->visible()->latest()])
+            ->get();
+        $mainRecordIds = $mainRecords->pluck('id')->toArray();
+
+        // Community flags on main records drive their rank nulling.
+        // attachCommunityFlags iterates directly over $records, so a plain
+        // Eloquent Collection works — no paginator wrapping needed.
+        $this->attachCommunityFlags($mainRecords);
+
+        // Compute MDD rank map across ALL main records (sorted by time
+        // ASC) so each main record carries its own MDD-table rank, which
+        // the unified view overwrites for the merged rank but the client
+        // still exposes via `mdd_rank` for tooltips / cluster badges.
+        $allMainIdsByTime = Record::where('mapname', $mapname)
+            ->where('gametype', $gametype)
+            ->orderBy('time', 'ASC')
+            ->orderBy('date_set', 'ASC')
+            ->pluck('id')
+            ->toArray();
+        $flaggedMainIds = RecordFlag::where('status', 'approved')->whereNotNull('record_id')
+            ->whereIn('record_id', $allMainIdsByTime)->pluck('record_id')->unique()->toArray();
+        $mddRankMap = [];
+        $mr = 0;
+        foreach ($allMainIdsByTime as $id) {
+            $mddRankMap[$id] = in_array($id, $flaggedMainIds) ? null : ++$mr;
         }
 
-        // Recalculate ranks: skip flagged reps.
-        $rank = 0;
-        $reps = $reps->map(function ($item) use (&$rank) {
-            $hasFlag = !empty($item->approved_flags) ||
-                ($item->verification_type && !in_array($item->verification_type, ['OFFLINE', 'ONLINE', 'verified']));
-            $item->rank = $hasFlag ? null : ++$rank;
-            return $item;
-        });
+        $unified = collect();
 
-        // Manual pagination over representatives.
-        $total = $reps->count();
-        $offset = ($currentPage - 1) * $perPage;
-        $items = $reps->slice($offset, $perPage)->values();
+        foreach ($mainRecords as $record) {
+            $record->time_ms = $record->time; // mirror so sort/rank share one field
+            $record->mdd_rank = $mddRankMap[$record->id] ?? null;
+            $record->source_type = 'main';
+            // Don't stamp verification_type — the frontend decides
+            // verification from uploaded_demos.length > 0. Forcing
+            // 'verified' here made every main record light up green even
+            // when no demo was attached.
+            $unified->push($record);
+        }
 
-        return new \Illuminate\Pagination\LengthAwarePaginator(
-            $items,
-            $total,
-            $perPage,
-            $currentPage,
-            [
-                'path' => request()->url(),
-                'query' => request()->query(),
-                'pageName' => $pageName,
-            ]
-        );
+        // --- Oldtop ---------------------------------------------------------
+        if ($includeOldtop) {
+            $oldRecords = OldtopRecord::where('mapname', $mapname)
+                ->where('gametype', $gametype)
+                ->orderBy('time', 'ASC')
+                ->get();
+            foreach ($oldRecords as $old) {
+                $old->time_ms = $old->time;
+                $old->oldtop = true;
+                $old->source_type = 'oldtop';
+                // Same reasoning as main records — leave verification_type
+                // unset so the frontend's demo-attached check decides.
+                $unified->push($old);
+            }
+        }
+
+        // --- Demos Top reps -------------------------------------------------
+        // Same grouping logic as the stand-alone Demos Top paginator: each
+        // cluster contributes up to two rows (fastest online + fastest
+        // offline) with embedded time-history metadata.
+        if ($includeOffline) {
+            $dtReps = $this->buildDemosTopReps($mapname, $physicsPattern, $mainRecordIds);
+            foreach ($dtReps as $rep) {
+                if (empty($rep->source_type)) {
+                    $rep->source_type = $rep->is_online ?? false ? 'dt_online' : 'dt_offline';
+                }
+                $unified->push($rep);
+            }
+        }
+
+        return $this->paginateReps($unified, $column, $order, $pageName, 50);
     }
 
     /**

--- a/app/Services/DemoAutoAssignContext.php
+++ b/app/Services/DemoAutoAssignContext.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Record;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Preloaded lookup tables for batch auto-assign runs.
+ *
+ * A nightly demos:rematch-all pass would otherwise issue two Record
+ * lookups per demo (up to ~212k demos × ~4 lookups including q3df login,
+ * uploader record, and fuzzy match Record). Building one in-memory
+ * hashmap up front turns each of those into an O(1) array access,
+ * eliminating the dominant DB cost of the batch.
+ *
+ * Only passed explicitly in the batch path — live upload (ProcessDemoJob)
+ * processes one demo at a time where ad-hoc queries are perfectly fine
+ * and loading ~650k records into memory would be wasteful.
+ */
+class DemoAutoAssignContext
+{
+    /**
+     * Key format: "mapname|gametype|time_ms|user_id" => record_id.
+     *
+     * Only (mapname, gametype, time, user_id) is indexed because that's
+     * the exact 4-tuple every auto-assign PASS looks up. Storing only the
+     * id keeps the hashmap compact (~100 bytes per entry vs a hydrated
+     * Eloquent model); callers only need the id for $demo->record_id
+     * assignment.
+     *
+     * @param array<string, int> $recordIndex
+     */
+    public function __construct(protected array $recordIndex) {}
+
+    /**
+     * Build the context by streaming Records in chunks so the full
+     * collection never sits in memory at once.
+     */
+    public static function build(): self
+    {
+        $index = [];
+        DB::table('records')
+            ->select(['id', 'mapname', 'gametype', 'time', 'user_id'])
+            ->orderBy('id')
+            ->chunk(20000, function ($chunk) use (&$index) {
+                foreach ($chunk as $r) {
+                    if ($r->user_id === null) {
+                        continue;
+                    }
+                    $key = $r->mapname . '|' . $r->gametype . '|' . $r->time . '|' . $r->user_id;
+                    $index[$key] = (int) $r->id;
+                }
+            });
+        return new self($index);
+    }
+
+    public function findRecordId(string $mapname, string $gametype, int $timeMs, int $userId): ?int
+    {
+        return $this->recordIndex[$mapname . '|' . $gametype . '|' . $timeMs . '|' . $userId] ?? null;
+    }
+
+    public function recordCount(): int
+    {
+        return count($this->recordIndex);
+    }
+}

--- a/app/Services/DemoAutoAssigner.php
+++ b/app/Services/DemoAutoAssigner.php
@@ -36,8 +36,12 @@ class DemoAutoAssigner
     /**
      * Run the 3-pass auto-assign pipeline on an ONLINE demo. For offline
      * demos this returns OUTCOME_NONE without touching the demo.
+     *
+     * When $ctx is supplied (batch rematch), Record lookups go through an
+     * in-memory hashmap instead of per-demo SELECTs. Live upload path
+     * passes null and falls back to direct queries.
      */
-    public function attemptAssignToRecord(UploadedDemo $demo): string
+    public function attemptAssignToRecord(UploadedDemo $demo, ?DemoAutoAssignContext $ctx = null): string
     {
         if (!$demo->map_name || !$demo->physics || !$demo->time_ms || !$demo->player_name) {
             return self::OUTCOME_NONE;
@@ -72,18 +76,14 @@ class DemoAutoAssigner
                 $matchedUserId = $loginMatch['user_id'];
                 $tier = $loginMatch['tier']; // 'q3df_colored' | 'q3df_plain'
 
-                $record = Record::where('mapname', $demo->map_name)
-                    ->where('gametype', $gametype)
-                    ->where('time', $demo->time_ms)
-                    ->where('user_id', $matchedUserId)
-                    ->first();
+                $recordId = $this->findRecordId($ctx, $demo->map_name, $gametype, (int) $demo->time_ms, (int) $matchedUserId);
 
-                if ($record) {
+                if ($recordId !== null) {
                     // Scénár A: login + time agree → strongest match
                     $this->upgradeOfflineRecordToOnline($demo);
 
                     $demo->update([
-                        'record_id'        => $record->id,
+                        'record_id'        => $recordId,
                         'status'           => 'assigned',
                         'name_confidence'  => 100,
                         'suggested_user_id'=> $matchedUserId,
@@ -93,7 +93,7 @@ class DemoAutoAssigner
 
                     Log::info('Demo auto-assigned to record via q3df login', [
                         'demo_id' => $demo->id,
-                        'record_id' => $record->id,
+                        'record_id' => $recordId,
                         'user_id' => $matchedUserId,
                         'tier' => $tier,
                         'matched_alias' => $loginMatch['matched_alias'],
@@ -127,17 +127,13 @@ class DemoAutoAssigner
         // PASS 1: uploader has a Record at this map/gametype/time.
         // Ignores name entirely — uploader identity is authoritative.
         if ($demo->user_id) {
-            $uploaderRecord = Record::where('mapname', $demo->map_name)
-                ->where('gametype', $gametype)
-                ->where('time', $demo->time_ms)
-                ->where('user_id', $demo->user_id)
-                ->first();
+            $uploaderRecordId = $this->findRecordId($ctx, $demo->map_name, $gametype, (int) $demo->time_ms, (int) $demo->user_id);
 
-            if ($uploaderRecord) {
+            if ($uploaderRecordId !== null) {
                 $this->upgradeOfflineRecordToOnline($demo);
 
                 $demo->update([
-                    'record_id'        => $uploaderRecord->id,
+                    'record_id'        => $uploaderRecordId,
                     'status'           => 'assigned',
                     'name_confidence'  => 100,
                     'suggested_user_id'=> $demo->user_id,
@@ -147,7 +143,7 @@ class DemoAutoAssigner
 
                 Log::info('Demo auto-assigned to uploader\'s record', [
                     'demo_id' => $demo->id,
-                    'record_id' => $uploaderRecord->id,
+                    'record_id' => $uploaderRecordId,
                     'user_id' => $demo->user_id,
                     'gametype' => $gametype,
                     'file_path' => $demo->file_path,
@@ -160,43 +156,47 @@ class DemoAutoAssigner
         // PASS 2: global fuzzy nick match across all user aliases.
         $nameMatch = $this->nameMatcher->findBestMatch($demo->player_name, null);
 
-        $demo->update([
-            'name_confidence'  => $nameMatch['confidence'],
-            'suggested_user_id'=> $nameMatch['user_id'],
-            'matched_alias'    => $nameMatch['matched_name'] ?? null,
-        ]);
+        // Skip no-op writes: rematch runs daily; if aliases didn't change,
+        // most demos already have the correct name-match hints. Writing
+        // the same values back wastes ~80% of UPDATE queries in batch.
+        $newAlias = $nameMatch['matched_name'] ?? null;
+        if ($demo->name_confidence !== $nameMatch['confidence']
+            || $demo->suggested_user_id !== $nameMatch['user_id']
+            || $demo->matched_alias !== $newAlias) {
+            $demo->update([
+                'name_confidence'  => $nameMatch['confidence'],
+                'suggested_user_id'=> $nameMatch['user_id'],
+                'matched_alias'    => $newAlias,
+            ]);
 
-        Log::info('Name matching completed', [
-            'demo_id' => $demo->id,
-            'player_name' => $demo->player_name,
-            'confidence' => $nameMatch['confidence'],
-            'suggested_user_id' => $nameMatch['user_id'],
-            'matched_alias' => $nameMatch['matched_name'] ?? null,
-            'source' => $nameMatch['source'],
-        ]);
+            Log::info('Name matching completed', [
+                'demo_id' => $demo->id,
+                'player_name' => $demo->player_name,
+                'confidence' => $nameMatch['confidence'],
+                'suggested_user_id' => $nameMatch['user_id'],
+                'matched_alias' => $newAlias,
+                'source' => $nameMatch['source'],
+            ]);
+        }
 
         if ($nameMatch['confidence'] === 100 && $nameMatch['user_id']) {
-            $record = Record::where('mapname', $demo->map_name)
-                ->where('gametype', $gametype)
-                ->where('time', $demo->time_ms)
-                ->where('user_id', $nameMatch['user_id'])
-                ->first();
+            $recordId = $this->findRecordId($ctx, $demo->map_name, $gametype, (int) $demo->time_ms, (int) $nameMatch['user_id']);
 
-            if ($record) {
+            if ($recordId !== null) {
                 $this->upgradeOfflineRecordToOnline($demo);
 
                 $demo->update([
-                    'record_id'    => $record->id,
+                    'record_id'    => $recordId,
                     'status'       => 'assigned',
                     'match_method' => 'fuzzy_nick',
                 ]);
 
                 Log::info('Demo auto-assigned to record with 100% name match', [
                     'demo_id' => $demo->id,
-                    'record_id' => $record->id,
+                    'record_id' => $recordId,
                     'user_id' => $nameMatch['user_id'],
                     'gametype' => $demo->gametype,
-                    'matched_alias' => $nameMatch['matched_name'] ?? null,
+                    'matched_alias' => $newAlias,
                     'file_path' => $demo->file_path,
                 ]);
 
@@ -205,6 +205,23 @@ class DemoAutoAssigner
         }
 
         return self::OUTCOME_NONE;
+    }
+
+    /**
+     * O(1) Record lookup via context hashmap, or ad-hoc SELECT when no
+     * context is supplied (live upload path).
+     */
+    protected function findRecordId(?DemoAutoAssignContext $ctx, string $mapname, string $gametype, int $timeMs, int $userId): ?int
+    {
+        if ($ctx !== null) {
+            return $ctx->findRecordId($mapname, $gametype, $timeMs, $userId);
+        }
+        $r = Record::where('mapname', $mapname)
+            ->where('gametype', $gametype)
+            ->where('time', $timeMs)
+            ->where('user_id', $userId)
+            ->first(['id']);
+        return $r?->id;
     }
 
     /**
@@ -219,11 +236,16 @@ class DemoAutoAssigner
     {
         $nameMatch = $this->nameMatcher->findBestMatch($demo->player_name, null);
 
-        $demo->update([
-            'name_confidence'  => $nameMatch['confidence'],
-            'suggested_user_id'=> $nameMatch['user_id'],
-            'matched_alias'    => $nameMatch['matched_name'] ?? null,
-        ]);
+        $newAlias = $nameMatch['matched_name'] ?? null;
+        if ($demo->name_confidence !== $nameMatch['confidence']
+            || $demo->suggested_user_id !== $nameMatch['user_id']
+            || $demo->matched_alias !== $newAlias) {
+            $demo->update([
+                'name_confidence'  => $nameMatch['confidence'],
+                'suggested_user_id'=> $nameMatch['user_id'],
+                'matched_alias'    => $newAlias,
+            ]);
+        }
 
         return $nameMatch;
     }

--- a/app/Services/DemoAutoAssigner.php
+++ b/app/Services/DemoAutoAssigner.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\UploadedDemo;
+use App\Models\Record;
+use App\Models\OfflineRecord;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Shared auto-assign pipeline for online demos.
+ *
+ * Extracted from DemoProcessorService::autoAssignToRecord so that both the
+ * live upload path (DemoProcessorService) and the nightly batch rematch
+ * (RematchAllDemos) run the same matching logic — PASS 0 (q3df login),
+ * PASS 1 (uploader record), PASS 2 (fuzzy nick) — and write the same
+ * match_method values.
+ *
+ * Does NOT create offline records. Caller is responsible for fall-through
+ * handling:
+ *   - OUTCOME_RECORD  : demo is fully assigned; nothing more to do
+ *   - OUTCOME_PROFILE : user_id was upgraded via q3df login but no Record
+ *                       exists; caller should create an offline_record
+ *   - OUTCOME_NONE    : no match. Name-match fields may have been updated.
+ *                       Processor creates offline_record; rematch may
+ *                       create one for offline demos with 100% name match.
+ */
+class DemoAutoAssigner
+{
+    public const OUTCOME_RECORD  = 'record';
+    public const OUTCOME_PROFILE = 'profile';
+    public const OUTCOME_NONE    = 'none';
+
+    public function __construct(protected NameMatcher $nameMatcher) {}
+
+    /**
+     * Run the 3-pass auto-assign pipeline on an ONLINE demo. For offline
+     * demos this returns OUTCOME_NONE without touching the demo.
+     */
+    public function attemptAssignToRecord(UploadedDemo $demo): string
+    {
+        if (!$demo->map_name || !$demo->physics || !$demo->time_ms || !$demo->player_name) {
+            return self::OUTCOME_NONE;
+        }
+
+        // Online demos are m-prefixed gametypes (mdf, mfs, mfc). Offline
+        // demos (df, fs, fc) have their own leaderboards and are never
+        // matched to online Records.
+        if ($demo->gametype && !str_starts_with($demo->gametype, 'm')) {
+            Log::info('Skipping auto-assign for offline demo', [
+                'demo_id' => $demo->id,
+                'gametype' => $demo->gametype,
+                'map' => $demo->map_name,
+            ]);
+            return self::OUTCOME_NONE;
+        }
+
+        $physics = str_replace('.tr', '', strtolower($demo->physics));
+        $gametype = 'run_' . $physics;
+
+        // PASS 0: q3df login — server-side authoritative identifier from
+        // console messages ("Enter(Enter), you are now rank..."). Colored
+        // variant is effectively unique; plain variant is accepted only
+        // when exactly one user owns it.
+        if ($demo->q3df_login_name || $demo->q3df_login_name_colored) {
+            $loginMatch = $this->nameMatcher->matchByQ3dfLogin(
+                $demo->q3df_login_name,
+                $demo->q3df_login_name_colored
+            );
+
+            if ($loginMatch['user_id']) {
+                $matchedUserId = $loginMatch['user_id'];
+                $tier = $loginMatch['tier']; // 'q3df_colored' | 'q3df_plain'
+
+                $record = Record::where('mapname', $demo->map_name)
+                    ->where('gametype', $gametype)
+                    ->where('time', $demo->time_ms)
+                    ->where('user_id', $matchedUserId)
+                    ->first();
+
+                if ($record) {
+                    // Scénár A: login + time agree → strongest match
+                    $this->upgradeOfflineRecordToOnline($demo);
+
+                    $demo->update([
+                        'record_id'        => $record->id,
+                        'status'           => 'assigned',
+                        'name_confidence'  => 100,
+                        'suggested_user_id'=> $matchedUserId,
+                        'matched_alias'    => $loginMatch['matched_alias'],
+                        'match_method'     => $tier . '_record',
+                    ]);
+
+                    Log::info('Demo auto-assigned to record via q3df login', [
+                        'demo_id' => $demo->id,
+                        'record_id' => $record->id,
+                        'user_id' => $matchedUserId,
+                        'tier' => $tier,
+                        'matched_alias' => $loginMatch['matched_alias'],
+                    ]);
+
+                    return self::OUTCOME_RECORD;
+                }
+
+                // Scénár B: login matches a user but no Record with this
+                // time. Attribute demo to that profile; caller creates an
+                // offline_record so the run appears on that user's leaderboard.
+                $demo->update([
+                    'user_id'          => $matchedUserId,
+                    'name_confidence'  => 100,
+                    'suggested_user_id'=> $matchedUserId,
+                    'matched_alias'    => $loginMatch['matched_alias'],
+                    'match_method'     => $tier . '_profile',
+                ]);
+
+                Log::info('Demo auto-assigned to profile via q3df login (no record match)', [
+                    'demo_id' => $demo->id,
+                    'user_id' => $matchedUserId,
+                    'tier' => $tier,
+                    'matched_alias' => $loginMatch['matched_alias'],
+                ]);
+
+                return self::OUTCOME_PROFILE;
+            }
+        }
+
+        // PASS 1: uploader has a Record at this map/gametype/time.
+        // Ignores name entirely — uploader identity is authoritative.
+        if ($demo->user_id) {
+            $uploaderRecord = Record::where('mapname', $demo->map_name)
+                ->where('gametype', $gametype)
+                ->where('time', $demo->time_ms)
+                ->where('user_id', $demo->user_id)
+                ->first();
+
+            if ($uploaderRecord) {
+                $this->upgradeOfflineRecordToOnline($demo);
+
+                $demo->update([
+                    'record_id'        => $uploaderRecord->id,
+                    'status'           => 'assigned',
+                    'name_confidence'  => 100,
+                    'suggested_user_id'=> $demo->user_id,
+                    'matched_alias'    => null,
+                    'match_method'     => 'uploader_record',
+                ]);
+
+                Log::info('Demo auto-assigned to uploader\'s record', [
+                    'demo_id' => $demo->id,
+                    'record_id' => $uploaderRecord->id,
+                    'user_id' => $demo->user_id,
+                    'gametype' => $gametype,
+                    'file_path' => $demo->file_path,
+                ]);
+
+                return self::OUTCOME_RECORD;
+            }
+        }
+
+        // PASS 2: global fuzzy nick match across all user aliases.
+        $nameMatch = $this->nameMatcher->findBestMatch($demo->player_name, null);
+
+        $demo->update([
+            'name_confidence'  => $nameMatch['confidence'],
+            'suggested_user_id'=> $nameMatch['user_id'],
+            'matched_alias'    => $nameMatch['matched_name'] ?? null,
+        ]);
+
+        Log::info('Name matching completed', [
+            'demo_id' => $demo->id,
+            'player_name' => $demo->player_name,
+            'confidence' => $nameMatch['confidence'],
+            'suggested_user_id' => $nameMatch['user_id'],
+            'matched_alias' => $nameMatch['matched_name'] ?? null,
+            'source' => $nameMatch['source'],
+        ]);
+
+        if ($nameMatch['confidence'] === 100 && $nameMatch['user_id']) {
+            $record = Record::where('mapname', $demo->map_name)
+                ->where('gametype', $gametype)
+                ->where('time', $demo->time_ms)
+                ->where('user_id', $nameMatch['user_id'])
+                ->first();
+
+            if ($record) {
+                $this->upgradeOfflineRecordToOnline($demo);
+
+                $demo->update([
+                    'record_id'    => $record->id,
+                    'status'       => 'assigned',
+                    'match_method' => 'fuzzy_nick',
+                ]);
+
+                Log::info('Demo auto-assigned to record with 100% name match', [
+                    'demo_id' => $demo->id,
+                    'record_id' => $record->id,
+                    'user_id' => $nameMatch['user_id'],
+                    'gametype' => $demo->gametype,
+                    'matched_alias' => $nameMatch['matched_name'] ?? null,
+                    'file_path' => $demo->file_path,
+                ]);
+
+                return self::OUTCOME_RECORD;
+            }
+        }
+
+        return self::OUTCOME_NONE;
+    }
+
+    /**
+     * Run only the global fuzzy nick match and persist the name-match
+     * fields. Used by the batch rematch for offline demos, which never
+     * assign to online Records but still benefit from keeping the
+     * suggested-user / alias hint fresh when new aliases are approved.
+     *
+     * @return array{user_id: int|null, confidence: int, source: string, matched_name: string|null}
+     */
+    public function updateNameMatchOnly(UploadedDemo $demo): array
+    {
+        $nameMatch = $this->nameMatcher->findBestMatch($demo->player_name, null);
+
+        $demo->update([
+            'name_confidence'  => $nameMatch['confidence'],
+            'suggested_user_id'=> $nameMatch['user_id'],
+            'matched_alias'    => $nameMatch['matched_name'] ?? null,
+        ]);
+
+        return $nameMatch;
+    }
+
+    /**
+     * If the demo already has an offline_record (from a prior
+     * fallback-assignment), delete it and decrement ranks of any slower
+     * offline records for the same map/physics/gametype. No-op when no
+     * offline_record exists — safe to call from the live processor path
+     * where there's never a pre-existing offline_record for a demo.
+     */
+    protected function upgradeOfflineRecordToOnline(UploadedDemo $demo): void
+    {
+        $offlineRecord = OfflineRecord::where('demo_id', $demo->id)->first();
+        if (!$offlineRecord) {
+            return;
+        }
+
+        OfflineRecord::where('map_name', $offlineRecord->map_name)
+            ->where('physics', $offlineRecord->physics)
+            ->where('gametype', $offlineRecord->gametype)
+            ->where('time_ms', '>', $offlineRecord->time_ms)
+            ->decrement('rank');
+
+        $offlineRecordId = $offlineRecord->id;
+        $offlineRecord->delete();
+
+        Log::info('Upgraded offline_record to online record (deleted offline_record)', [
+            'demo_id' => $demo->id,
+            'offline_record_id' => $offlineRecordId,
+        ]);
+    }
+}

--- a/app/Services/DemoProcessorService.php
+++ b/app/Services/DemoProcessorService.php
@@ -605,194 +605,36 @@ class DemoProcessorService
     }
 
     /**
-     * Try to automatically assign demo to a record using name matching
+     * Try to automatically assign demo to a record using the shared
+     * DemoAutoAssigner pipeline (PASS 0/1/2). On fall-through (no Record
+     * matched) or on the PASS 0 profile-only scenario, creates an offline
+     * record so the run still appears on the Demos Top leaderboard.
      */
     protected function autoAssignToRecord(UploadedDemo $demo, $compressedLocalPath)
     {
-        if (!$demo->map_name || !$demo->physics || !$demo->time_ms || !$demo->player_name) {
-            return; // Not enough data to match
-        }
+        $autoAssigner = app(DemoAutoAssigner::class);
+        $outcome = $autoAssigner->attemptAssignToRecord($demo);
 
-        // IMPORTANT: Only assign ONLINE demos to records
-        // Offline demos (df, fs, fc) should NOT be assigned to online records
-        // They will have their own offline leaderboards
-        if ($demo->gametype && !str_starts_with($demo->gametype, 'm')) {
-            Log::info('Skipping auto-assign for offline demo', [
-                'demo_id' => $demo->id,
-                'gametype' => $demo->gametype,
-                'map' => $demo->map_name,
-            ]);
+        if ($outcome === DemoAutoAssigner::OUTCOME_RECORD) {
             return;
         }
 
-        // Build gametype string (e.g., "run_cpm" or "run_vq3")
-        // Records from q3df.org are all online records
-        // Strip .tr suffix (timer reset) as it's just an indicator and not part of physics matching
-        $physics = str_replace('.tr', '', strtolower($demo->physics));
-        $gametype = 'run_' . $physics;
-
-        $nameMatcher = app(NameMatcher::class);
-
-        // PASS 0: q3df login match — server-side authoritative identifier
-        // extracted from console messages like "Enter(Enter), you are now rank..."
-        // Preferred over nick fuzzy matching because it cannot be impersonated
-        // without server-side control.
-        if ($demo->q3df_login_name || $demo->q3df_login_name_colored) {
-            $loginMatch = $nameMatcher->matchByQ3dfLogin(
-                $demo->q3df_login_name,
-                $demo->q3df_login_name_colored
-            );
-
-            if ($loginMatch['user_id']) {
-                $matchedUserId = $loginMatch['user_id'];
-                $tier = $loginMatch['tier']; // 'q3df_colored' or 'q3df_plain'
-
-                // Look for a matching record owned by the matched user
-                $record = Record::where('mapname', $demo->map_name)
-                    ->where('gametype', $gametype)
-                    ->where('time', $demo->time_ms)
-                    ->where('user_id', $matchedUserId)
-                    ->first();
-
-                if ($record) {
-                    // Scénář A: both signals agree (login AND time) → strongest match
-                    $demo->update([
-                        'record_id' => $record->id,
-                        'status' => 'assigned',
-                        'name_confidence' => 100,
-                        'suggested_user_id' => $matchedUserId,
-                        'matched_alias' => $loginMatch['matched_alias'],
-                        'match_method' => $tier . '_record',
-                    ]);
-
-                    Log::info('Demo auto-assigned to record via q3df login', [
-                        'demo_id' => $demo->id,
-                        'record_id' => $record->id,
-                        'user_id' => $matchedUserId,
-                        'tier' => $tier,
-                        'matched_alias' => $loginMatch['matched_alias'],
-                    ]);
-
-                    return;
-                }
-
-                // Scénář B: login matches a user but no record exists with that
-                // time. Attribute the demo to the matched user's profile and let
-                // it flow into the offline leaderboard as a "slow run" entry.
-                $demo->update([
-                    'user_id' => $matchedUserId,
-                    'name_confidence' => 100,
-                    'suggested_user_id' => $matchedUserId,
-                    'matched_alias' => $loginMatch['matched_alias'],
-                    'match_method' => $tier . '_profile',
-                ]);
-                $demo = $demo->fresh();
-
-                Log::info('Demo auto-assigned to profile via q3df login (no record match)', [
-                    'demo_id' => $demo->id,
-                    'user_id' => $matchedUserId,
-                    'tier' => $tier,
-                    'matched_alias' => $loginMatch['matched_alias'],
-                ]);
-
-                $this->createOfflineRecord($demo, $compressedLocalPath);
-                return;
-            }
-        }
-
-        // PASS 1: Check if uploader has a matching record (ignores name completely)
-        $uploaderRecordMatch = false;
-        if ($demo->user_id) {
-            $uploaderRecord = Record::where('mapname', $demo->map_name)
-                ->where('gametype', $gametype)
-                ->where('time', $demo->time_ms)
-                ->where('user_id', $demo->user_id)
-                ->first();
-
-            if ($uploaderRecord) {
-                // Uploader has a matching record - assign immediately with 100% confidence
-                // File already uploaded to Backblaze during processing
-                $demo->update([
-                    'record_id' => $uploaderRecord->id,
-                    'status' => 'assigned',
-                    'name_confidence' => 100,
-                    'suggested_user_id' => $demo->user_id,
-                    'matched_alias' => null, // Matched by uploader record, not name
-                    'match_method' => 'uploader_record',
-                ]);
-
-                Log::info('Demo auto-assigned to uploader\'s record', [
-                    'demo_id' => $demo->id,
-                    'record_id' => $uploaderRecord->id,
-                    'user_id' => $demo->user_id,
-                    'gametype' => $gametype,
-                    'file_path' => $demo->file_path,
-                ]);
-
-                $uploaderRecordMatch = true;
-                return;
-            }
-        }
-
-        // PASS 2: Global name matching (only if uploader didn't match in PASS 1)
-        if (!$uploaderRecordMatch) {
-            $nameMatch = $nameMatcher->findBestMatch($demo->player_name, null); // null = global search
-
-            // Store name matching results including matched_alias
-            $demo->update([
-                'name_confidence' => $nameMatch['confidence'],
-                'suggested_user_id' => $nameMatch['user_id'],
-                'matched_alias' => $nameMatch['matched_name'] ?? null,
-            ]);
-
-            Log::info('Name matching completed', [
+        // PROFILE: q3df login matched a user but no Record existed at this
+        // time. The service already updated user_id + name fields; we just
+        // need the offline_record so the run appears on that user's
+        // leaderboard. Re-fetch because service called refresh().
+        // NONE: no match — fall back to offline_record so the run still
+        // shows up in Demos Top (player_name attribution).
+        if ($outcome === DemoAutoAssigner::OUTCOME_PROFILE) {
+            $demo = $demo->fresh();
+        } else {
+            Log::info('Creating offline record for non-100% match', [
                 'demo_id' => $demo->id,
-                'player_name' => $demo->player_name,
-                'confidence' => $nameMatch['confidence'],
-                'suggested_user_id' => $nameMatch['user_id'],
-                'matched_alias' => $nameMatch['matched_name'] ?? null,
-                'source' => $nameMatch['source'],
+                'confidence' => $demo->name_confidence,
+                'map' => $demo->map_name,
+                'time_ms' => $demo->time_ms,
             ]);
-
-            // Only auto-assign if we have 100% confidence match
-            if ($nameMatch['confidence'] === 100 && $nameMatch['user_id']) {
-                // Find matching record for this user
-                $record = Record::where('mapname', $demo->map_name)
-                    ->where('gametype', $gametype)
-                    ->where('time', $demo->time_ms)
-                    ->where('user_id', $nameMatch['user_id'])
-                    ->first();
-
-                if ($record) {
-                    // Perfect match found! File already uploaded to Backblaze during processing
-                    $demo->update([
-                        'record_id' => $record->id,
-                        'status' => 'assigned',
-                        'match_method' => 'fuzzy_nick',
-                    ]);
-
-                    Log::info('Demo auto-assigned to record with 100% name match', [
-                        'demo_id' => $demo->id,
-                        'record_id' => $record->id,
-                        'user_id' => $nameMatch['user_id'],
-                        'gametype' => $demo->gametype,
-                        'matched_alias' => $nameMatch['matched_name'] ?? null,
-                        'file_path' => $demo->file_path,
-                    ]);
-
-                    return;
-                }
-            }
         }
-
-        // Less than 100% confidence or no matching record found
-        // Create offline record instead (goes to "Demos Top")
-        Log::info('Creating offline record for non-100% match', [
-            'demo_id' => $demo->id,
-            'confidence' => $nameMatch['confidence'],
-            'map' => $demo->map_name,
-            'time_ms' => $demo->time_ms,
-        ]);
 
         $this->createOfflineRecord($demo, $compressedLocalPath);
     }

--- a/app/Services/NameMatcher.php
+++ b/app/Services/NameMatcher.php
@@ -16,6 +16,20 @@ class NameMatcher
     protected ?array $userCache = null;
 
     /**
+     * Exact-match alias index built from userCache on first use.
+     *
+     * Key is strtolower(stripColorCodes($alias)) so a demo's player name can
+     * be compared in O(1) instead of iterating every user's aliases and
+     * running Levenshtein. Collisions (multiple users with the same plain
+     * alias) are resolved first-write-wins to preserve the iteration order
+     * semantics of the original matchGlobally loop, which early-exited on
+     * the first 100% match.
+     *
+     * Format: [stripped_lowered_name => ['user_id' => int, 'matched_name' => string]]
+     */
+    protected ?array $aliasIndex = null;
+
+    /**
      * Strip Quake 3 color codes from a name
      * Removes patterns like ^0-^9, ^[, ^]
      */
@@ -65,7 +79,60 @@ class NameMatcher
     public function clearCache(): void
     {
         $this->userCache = null;
+        $this->aliasIndex = null;
         Cache::forget('name_matcher_users');
+    }
+
+    /**
+     * Build the exact-match alias index from the already-loaded userCache.
+     * Plain_name is added before aliases to mirror matchAgainstUser's check
+     * order, and first-write-wins preserves the early-exit semantics of
+     * matchGlobally across ambiguous names shared by multiple users.
+     */
+    protected function loadAliasIndex(): void
+    {
+        if ($this->aliasIndex !== null) {
+            return;
+        }
+        $this->loadUserCache();
+
+        $index = [];
+        foreach ($this->userCache as $userId => $userData) {
+            $candidates = [];
+            if (!empty($userData['plain_name'])) {
+                $candidates[] = $userData['plain_name'];
+            }
+            foreach ($userData['aliases'] as $alias) {
+                $candidates[] = $alias;
+            }
+            foreach ($candidates as $name) {
+                $key = strtolower($this->stripColorCodes($name));
+                if ($key === '') {
+                    continue;
+                }
+                if (!isset($index[$key])) {
+                    $index[$key] = ['user_id' => $userId, 'matched_name' => $name];
+                }
+            }
+        }
+        $this->aliasIndex = $index;
+    }
+
+    /**
+     * O(1) exact-match lookup against the approved-alias set. Returns null
+     * if no user owns this (stripped, lowercased) name. Used as a fast
+     * path before falling back to fuzzy Levenshtein matching.
+     *
+     * @return array{user_id: int, matched_name: string}|null
+     */
+    public function findExactMatch(string $demoPlayerName): ?array
+    {
+        $this->loadAliasIndex();
+        $key = strtolower($this->stripColorCodes($demoPlayerName));
+        if ($key === '') {
+            return null;
+        }
+        return $this->aliasIndex[$key] ?? null;
     }
 
     /**
@@ -180,6 +247,21 @@ class NameMatcher
      */
     public function findBestMatch(string $demoPlayerName, ?int $uploaderId = null): array
     {
+        // Fast path: an exact (stripped + lowercased) alias match is always
+        // 100% confidence, and it's the vast majority of real-world names.
+        // This skips the O(users * aliases) Levenshtein sweep entirely,
+        // which dominates batch-rematch runtime. Semantically identical to
+        // matchGlobally's early-exit on a 100% match.
+        $exact = $this->findExactMatch($demoPlayerName);
+        if ($exact !== null) {
+            return [
+                'user_id' => $exact['user_id'],
+                'confidence' => 100,
+                'source' => 'global',
+                'matched_name' => $exact['matched_name'],
+            ];
+        }
+
         // Pass 1: Check global search first
         $globalMatch = $this->matchGlobally($demoPlayerName, null); // Don't exclude uploader
 

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -879,17 +879,12 @@
         combined.sort((a, b) => (a.time || a.time_ms) - (b.time || b.time_ms));
         combined = groupByVirtualPlayer(combined);
 
-        // Recalculate ranks (skip flagged items)
-        let rankCounter = 0;
-        combined = combined.map((item) => {
-            const hasFlag = (item.approved_flags && item.approved_flags.length > 0) ||
-                (item.verification_type && !['OFFLINE', 'ONLINE', 'verified'].includes(item.verification_type));
-            if (hasFlag) {
-                return { ...item, rank: null };
-            }
-            rankCounter++;
-            return { ...item, rank: rankCounter };
-        });
+        // DON'T reassign ranks per page — each server-side paginator (main
+        // records, Demos Top, oldtop) ranks its own data, and reassigning
+        // here from 1 on every page made ranks reset whenever the user
+        // clicks Next. We lose cross-source rank unification (main rank 5
+        // and DT rank 5 can collide in the merged view) but ranks are
+        // stable across pages, which matters far more.
 
         // The offline paginator is already grouped server-side (one rep per
         // virtual player), so its last_page is correct. Main records and
@@ -918,14 +913,20 @@
     };
 
     const getVq3Records = computed(() => {
-        if (props.showOldtop || props.showOffline) {
+        // Server now returns a unified leaderboard in `vq3Records` when
+        // showOldtop or showOffline is on (merging main + DT + oldtop into
+        // one paginator with continuous ranks). Detect the unified case by
+        // both extras props being null and short-circuit the legacy merge.
+        const unified = props.vq3OldRecords === null && props.vq3OfflineRecords === null;
+        if (! unified && (props.showOldtop || props.showOffline)) {
             return mergeRecordSources(props.vq3Records, props.vq3OldRecords, props.vq3OfflineRecords);
         }
         return props.vq3Records;
     })
 
     const getCpmRecords = computed(() => {
-        if (props.showOldtop || props.showOffline) {
+        const unified = props.cpmOldRecords === null && props.cpmOfflineRecords === null;
+        if (! unified && (props.showOldtop || props.showOffline)) {
             return mergeRecordSources(props.cpmRecords, props.cpmOldRecords, props.cpmOfflineRecords);
         }
         return props.cpmRecords;


### PR DESCRIPTION
## Summary
- Unified leaderboard paginator merges main records, Demos Top reps, and Oldtop into one server-side paginator with continuous ranks (fixes rank collisions when `showOffline`/`showOldtop` were enabled) + fixes forced `verified` badge
- Extracted 3-pass auto-assign logic (q3df login / uploader record / fuzzy nick) into `DemoAutoAssigner` shared by live upload and nightly batch — rematch now runs PASS 0 and writes `match_method` consistently
- Phase 2 speedup: alias exact-match hashmap in `NameMatcher`, preloaded Record index in `DemoAutoAssignContext`, `chunkById` streaming with `DB::transaction` per chunk, skip no-op updates. ~90× faster end-to-end

## Test plan
- [ ] Open `/maps/interference?showOffline=true&vq3Page=1` — 50 rows, continuous ranks, page 2 continues from rank 51
- [ ] Map with records lacking attached demos — verified badge should not appear
- [ ] `php artisan demos:rematch-all <id>` — shows outcome + match_method (e.g. `fuzzy_nick`, `q3df_plain_record`)
- [ ] Full batch: `php artisan demos:rematch-all` should complete in ~20 minutes with preload logs
- [ ] Upload demo via launcher or web — new demo gets non-null `match_method` in DB
