### PR TITLE
Replace CKEditor with TipTap and clear npm audit (85 → 0 vulnerabilities)

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -28,7 +28,7 @@ def get_git_clone_cmd(name):
 
 def pipeline_cmds(name):
     cmds = [
-        "composer install --optimize-autoloader --no-dev --no-interaction",
+        "COMPOSER_ALLOW_SUPERUSER=1 composer install --optimize-autoloader --no-dev --no-interaction",
         "npm install",
         "npm run build",
         f"ln -s {PROJECT_PATH}/deploy/.env {PROJECT_PATH}/releases/{name}/.env",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,6 @@
         "": {
             "hasInstallScript": true,
             "dependencies": {
-                "@ckeditor/ckeditor5-build-classic": "^41.1.0",
-                "@ckeditor/ckeditor5-vue": "^5.1.0",
                 "@tiptap/extension-code-block-lowlight": "^3.21.0",
                 "@tiptap/extension-image": "^3.21.0",
                 "@tiptap/extension-link": "^3.21.0",
@@ -44,15 +42,15 @@
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/line-clamp": "^0.4.4",
                 "@tailwindcss/typography": "^0.5.2",
-                "@vitejs/plugin-vue": "^4.5.0",
+                "@vitejs/plugin-vue": "^6.0.6",
                 "autoprefixer": "^10.4.7",
                 "axios": "^1.6.4",
-                "laravel-vite-plugin": "^1.0.0",
+                "laravel-vite-plugin": "^3.0.1",
                 "postcss": "^8.4.14",
                 "puppeteer": "^24.24.1",
                 "sass": "^1.70.0",
                 "tailwindcss": "^3.1.0",
-                "vite": "^5.0.0",
+                "vite": "^8.0.9",
                 "vue": "^3.2.31"
             }
         },
@@ -125,1073 +123,38 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-41.4.2.tgz",
-            "integrity": "sha512-yXVVEy+lEmyvYwTxn76Ff53fK/qJphf9stoBF4kFKKK/Tfi59EMog2Ctk3iIkLLyt74KmxzvuCXZwE00wDqfLA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-alignment": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
-            "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-autoformat": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-41.4.2.tgz",
-            "integrity": "sha512-Ukit63jHiAuLyfESdLSc6ya12xKJxDP83krZFiMY5bfXssg0z39CGuHOZlwaI9r7bBjWWMGJJeaC/9i/6L9y7g==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-autosave": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
-            "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-basic-styles": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-41.4.2.tgz",
-            "integrity": "sha512-+Y+M9/JRX3xSHX/E5zFwzuKPzEeeuL61wcig1DuEz7GvK5sRLJcbdVQmiJnfDh3iOcf/ob1nahNgHAEoCno0Dw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-block-quote": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-41.4.2.tgz",
-            "integrity": "sha512-tkEKd3pmDO8QWm243FRDRUv5COayXYZJpMFUL6blw3m6IXb4ujcXKn61A+UwUO+kM0NGTuepHZJkFSuV1/90sw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-build-balloon": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon/-/ckeditor5-build-balloon-41.4.2.tgz",
-            "integrity": "sha512-4FLvd2OV4UgPva0/+xHT4ZuEzKLxB9M6D04/G0YFFwvbPiy71zH0iEMj132Wd0fdEJ0fwjF1HfDzhNgI9BPhPA==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-build-balloon-block": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon-block/-/ckeditor5-build-balloon-block-41.4.2.tgz",
-            "integrity": "sha512-p2pXJcS0hNuDZXyMi0frSwLZBm1hGGEEajJtAvKdg+pKZvvrIabQzvjtrkUf5P6Lbhl/z1/v2h0pBa76025Q5Q==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-build-classic": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-41.4.2.tgz",
-            "integrity": "sha512-fdsxmEPdNdo/usXyYMS2cN/E9KcQIrtmImUYDI+jEs6yzmSgI8By01n+enkKgVxu+2t+g+ctjQwrCpiyWIHTAQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-classic": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-build-decoupled-document": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-decoupled-document/-/ckeditor5-build-decoupled-document-41.4.2.tgz",
-            "integrity": "sha512-YIjcJc9flghFsA5gZaL5oIf6TxLJxUZpXgWYa9l5C68enm36bsDycgJWGGbexHK2HOR9AnBr6ThUBQJkn3StTg==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-alignment": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-font": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-build-inline": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-inline/-/ckeditor5-build-inline-41.4.2.tgz",
-            "integrity": "sha512-h57jjFm0cSOFGSTA2MbvhSXMFxUbPZqwIeA9S0bfUNcGrnm84YaerX8ev8ZP2iMLOckPOcjBiC/70Sp0SvGwxg==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-inline": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-build-multi-root": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-multi-root/-/ckeditor5-build-multi-root-41.4.2.tgz",
-            "integrity": "sha512-Hou3cHuzx2YR6cfbTYYgk2cSBkudCfPru471KxsXUtzw+B7KuHLm3LtnLJNpScF2WoGaOoaFzB9D2PkzlhF5hA==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-ckbox": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-41.4.2.tgz",
-            "integrity": "sha512-u6HVTW7O+YSeeCZ+plg78aW74B2G+E7uKy5YQxvB99uCXGWmYy57D2maaEkPI87ZwZD3VlRnvAalaAdngc4M1g==",
-            "dependencies": {
-                "blurhash": "2.0.5",
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-ckfinder": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-41.4.2.tgz",
-            "integrity": "sha512-QB3igdZOBI+I8q6eTA5+q27VQrj3Nu7PctNKRehwMC/Z6URboTnntqtkZ3inAZEbWcoLTN2tpDthlufUbQ+cfA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-clipboard": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
-            "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "@ckeditor/ckeditor5-widget": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-cloud-services": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-41.4.2.tgz",
-            "integrity": "sha512-rgDrpEonA2AchfvgYaeb/olMk/HYxUK4B8XPqs+nJxLmBraTv2lANsgsMbwsqAIiRjT9MknmJdX+CEbqljgL/w==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-code-block": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
-            "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-core": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-41.4.2.tgz",
-            "integrity": "sha512-kCIJjviiMNIMBMx7XFXFp1IeTELQKv7xyPJiVFDyUftIfthf9uWty72ipZ3BBNBGBkaoTiSzDZ507EsX6czuIQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-easy-image": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-41.4.2.tgz",
-            "integrity": "sha512-HJJ3Z4R4mCazV2cz+s8bI00ci3/KyIa+fXodBN1+kg3PldX471zSj+DtyFsZyKnUcpUTVygjPEaHKBDpxtUhjQ==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
-            "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-editor-classic": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-41.4.2.tgz",
-            "integrity": "sha512-BVf4ipZz36eCTDFiQ8hqN+oBmuvZPzCmNDDjCYuHNGCKGLaIo1Yzi09fHPUWDw1U+en6Cgnwc2HSWgwf7zC7aA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
-            "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-editor-inline": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
-            "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
-            "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-engine": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-41.4.2.tgz",
-            "integrity": "sha512-25JqIzNYvCqQ6f02YY+a8A8xtjClzI0YCio0JGoRG3JHJXzYsQbTPsiokuE1BCwMCu3gYoFz8eKJYt2selLsCw==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-enter": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
-            "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-essentials": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-41.4.2.tgz",
-            "integrity": "sha512-1UCvk76v2+NDfHfTo3Qg0EJYpddgSC/i66jY3NnQUFt1zt68rAzm/kFOVYjTD/QDn6pyiMAIUeMlKFkswF+upg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
-            "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-font": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
-            "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-heading": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-41.4.2.tgz",
-            "integrity": "sha512-8AyMumy90nY49reQlHuCgSJFSaym4emCVF6vAAqd71FHtmgtfS9w3xMqXAk6QbgMjfy46cwind0JITZfBfKqLg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-highlight": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
-            "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
-            "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-html-embed": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
-            "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-html-support": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
-            "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-image": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
-            "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-indent": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-41.4.2.tgz",
-            "integrity": "sha512-pghHa+DKya6788nTiU1ZItKmAgjf+up4Rqe5GOkxKB7vJc189KSBJYc5foov65nM831rXcWgTk4jybK+JGHmjQ==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-language": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
-            "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-link": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-41.4.2.tgz",
-            "integrity": "sha512-woMv9/BxkDjG5xsS/OyaxW9tWTuiG6wZWWcYxVJq8FOW2NL68CKQLmyoQ1rdv/2Gw4UPUXTtB+1uGVmQDMXDsQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-list": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-41.4.2.tgz",
-            "integrity": "sha512-nGb36jNJO6YAU35piKabey9B13xw6TnmL5VySS2dEqSt/DTy7RdY5z2K7CU/NGuIGe/bPBZgU1J0dQkRr2F3hA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
-            "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "marked": "4.0.12",
-                "turndown": "6.0.0",
-                "turndown-plugin-gfm": "1.0.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/marked": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-            "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+        "node_modules/@emnapi/core": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+            "dev": true,
             "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-media-embed": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
-            "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-mention": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
-            "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-minimap": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
-            "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-page-break": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
-            "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-paragraph": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-41.4.2.tgz",
-            "integrity": "sha512-tOsD40Fcqli5zkH/68WhcqYU8BL4qb8J5xGuk1xmBokz3W0LzebWW0GXmFk5PmWv+fg0dOXfSo8uMzb5ni+CuQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-41.4.2.tgz",
-            "integrity": "sha512-jby5YQ2QowGdDCshPq5Ej11wTFcBZP2dYhQTu6fRZRc+mdihKCILxh0rwBgBOCCf+buflx8RYp/WKd76Kcuq5g==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-remove-format": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
-            "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
-            "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-select-all": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
-            "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-show-blocks": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
-            "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-source-editing": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
-            "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-theme-lark": "41.4.2",
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-special-characters": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
-            "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
-            "dependencies": {
-                "ckeditor5": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-style": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
-            "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-table": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
-            "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-theme-lark": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
-            "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-ui": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-typing": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-41.4.2.tgz",
-            "integrity": "sha512-dXP+uNl+jkfrSIqMNai2yakR/3JqJ9g0M9WwwnV5vzbEOKD4YKP5+ixvqKb39dwLCLZ4mGpJaX+rjNXBExjSIw==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-ui": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-41.4.2.tgz",
-            "integrity": "sha512-wvRbDXJN8PmaWyB0H487DjvdH2ayMyN52+WLkZlVbhX9ICb1sf5XnLz4v/wXeQ4W8JbWdsg2FZIDDQDeXjvyJw==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "color-convert": "2.0.1",
-                "color-parse": "1.4.2",
-                "lodash-es": "4.17.21",
-                "vanilla-colorful": "0.7.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-undo": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
-            "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-upload": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
-            "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-utils": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-41.4.2.tgz",
-            "integrity": "sha512-VgLr2eLVggyhDqa7H8JUxpnOLTZ0R/YuDZ6ENVUumd9q4VrpNs94ZK0Y/Shp7UmuHQ/sTth+PWTsi+t5KwYqeQ==",
-            "dependencies": {
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-vue": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-5.1.0.tgz",
-            "integrity": "sha512-KEx4Tj2Irr4ZbLG8LnaKpb0Dgd8qmLmKFWeiKkQwM3RAAeYRYOCcBVB2Y168I9KA8wRosPxgOO9jbQ92yopYHA==",
-            "hasInstallScript": true,
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=5.7.1"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-watchdog": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
-            "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
-            "dependencies": {
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-widget": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
-            "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-enter": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@ckeditor/ckeditor5-word-count": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
-            "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
-            "dependencies": {
-                "ckeditor5": "41.4.2",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
             "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=12"
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-            "cpu": [
-                "arm64"
-            ],
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@floating-ui/core": {
@@ -1259,6 +222,18 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -1335,6 +310,25 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1433,6 +427,16 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.126.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+            "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@parcel/watcher": {
@@ -1777,24 +781,10 @@
             "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
             "license": "MIT"
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-            "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-            "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
             "cpu": [
                 "arm64"
             ],
@@ -1803,12 +793,15 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-            "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1817,12 +810,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-            "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
             "cpu": [
                 "x64"
             ],
@@ -1831,26 +827,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-            "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-            "cpu": [
-                "arm64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-            "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
             "cpu": [
                 "x64"
             ],
@@ -1859,46 +844,32 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-            "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+            "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-            "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-            "cpu": [
-                "arm"
             ],
-            "dev": true,
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-            "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
             "cpu": [
                 "arm64"
             ],
@@ -1910,12 +881,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-            "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+            "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
             "cpu": [
                 "arm64"
             ],
@@ -1927,46 +901,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-            "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-            "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-            "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1978,63 +921,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-            "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-            "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-            "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-            "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2046,12 +941,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
             "cpu": [
                 "x64"
             ],
@@ -2063,12 +961,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-            "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+            "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
             "cpu": [
                 "x64"
             ],
@@ -2080,26 +981,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-            "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-            "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
             "cpu": [
                 "arm64"
             ],
@@ -2108,12 +998,34 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-            "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+            "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.9.2",
+                "@emnapi/runtime": "1.9.2",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+            "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2122,26 +1034,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-            "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-            "cpu": [
-                "ia32"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+            "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
             "cpu": [
                 "x64"
             ],
@@ -2150,21 +1051,17 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-            "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-            "cpu": [
-                "x64"
             ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.13",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+            "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "license": "MIT"
         },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.10",
@@ -2738,14 +1635,6 @@
                 "vue": "^3.0.0"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -2753,17 +1642,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@types/draco3d": {
             "version": "1.4.10",
             "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
             "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/hast": {
@@ -2838,15 +1731,19 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.2.tgz",
-            "integrity": "sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==",
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+            "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-rc.13"
+            },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^4.0.0 || ^5.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "vue": "^3.2.25"
             }
         },
@@ -2941,56 +1838,11 @@
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
             "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
         },
-        "node_modules/abab": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-            "deprecated": "Use your platform's native atob() and btoa() methods instead"
-        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "license": "ISC"
-        },
-        "node_modules/acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-globals": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-            "dependencies": {
-                "acorn": "^7.1.1",
-                "acorn-walk": "^7.1.1"
-            }
-        },
-        "node_modules/acorn-globals/node_modules/acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
@@ -3105,7 +1957,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
         },
         "node_modules/autoprefixer": {
             "version": "10.4.21",
@@ -3145,15 +1998,25 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/b4a": {
@@ -3290,9 +2153,9 @@
             "license": "MIT"
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-            "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3337,15 +2200,10 @@
                 "readable-stream": "^3.4.0"
             }
         },
-        "node_modules/blurhash": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
-            "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w=="
-        },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -3362,11 +2220,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/browser-process-hrtime": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
         },
         "node_modules/browserslist": {
             "version": "4.24.5",
@@ -3461,6 +2314,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -3505,9 +2359,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001779",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
-            "integrity": "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==",
+            "version": "1.0.30001790",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+            "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
             "dev": true,
             "funding": [
                 {
@@ -3556,12 +2410,12 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "license": "ISC",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/chromium-bidi": {
@@ -3576,76 +2430,6 @@
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
-            }
-        },
-        "node_modules/ckeditor5": {
-            "version": "41.4.2",
-            "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
-            "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
-            "dependencies": {
-                "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-alignment": "41.4.2",
-                "@ckeditor/ckeditor5-autoformat": "41.4.2",
-                "@ckeditor/ckeditor5-autosave": "41.4.2",
-                "@ckeditor/ckeditor5-basic-styles": "41.4.2",
-                "@ckeditor/ckeditor5-block-quote": "41.4.2",
-                "@ckeditor/ckeditor5-build-balloon": "41.4.2",
-                "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
-                "@ckeditor/ckeditor5-build-classic": "41.4.2",
-                "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
-                "@ckeditor/ckeditor5-build-inline": "41.4.2",
-                "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
-                "@ckeditor/ckeditor5-ckbox": "41.4.2",
-                "@ckeditor/ckeditor5-ckfinder": "41.4.2",
-                "@ckeditor/ckeditor5-clipboard": "41.4.2",
-                "@ckeditor/ckeditor5-cloud-services": "41.4.2",
-                "@ckeditor/ckeditor5-code-block": "41.4.2",
-                "@ckeditor/ckeditor5-core": "41.4.2",
-                "@ckeditor/ckeditor5-easy-image": "41.4.2",
-                "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
-                "@ckeditor/ckeditor5-editor-classic": "41.4.2",
-                "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
-                "@ckeditor/ckeditor5-editor-inline": "41.4.2",
-                "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
-                "@ckeditor/ckeditor5-engine": "41.4.2",
-                "@ckeditor/ckeditor5-enter": "41.4.2",
-                "@ckeditor/ckeditor5-essentials": "41.4.2",
-                "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
-                "@ckeditor/ckeditor5-font": "41.4.2",
-                "@ckeditor/ckeditor5-heading": "41.4.2",
-                "@ckeditor/ckeditor5-highlight": "41.4.2",
-                "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
-                "@ckeditor/ckeditor5-html-embed": "41.4.2",
-                "@ckeditor/ckeditor5-html-support": "41.4.2",
-                "@ckeditor/ckeditor5-image": "41.4.2",
-                "@ckeditor/ckeditor5-indent": "41.4.2",
-                "@ckeditor/ckeditor5-language": "41.4.2",
-                "@ckeditor/ckeditor5-link": "41.4.2",
-                "@ckeditor/ckeditor5-list": "41.4.2",
-                "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
-                "@ckeditor/ckeditor5-media-embed": "41.4.2",
-                "@ckeditor/ckeditor5-mention": "41.4.2",
-                "@ckeditor/ckeditor5-minimap": "41.4.2",
-                "@ckeditor/ckeditor5-page-break": "41.4.2",
-                "@ckeditor/ckeditor5-paragraph": "41.4.2",
-                "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
-                "@ckeditor/ckeditor5-remove-format": "41.4.2",
-                "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
-                "@ckeditor/ckeditor5-select-all": "41.4.2",
-                "@ckeditor/ckeditor5-show-blocks": "41.4.2",
-                "@ckeditor/ckeditor5-source-editing": "41.4.2",
-                "@ckeditor/ckeditor5-special-characters": "41.4.2",
-                "@ckeditor/ckeditor5-style": "41.4.2",
-                "@ckeditor/ckeditor5-table": "41.4.2",
-                "@ckeditor/ckeditor5-theme-lark": "41.4.2",
-                "@ckeditor/ckeditor5-typing": "41.4.2",
-                "@ckeditor/ckeditor5-ui": "41.4.2",
-                "@ckeditor/ckeditor5-undo": "41.4.2",
-                "@ckeditor/ckeditor5-upload": "41.4.2",
-                "@ckeditor/ckeditor5-utils": "41.4.2",
-                "@ckeditor/ckeditor5-watchdog": "41.4.2",
-                "@ckeditor/ckeditor5-widget": "41.4.2",
-                "@ckeditor/ckeditor5-word-count": "41.4.2"
             }
         },
         "node_modules/classnames": {
@@ -3773,14 +2557,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "node_modules/color-parse": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-            "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
-            "dependencies": {
-                "color-name": "^1.0.0"
-            }
-        },
         "node_modules/color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -3794,6 +2570,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -3892,27 +2669,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/cssom": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-        },
-        "node_modules/cssstyle": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-            "dependencies": {
-                "cssom": "~0.3.6"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cssstyle/node_modules/cssom": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        },
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3926,19 +2682,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/data-urls": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-            "dependencies": {
-                "abab": "^2.0.3",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/debounce": {
@@ -3962,11 +2705,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/decimal.js": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
         },
         "node_modules/decompress-response": {
             "version": "4.2.1",
@@ -4017,6 +2755,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -4090,26 +2829,6 @@
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true
         },
-        "node_modules/domexception": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-            "deprecated": "Use your platform's native DOMException instead",
-            "dependencies": {
-                "webidl-conversions": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/domexception/node_modules/webidl-conversions": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-            "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/draco3d": {
             "version": "1.5.7",
             "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
@@ -4120,6 +2839,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -4223,6 +2943,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -4231,6 +2952,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -4239,6 +2961,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -4250,6 +2973,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -4258,44 +2982,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/esbuild": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/escalade": {
@@ -4323,6 +3009,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "dev": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -4343,6 +3030,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -4355,6 +3043,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -4368,6 +3057,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4497,9 +3187,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -4604,6 +3294,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4690,6 +3381,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -4713,6 +3405,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -4844,6 +3537,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4861,6 +3555,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4872,6 +3567,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -4892,6 +3588,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -4908,17 +3605,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/html-encoding-sniffer": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
-            "dependencies": {
-                "whatwg-encoding": "^1.0.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/htmldiff-js": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/htmldiff-js/-/htmldiff-js-1.0.5.tgz",
@@ -4931,19 +3617,6 @@
             "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "license": "BSD-2-Clause"
         },
-        "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -4954,17 +3627,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/ieee754": {
@@ -5139,11 +3801,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-potential-custom-element-name": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-        },
         "node_modules/isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5198,67 +3855,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsdom": {
-            "version": "16.7.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-            "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
-            "dependencies": {
-                "abab": "^2.0.5",
-                "acorn": "^8.2.4",
-                "acorn-globals": "^6.0.0",
-                "cssom": "^0.4.4",
-                "cssstyle": "^2.3.0",
-                "data-urls": "^2.0.0",
-                "decimal.js": "^10.2.1",
-                "domexception": "^2.0.1",
-                "escodegen": "^2.0.0",
-                "form-data": "^3.0.0",
-                "html-encoding-sniffer": "^2.0.1",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.0",
-                "parse5": "6.0.1",
-                "saxes": "^5.0.1",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.0.0",
-                "w3c-hr-time": "^1.0.2",
-                "w3c-xmlserializer": "^2.0.0",
-                "webidl-conversions": "^6.1.0",
-                "whatwg-encoding": "^1.0.5",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.5.0",
-                "ws": "^7.4.6",
-                "xml-name-validator": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "canvas": "^2.5.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jsdom/node_modules/form-data": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-            "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.35"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5267,22 +3863,307 @@
             "license": "MIT"
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.2.0.tgz",
-            "integrity": "sha512-R0pJ+IcTVeqEMoKz/B2Ij57QVq3sFTABiFmb06gAwFdivbOgsUtuhX6N2MGLEArajrS3U5JbberzwOe7uXHMHQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.0.1.tgz",
+            "integrity": "sha512-Bx8sVcLIaZT1d0eisABcmjQ1GZdJpaXcV66A8RhXGp9JgR3iL8jDnvakVDXuH87Tn5S9KNx3VOhmJZW1CSexOg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
+                "tinyglobby": "^0.2.12",
                 "vite-plugin-full-reload": "^1.1.0"
             },
             "bin": {
                 "clean-orphaned-assets": "bin/clean.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^8.0.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/lilconfig": {
@@ -5317,17 +4198,6 @@
             "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
             "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
             "license": "MIT"
-        },
-        "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "license": "MIT"
-        },
-        "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash.castarray": {
             "version": "4.4.0",
@@ -5468,6 +4338,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -5504,6 +4375,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5512,6 +4384,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -5704,18 +4577,6 @@
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
@@ -5997,11 +4858,6 @@
             "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
             "dev": true
         },
-        "node_modules/nwsapi": {
-            "version": "2.2.20",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
-            "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA=="
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6170,11 +5026,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/parse5": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6226,10 +5077,11 @@
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -6256,9 +5108,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6273,8 +5125,9 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.8",
+                "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -6838,17 +5691,6 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
             "dev": true
         },
-        "node_modules/psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
         "node_modules/pump": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -6857,14 +5699,6 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
-            }
-        },
-        "node_modules/punycode": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/punycode.js": {
@@ -6955,11 +5789,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/querystringify": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7041,11 +5870,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -7112,9 +5936,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -7154,50 +5978,46 @@
                 "node": "*"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-            "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+            "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@oxc-project/types": "=0.126.0",
+                "@rolldown/pluginutils": "1.0.0-rc.16"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.59.0",
-                "@rollup/rollup-android-arm64": "4.59.0",
-                "@rollup/rollup-darwin-arm64": "4.59.0",
-                "@rollup/rollup-darwin-x64": "4.59.0",
-                "@rollup/rollup-freebsd-arm64": "4.59.0",
-                "@rollup/rollup-freebsd-x64": "4.59.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-                "@rollup/rollup-linux-arm64-musl": "4.59.0",
-                "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-                "@rollup/rollup-linux-loong64-musl": "4.59.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-                "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-musl": "4.59.0",
-                "@rollup/rollup-openbsd-x64": "4.59.0",
-                "@rollup/rollup-openharmony-arm64": "4.59.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-                "@rollup/rollup-win32-x64-gnu": "4.59.0",
-                "@rollup/rollup-win32-x64-msvc": "4.59.0",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
             }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+            "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/rope-sequence": {
             "version": "1.3.4",
@@ -7251,7 +6071,8 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "optional": true
         },
         "node_modules/sass": {
             "version": "1.87.0",
@@ -7271,17 +6092,6 @@
             },
             "optionalDependencies": {
                 "@parcel/watcher": "^2.4.1"
-            }
-        },
-        "node_modules/saxes": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-            "dependencies": {
-                "xmlchars": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/semver": {
@@ -7492,6 +6302,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -7669,11 +6480,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/symbol-tree": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-        },
         "node_modules/tailwindcss": {
             "version": "3.4.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -7773,20 +6579,19 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "license": "ISC",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/tar-fs": {
@@ -7817,37 +6622,25 @@
                 "streamx": "^2.15.0"
             }
         },
-        "node_modules/tar/node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "license": "ISC",
+        "node_modules/tar/node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "license": "MIT",
             "dependencies": {
-                "minipass": "^3.0.0"
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">= 18"
             }
         },
-        "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tar/node_modules/minipass": {
+        "node_modules/tar/node_modules/yallist": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             }
         },
         "node_modules/teex": {
@@ -7942,6 +6735,54 @@
             "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
             "license": "MIT"
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7952,31 +6793,6 @@
             },
             "engines": {
                 "node": ">=8.0"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-            "dependencies": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.2.0",
-                "url-parse": "^1.5.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-            "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-            "dependencies": {
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ts-interface-checker": {
@@ -8003,19 +6819,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/turndown": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/turndown/-/turndown-6.0.0.tgz",
-            "integrity": "sha512-UVJBhSyRHCpNKtQ00mNWlYUM/i+tcipkb++F0PrOpt0L7EhNd0AX9mWEpL2dRFBu7LWXMp4HgAMA4OeKKnN7og==",
-            "dependencies": {
-                "jsdom": "^16.2.0"
-            }
-        },
-        "node_modules/turndown-plugin-gfm": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-            "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
         },
         "node_modules/typed-query-selector": {
             "version": "2.12.1",
@@ -8062,14 +6865,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/universalify": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -8100,41 +6895,29 @@
                 "browserslist": ">= 4.21.0"
             }
         },
-        "node_modules/url-parse": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "dependencies": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
-        "node_modules/vanilla-colorful": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
-            "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
-        },
         "node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "version": "8.0.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+            "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.16",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -8143,23 +6926,33 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
                     "optional": true
                 },
-                "less": {
+                "@vitejs/devtools": {
                     "optional": true
                 },
-                "lightningcss": {
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
                     "optional": true
                 },
                 "sass": {
@@ -8176,6 +6969,12 @@
                 },
                 "terser": {
                     "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
                 }
             }
         },
@@ -8187,6 +6986,19 @@
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/vue": {
@@ -8295,31 +7107,11 @@
                 }
             }
         },
-        "node_modules/w3c-hr-time": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-            "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
-            "dependencies": {
-                "browser-process-hrtime": "^1.0.0"
-            }
-        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "license": "MIT"
-        },
-        "node_modules/w3c-xmlserializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
-            "dependencies": {
-                "xml-name-validator": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/webdriver-bidi-protocol": {
             "version": "0.4.1",
@@ -8327,40 +7119,6 @@
             "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-            "engines": {
-                "node": ">=10.4"
-            }
-        },
-        "node_modules/whatwg-encoding": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-            "dependencies": {
-                "iconv-lite": "0.4.24"
-            }
-        },
-        "node_modules/whatwg-mimetype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-        },
-        "node_modules/whatwg-url": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
-            "dependencies": {
-                "lodash": "^4.7.0",
-                "tr46": "^2.1.0",
-                "webidl-conversions": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -8516,36 +7274,6 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
         },
-        "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/xml-name-validator": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
-        },
-        "node_modules/xmlchars": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -8572,15 +7300,19 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -11,20 +11,21 @@
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.2",
-        "@vitejs/plugin-vue": "^4.5.0",
+        "@vitejs/plugin-vue": "^6.0.6",
         "autoprefixer": "^10.4.7",
         "axios": "^1.6.4",
-        "laravel-vite-plugin": "^1.0.0",
+        "laravel-vite-plugin": "^3.0.1",
         "postcss": "^8.4.14",
         "puppeteer": "^24.24.1",
         "sass": "^1.70.0",
         "tailwindcss": "^3.1.0",
-        "vite": "^5.0.0",
+        "vite": "^8.0.9",
         "vue": "^3.2.31"
     },
+    "overrides": {
+        "tar": "^7.5.13"
+    },
     "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^41.1.0",
-        "@ckeditor/ckeditor5-vue": "^5.1.0",
         "@tiptap/extension-code-block-lowlight": "^3.21.0",
         "@tiptap/extension-image": "^3.21.0",
         "@tiptap/extension-link": "^3.21.0",

--- a/resources/js/Components/RichTextEditor.vue
+++ b/resources/js/Components/RichTextEditor.vue
@@ -1,0 +1,347 @@
+<script setup>
+import { ref, watch, nextTick, onBeforeUnmount, computed } from 'vue';
+import { useEditor, EditorContent } from '@tiptap/vue-3';
+import axios from 'axios';
+import StarterKit from '@tiptap/starter-kit';
+import Link from '@tiptap/extension-link';
+import { Table } from '@tiptap/extension-table';
+import { TableRow } from '@tiptap/extension-table-row';
+import { TableCell } from '@tiptap/extension-table-cell';
+import { TableHeader } from '@tiptap/extension-table-header';
+import { Image } from '@tiptap/extension-image';
+import { Underline } from '@tiptap/extension-underline';
+import { TextAlign } from '@tiptap/extension-text-align';
+import Placeholder from '@tiptap/extension-placeholder';
+
+const props = defineProps({
+    modelValue: { type: String, default: '' },
+    placeholder: { type: String, default: 'Start writing...' },
+    minHeight: { type: String, default: '15rem' },
+    // Feature toggles — default matches full WikiEditor-like toolbar
+    enableImage: { type: Boolean, default: true },
+    enableTable: { type: Boolean, default: true },
+    enableHeadings: { type: Boolean, default: true },
+    enableCode: { type: Boolean, default: true },
+    enableSource: { type: Boolean, default: false },
+    // Route name for image upload (Laravel named route)
+    imageUploadRoute: { type: String, default: 'wiki.uploadImage' },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const sourceMode = ref(false);
+const sourceCode = ref('');
+const imageUploading = ref(false);
+
+async function uploadAndInsert(file) {
+    imageUploading.value = true;
+    try {
+        const formData = new FormData();
+        formData.append('image', file);
+        const { data } = await axios.post(route(props.imageUploadRoute), formData);
+        editor.value.chain().focus().setImage({ src: data.url }).run();
+    } catch (err) {
+        alert('Upload failed: ' + (err.response?.data?.message || err.message));
+    }
+    imageUploading.value = false;
+}
+
+const extensions = computed(() => {
+    const exts = [
+        StarterKit.configure({ link: false, underline: false }),
+        Link.configure({ openOnClick: false, HTMLAttributes: { class: 'text-blue-400 underline' } }),
+        Underline,
+        TextAlign.configure({ types: ['heading', 'paragraph'] }),
+        Placeholder.configure({ placeholder: props.placeholder }),
+    ];
+    if (props.enableTable) {
+        exts.push(Table.configure({ resizable: true }), TableRow, TableCell, TableHeader);
+    }
+    if (props.enableImage) {
+        exts.push(Image.configure({ inline: false, allowBase64: false }));
+    }
+    return exts;
+});
+
+const editor = useEditor({
+    content: props.modelValue,
+    extensions: extensions.value,
+    onUpdate: ({ editor }) => {
+        emit('update:modelValue', editor.getHTML());
+    },
+    editorProps: {
+        handlePaste(view, event) {
+            if (!props.enableImage) return false;
+            const items = event.clipboardData?.items;
+            if (!items) return false;
+            for (const item of items) {
+                if (item.type.startsWith('image/')) {
+                    event.preventDefault();
+                    const file = item.getAsFile();
+                    if (file) uploadAndInsert(file);
+                    return true;
+                }
+            }
+            return false;
+        },
+        handleDrop(view, event) {
+            if (!props.enableImage) return false;
+            const files = event.dataTransfer?.files;
+            if (!files?.length) return false;
+            for (const file of files) {
+                if (file.type.startsWith('image/')) {
+                    event.preventDefault();
+                    uploadAndInsert(file);
+                    return true;
+                }
+            }
+            return false;
+        },
+    },
+});
+
+watch(() => props.modelValue, (val) => {
+    if (editor.value && editor.value.getHTML() !== val) {
+        editor.value.commands.setContent(val, false);
+    }
+});
+
+const toggleSource = () => {
+    if (!sourceMode.value) {
+        sourceCode.value = editor.value.getHTML();
+        sourceMode.value = true;
+    } else {
+        editor.value.commands.setContent(sourceCode.value, false);
+        emit('update:modelValue', sourceCode.value);
+        sourceMode.value = false;
+    }
+};
+
+const updateSource = (e) => {
+    sourceCode.value = e.target.value;
+    emit('update:modelValue', sourceCode.value);
+};
+
+const showLinkDialog = ref(false);
+const linkUrl = ref('');
+const linkDialogRef = ref(null);
+
+watch(showLinkDialog, async (open) => {
+    if (open) {
+        const attrs = editor.value?.getAttributes('link');
+        linkUrl.value = attrs?.href || '';
+        await nextTick();
+        linkDialogRef.value?.querySelector('input')?.focus();
+    }
+});
+
+const insertLink = () => {
+    if (linkUrl.value) {
+        editor.value.chain().focus().extendMarkRange('link').setLink({ href: linkUrl.value }).run();
+    } else {
+        editor.value.chain().focus().extendMarkRange('link').unsetLink().run();
+    }
+    linkUrl.value = '';
+    showLinkDialog.value = false;
+};
+
+const removeLink = () => {
+    editor.value.chain().focus().extendMarkRange('link').unsetLink().run();
+    linkUrl.value = '';
+    showLinkDialog.value = false;
+};
+
+const imageInputRef = ref(null);
+const showImageDialog = ref(false);
+const imageDialogRef = ref(null);
+const imageUrl = ref('');
+
+watch(showImageDialog, async (open) => {
+    if (open) {
+        await nextTick();
+        imageDialogRef.value?.focus();
+    }
+});
+
+const insertImageFromUrl = async () => {
+    if (!imageUrl.value) return;
+    imageUploading.value = true;
+    try {
+        const { data } = await axios.post(route(props.imageUploadRoute), { url: imageUrl.value });
+        editor.value.chain().focus().setImage({ src: data.url }).run();
+        imageUrl.value = '';
+        showImageDialog.value = false;
+    } catch (err) {
+        alert('Failed to download image: ' + (err.response?.data?.error || err.message));
+    }
+    imageUploading.value = false;
+};
+
+const triggerFileUpload = () => imageInputRef.value?.click();
+
+const handleImageUpload = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await uploadAndInsert(file);
+    showImageDialog.value = false;
+    e.target.value = '';
+};
+
+const addTable = () => {
+    editor.value.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+};
+
+onBeforeUnmount(() => {
+    editor.value?.destroy();
+});
+</script>
+
+<template>
+    <div class="rte-wrapper">
+        <div class="flex flex-wrap items-center gap-0.5 bg-gray-900/40 border border-gray-700/50 rounded-t-lg px-2 py-1.5">
+            <template v-if="!sourceMode">
+                <button type="button" @click="editor?.chain().focus().toggleBold().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('bold') }" class="toolbar-btn" title="Bold"><strong>B</strong></button>
+                <button type="button" @click="editor?.chain().focus().toggleItalic().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('italic') }" class="toolbar-btn italic" title="Italic">I</button>
+                <button type="button" @click="editor?.chain().focus().toggleUnderline().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('underline') }" class="toolbar-btn underline" title="Underline">U</button>
+                <button type="button" @click="editor?.chain().focus().toggleStrike().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('strike') }" class="toolbar-btn line-through" title="Strikethrough">S</button>
+
+                <template v-if="enableHeadings">
+                    <div class="w-px h-5 bg-gray-700 mx-1"></div>
+                    <button type="button" @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('heading', { level: 2 }) }" class="toolbar-btn" title="Heading 2">H2</button>
+                    <button type="button" @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('heading', { level: 3 }) }" class="toolbar-btn" title="Heading 3">H3</button>
+                    <button type="button" @click="editor?.chain().focus().toggleHeading({ level: 4 }).run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('heading', { level: 4 }) }" class="toolbar-btn" title="Heading 4">H4</button>
+                </template>
+
+                <div class="w-px h-5 bg-gray-700 mx-1"></div>
+                <button type="button" @click="editor?.chain().focus().toggleBulletList().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('bulletList') }" class="toolbar-btn" title="Bullet List">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+                </button>
+                <button type="button" @click="editor?.chain().focus().toggleOrderedList().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('orderedList') }" class="toolbar-btn" title="Ordered List">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
+                </button>
+
+                <div class="w-px h-5 bg-gray-700 mx-1"></div>
+                <button type="button" @click="editor?.chain().focus().toggleBlockquote().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('blockquote') }" class="toolbar-btn" title="Quote">"</button>
+
+                <template v-if="enableCode">
+                    <button type="button" @click="editor?.chain().focus().toggleCode().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('code') }" class="toolbar-btn font-mono" title="Inline Code">&lt;&gt;</button>
+                    <button type="button" @click="editor?.chain().focus().toggleCodeBlock().run()" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('codeBlock') }" class="toolbar-btn font-mono text-xs" title="Code Block">{ }</button>
+                </template>
+                <button type="button" @click="editor?.chain().focus().setHorizontalRule().run()" class="toolbar-btn" title="Horizontal Rule">--</button>
+
+                <div class="w-px h-5 bg-gray-700 mx-1"></div>
+                <button type="button" @click="showLinkDialog = true" :class="{ 'bg-blue-600/30 text-blue-400': editor?.isActive('link') }" class="toolbar-btn" title="Link">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
+                </button>
+                <button v-if="enableImage" type="button" @click="showImageDialog = true" class="toolbar-btn" title="Image">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+                </button>
+                <button v-if="enableTable" type="button" @click="addTable" class="toolbar-btn" title="Table">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 14h18M10 3v18M14 3v18"/></svg>
+                </button>
+
+                <div class="w-px h-5 bg-gray-700 mx-1"></div>
+                <button type="button" @click="editor?.chain().focus().undo().run()" class="toolbar-btn" title="Undo">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a5 5 0 015 5v2M3 10l4-4m-4 4l4 4"/></svg>
+                </button>
+                <button type="button" @click="editor?.chain().focus().redo().run()" class="toolbar-btn" title="Redo">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 10H11a5 5 0 00-5 5v2m15-7l-4-4m4 4l-4 4"/></svg>
+                </button>
+            </template>
+
+            <div class="flex-1"></div>
+
+            <button v-if="enableSource" type="button" @click="toggleSource" class="px-3 py-1 text-xs rounded transition" :class="sourceMode ? 'bg-orange-600/30 text-orange-400 font-bold' : 'text-gray-400 hover:text-white hover:bg-gray-700/50'">
+                {{ sourceMode ? 'Visual Editor' : 'Source Code' }}
+            </button>
+        </div>
+
+        <div v-if="!sourceMode" class="bg-gray-900/60 border border-t-0 border-gray-700/50 rounded-b-lg">
+            <editor-content :editor="editor" class="rte-content" :style="{ '--rte-min-height': minHeight }" />
+        </div>
+        <textarea v-else :value="sourceCode" @input="updateSource" rows="20" class="w-full bg-gray-900/60 border border-t-0 border-gray-700/50 rounded-b-lg px-4 py-3 text-gray-200 font-mono text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none resize-y"></textarea>
+
+        <Teleport to="body">
+            <div v-if="showLinkDialog" ref="linkDialogRef" class="fixed inset-0 z-[9999] flex items-center justify-center px-4" @click.self="showLinkDialog = false" @keydown.esc="showLinkDialog = false" tabindex="-1">
+                <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="showLinkDialog = false"></div>
+                <div class="relative bg-gray-900 border border-white/15 rounded-xl shadow-2xl p-6 w-full max-w-md">
+                    <h3 class="text-lg font-bold text-gray-200 mb-4">Insert Link</h3>
+                    <div class="space-y-3">
+                        <input v-model="linkUrl" type="text" placeholder="https://example.com" class="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5 text-sm text-gray-200 focus:border-blue-500 outline-none" @keydown.enter="insertLink" />
+                        <div class="flex items-center gap-2">
+                            <button type="button" @click="insertLink" class="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition">{{ linkUrl ? 'Apply Link' : 'Remove Link' }}</button>
+                            <button v-if="editor?.isActive('link')" type="button" @click="removeLink" class="px-4 py-2 bg-red-600/60 hover:bg-red-600 text-white text-sm font-medium rounded-lg transition">Remove</button>
+                            <button type="button" @click="showLinkDialog = false" class="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm font-medium rounded-lg transition">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Teleport>
+
+        <input ref="imageInputRef" type="file" accept="image/*" class="hidden" @change="handleImageUpload" />
+
+        <Teleport to="body">
+            <div v-if="showImageDialog" class="fixed inset-0 z-[9999] flex items-center justify-center px-4" @click.self="showImageDialog = false" @keydown.esc="showImageDialog = false" tabindex="-1" ref="imageDialogRef">
+                <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="showImageDialog = false"></div>
+                <div class="relative bg-gray-900 border border-white/15 rounded-xl shadow-2xl p-6 w-full max-w-md">
+                    <h3 class="text-lg font-bold text-gray-200 mb-4">Insert Image</h3>
+                    <button type="button" @click="triggerFileUpload" :disabled="imageUploading" class="w-full mb-4 px-4 py-8 border-2 border-dashed border-gray-600 hover:border-blue-500 rounded-lg text-gray-400 hover:text-blue-400 transition flex flex-col items-center gap-2">
+                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+                        <span v-if="imageUploading" class="text-sm">Uploading...</span>
+                        <span v-else class="text-sm">Click to upload an image</span>
+                        <span class="text-xs text-gray-600">Max 5MB - JPG, PNG, GIF, WebP</span>
+                    </button>
+                    <div class="flex items-center gap-3 mb-4">
+                        <div class="flex-1 h-px bg-gray-700"></div>
+                        <span class="text-xs text-gray-600">or paste URL</span>
+                        <div class="flex-1 h-px bg-gray-700"></div>
+                    </div>
+                    <div class="flex gap-2">
+                        <input v-model="imageUrl" type="text" placeholder="https://example.com/image.png" class="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:border-blue-500 outline-none" @keydown.enter="insertImageFromUrl" />
+                        <button type="button" @click="insertImageFromUrl" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition">Insert</button>
+                    </div>
+                </div>
+            </div>
+        </Teleport>
+    </div>
+</template>
+
+<style>
+.rte-wrapper .toolbar-btn {
+    @apply px-2 py-1 text-sm text-gray-400 hover:text-white hover:bg-gray-700/50 rounded transition;
+}
+.rte-content .tiptap {
+    @apply px-6 py-4 outline-none text-gray-300;
+    min-height: var(--rte-min-height, 15rem);
+}
+.rte-content .tiptap:focus { @apply outline-none; }
+.rte-content .tiptap h1 { @apply text-3xl font-bold text-gray-200 mt-6 mb-3; }
+.rte-content .tiptap h2 { @apply text-2xl font-bold text-gray-200 mt-6 mb-3; }
+.rte-content .tiptap h3 { @apply text-xl font-semibold text-gray-300 mt-4 mb-2; }
+.rte-content .tiptap h4 { @apply text-lg font-semibold text-gray-300 mt-3 mb-2; }
+.rte-content .tiptap p { @apply text-gray-400 leading-relaxed mb-3; }
+.rte-content .tiptap ul { @apply list-disc ml-6 text-gray-400 mb-3 space-y-1; }
+.rte-content .tiptap ol { @apply list-decimal ml-6 text-gray-400 mb-3 space-y-1; }
+.rte-content .tiptap li { @apply text-gray-400; }
+.rte-content .tiptap a { @apply text-blue-400 hover:text-blue-300 underline cursor-pointer; }
+.rte-content .tiptap code { @apply bg-gray-800 text-green-400 px-1.5 py-0.5 rounded text-sm; }
+.rte-content .tiptap pre { @apply bg-gray-800/80 border border-gray-700/50 rounded-lg p-4 mb-3 overflow-x-auto; }
+.rte-content .tiptap pre code { @apply bg-transparent p-0 text-gray-300 text-sm; }
+.rte-content .tiptap blockquote { @apply border-l-4 border-blue-500/50 pl-4 italic text-gray-500 mb-3; }
+.rte-content .tiptap hr { @apply border-gray-700/50 my-4; }
+.rte-content .tiptap strong { @apply text-gray-200 font-semibold; }
+.rte-content .tiptap em { @apply text-gray-300; }
+.rte-content .tiptap img { @apply rounded-lg max-w-full my-3 cursor-pointer; }
+.rte-content .tiptap img.ProseMirror-selectednode { outline: 3px solid rgb(59, 130, 246); outline-offset: 2px; }
+.rte-content .tiptap table { @apply w-full border-collapse mb-3; }
+.rte-content .tiptap th { @apply bg-gray-700/40 border border-gray-700/50 px-3 py-2 text-left text-sm font-semibold text-gray-300; }
+.rte-content .tiptap td { @apply border border-gray-700/50 px-3 py-2 text-sm text-gray-400; }
+.rte-content .tiptap .selectedCell { @apply bg-blue-600/20; }
+.rte-content .tiptap p.is-editor-empty:first-child::before {
+    @apply text-gray-600;
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+}
+</style>

--- a/resources/js/Pages/Clans/MemberNoteEditor.vue
+++ b/resources/js/Pages/Clans/MemberNoteEditor.vue
@@ -3,10 +3,7 @@
     import { ref } from 'vue';
     import InputError from '@/Components/Laravel/InputError.vue';
     import PrimaryButton from '@/Components/Laravel/PrimaryButton.vue';
-    import CKEditor from '@ckeditor/ckeditor5-vue';
-    import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
-
-    const ckeditor = CKEditor.component;
+    import RichTextEditor from '@/Components/RichTextEditor.vue';
 
     const props = defineProps({
         player: Object,
@@ -21,24 +18,6 @@
         position: props.player.position || '',
         config_file: null
     });
-
-    const editorConfig = {
-        toolbar: {
-            items: [
-                'heading',
-                '|',
-                'bold',
-                'italic',
-                'link',
-                'bulletedList',
-                'numberedList',
-                '|',
-                'blockQuote',
-                'undo',
-                'redo'
-            ]
-        }
-    };
 
     const saveNote = () => {
         form.post(route('clans.manage.member.note', { clan: props.clan.id, user: props.player.user_id }), {
@@ -155,13 +134,14 @@
                     <InputError class="mt-2" :message="form.errors.position" />
                 </div>
 
-                <div class="ckeditor-dark-theme">
-                    <ckeditor
-                        :editor="ClassicEditor"
-                        v-model="form.note"
-                        :config="editorConfig"
-                    ></ckeditor>
-                </div>
+                <RichTextEditor
+                    v-model="form.note"
+                    :enable-image="false"
+                    :enable-table="false"
+                    :enable-code="false"
+                    placeholder="Add a note about this member..."
+                    min-height="8rem"
+                />
                 <InputError class="mt-2" :message="form.errors.note" />
 
                 <!-- Config File Upload -->
@@ -205,50 +185,3 @@
     </div>
 </template>
 
-<style>
-.ckeditor-dark-theme .ck-editor__editable {
-    min-height: 200px;
-    background-color: rgba(255, 255, 255, 0.05) !important;
-    color: #fff !important;
-    border-color: rgba(255, 255, 255, 0.1) !important;
-}
-
-.ckeditor-dark-theme .ck-editor__editable:focus {
-    border-color: rgba(99, 102, 241, 0.5) !important;
-    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2) !important;
-}
-
-.ckeditor-dark-theme .ck.ck-toolbar {
-    background-color: rgba(255, 255, 255, 0.05) !important;
-    border-color: rgba(255, 255, 255, 0.1) !important;
-}
-
-.ckeditor-dark-theme .ck.ck-button,
-.ckeditor-dark-theme .ck.ck-dropdown__button {
-    color: #d1d5db !important;
-}
-
-.ckeditor-dark-theme .ck.ck-button:hover,
-.ckeditor-dark-theme .ck.ck-dropdown__button:hover {
-    background-color: rgba(255, 255, 255, 0.1) !important;
-}
-
-.ckeditor-dark-theme .ck.ck-button.ck-on,
-.ckeditor-dark-theme .ck.ck-button.ck-on:hover {
-    background-color: rgba(99, 102, 241, 0.3) !important;
-    color: #fff !important;
-}
-
-.ckeditor-dark-theme .ck.ck-dropdown__panel {
-    background-color: rgba(17, 24, 39, 0.95) !important;
-    border-color: rgba(255, 255, 255, 0.1) !important;
-}
-
-.ckeditor-dark-theme .ck.ck-list__item {
-    color: #d1d5db !important;
-}
-
-.ckeditor-dark-theme .ck.ck-list__item:hover {
-    background-color: rgba(255, 255, 255, 0.1) !important;
-}
-</style>

--- a/resources/js/Pages/Tournaments/TournamentForm.vue
+++ b/resources/js/Pages/Tournaments/TournamentForm.vue
@@ -7,7 +7,7 @@
     import InputLabel from '@/Components/Laravel/InputLabel.vue';
     import PrimaryButton from '@/Components/Laravel/PrimaryButton.vue';
     import TextInput from '@/Components/Laravel/TextInput.vue';
-    import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+    import RichTextEditor from '@/Components/RichTextEditor.vue';
     import rulesData from '@/rules';
 
     const props = defineProps({
@@ -27,21 +27,6 @@
         prize_pool: props.tournament.prize_pool?.toString() || '0',
         donation_link: props.tournament.donation_link || '',
     });
-
-    const editor = ClassicEditor;
-    const editorConfig = {
-        heading: {
-            options: [
-                { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-                { model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
-                { model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
-                { model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' },
-                { model: 'heading4', view: 'h4', title: 'Heading 4', class: 'ck-heading_heading4' },
-                { model: 'heading5', view: 'h5', title: 'Heading 5', class: 'ck-heading_heading5' },
-                { model: 'heading6', view: 'h6', title: 'Heading 6', class: 'ck-heading_heading6' }
-            ]
-        }
-    };
 
     const photoPreview = ref(null);
     const photoInput = ref(null);
@@ -242,13 +227,11 @@
                 <div class="col-span-6" v-show="tabs[currentTab] == 'details'">
                     <div class="mb-3">
                         <InputLabel for="rules" value="Rules" />
-                        <ckeditor
-                            :editor="editor"
-                            :config="editorConfig"
+                        <RichTextEditor
                             id="rules"
                             v-model="form.rules"
-                            type="text"
-                            class="mt-1 block w-full border-2 border-grayop-700 bg-grayop-900 text-gray-300 focus:border-blue-600 focus:ring-blue-600 rounded-md shadow-sm"
+                            placeholder="Tournament rules..."
+                            class="mt-1"
                         />
                         <InputError :message="form.errors.rules" class="mt-2" />
                     </div>

--- a/resources/js/Pages/Wiki/Revision.vue
+++ b/resources/js/Pages/Wiki/Revision.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { Head, Link } from '@inertiajs/vue3';
 import { ref, computed, getCurrentInstance } from 'vue';
-import HtmlDiff from 'htmldiff-js';
+import HtmlDiffImport from 'htmldiff-js';
+const HtmlDiff = HtmlDiffImport.default ?? HtmlDiffImport;
 import { diffLines } from 'diff';
 
 const { proxy } = getCurrentInstance();

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -38,8 +38,6 @@ import MainLayout from "@/Layouts/MainLayout.vue"
 
 import { createVuetify } from 'vuetify'
 
-import CKEditor from '@ckeditor/ckeditor5-vue';
-
 const appName = import.meta.env.VITE_APP_NAME || 'Defrag Racing';
 
 const formatTime = (milliseconds) => {
@@ -200,8 +198,7 @@ createInertiaApp({
         const app = createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue)
-            .use(vuetify)
-            .use(CKEditor);
+            .use(vuetify);
 
         app.component("Popper", Popper);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,4 +27,11 @@ export default defineConfig({
             host: 'localhost',
         },
     },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                api: 'modern-compiler',
+            },
+        },
+    },
 });


### PR DESCRIPTION
## Summary

- Migrated TournamentForm rules editor and MemberNoteEditor clan notes from `@ckeditor/ckeditor5-build-classic` to a new generic `RichTextEditor.vue` built on TipTap, unifying the project on a single editor stack (WikiEditor already used TipTap)
- Cleared all npm audit vulnerabilities: **85 (11 high, 71 moderate, 3 low) → 0**
- Upgraded Vite 5→8, `@vitejs/plugin-vue` 4→6, `laravel-vite-plugin` 1→3 to fix esbuild dev-server CORS advisory
- Production bundle shrinks by ~1.7 MB (ckeditor + transitive deps gone)
- Enabled Sass modern compiler API (silences legacy-js-api deprecation)
- `deploy.py`: `COMPOSER_ALLOW_SUPERUSER=1` so composer plugins run cleanly on production

## Why CKEditor had to go

CKEditor 5 clipboard XSS (GHSA-rgg8-g5x8-wr9v / GHSA-x9gp-vjh6-3wv6) affected every version up to and including 44.3.0. The fix only landed in v45.2.2+, which is **only available under the new installation method** that requires a mandatory `licenseKey` (introduced in v44.0.0). TipTap (MIT, already in the project) covers all our features cleanly.

## Test plan

- [x] Vite 8 dev server starts cleanly, Octane boots, all main routes return 200
- [x] WikiEditor (TipTap) still works
- [x] ModelViewer (gl/three) still works
- [x] Revision diff (htmldiff-js default-export fix) renders
- [x] TournamentForm Rules editor loads, edits, saves existing CKEditor-produced HTML
- [x] MemberNoteEditor loads, edits, saves clan member notes
- [x] `npm audit` reports 0 vulnerabilities
- [ ] Production deploy (`git pull` in `current/` first so updated `deploy.py` runs this round)
