### PR TITLE
Deploy hygiene: npm ci + drop :deep() from unscoped styles

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -29,7 +29,7 @@ def get_git_clone_cmd(name):
 def pipeline_cmds(name):
     cmds = [
         "COMPOSER_ALLOW_SUPERUSER=1 composer install --optimize-autoloader --no-dev --no-interaction",
-        "npm install",
+        "npm ci",
         "npm run build",
         f"ln -s {PROJECT_PATH}/deploy/.env {PROJECT_PATH}/releases/{name}/.env",
         f"rm -rdf {PROJECT_PATH}/releases/{name}/storage",

--- a/resources/js/Components/ImageCropper.vue
+++ b/resources/js/Components/ImageCropper.vue
@@ -152,14 +152,14 @@
     overflow: hidden;
 }
 
-/* Override vue-cropper default styles using :deep() */
-.cropper-wrapper :deep(img) {
+/* Override vue-cropper default styles */
+.cropper-wrapper img {
     max-width: 100%;
     max-height: 100%;
 }
 
 /* The main cropper container that gets created */
-.cropper-wrapper :deep(.cropper-container) {
+.cropper-wrapper .cropper-container {
     position: relative !important;
     height: 500px !important;
     width: 100% !important;
@@ -167,63 +167,63 @@
 }
 
 /* Wrap box should be contained */
-.cropper-wrapper :deep(.cropper-wrap-box) {
+.cropper-wrapper .cropper-wrap-box {
     position: relative !important;
 }
 
 /* Canvas should not overflow */
-.cropper-wrapper :deep(.cropper-canvas) {
+.cropper-wrapper .cropper-canvas {
     position: relative !important;
 }
 
 /* Drag box and crop box need proper z-index */
-.cropper-wrapper :deep(.cropper-drag-box) {
+.cropper-wrapper .cropper-drag-box {
     position: absolute;
     z-index: 1;
 }
 
-.cropper-wrapper :deep(.cropper-crop-box) {
+.cropper-wrapper .cropper-crop-box {
     position: absolute;
     z-index: 2;
 }
 
 /* Cropper.js custom styling */
-:deep(.cropper-view-box) {
+.cropper-view-box {
     outline: 2px solid rgba(59, 130, 246, 0.8) !important;
     outline-color: rgba(59, 130, 246, 0.8) !important;
 }
 
-:deep(.cropper-point) {
+.cropper-point {
     background-color: rgba(59, 130, 246, 1) !important;
     width: 12px !important;
     height: 12px !important;
 }
 
-:deep(.cropper-line) {
+.cropper-line {
     background-color: rgba(59, 130, 246, 0.8) !important;
 }
 
-:deep(.cropper-face) {
+.cropper-face {
     background-color: transparent !important;
     cursor: move !important;
 }
 
-:deep(.cropper-dashed) {
+.cropper-dashed {
     border-color: rgba(59, 130, 246, 0.3) !important;
 }
 
-:deep(.cropper-center) {
+.cropper-center {
     background-color: rgba(59, 130, 246, 0.8) !important;
 }
 
 /* Dark background for area outside crop */
-:deep(.cropper-modal) {
+.cropper-modal {
     background-color: rgba(0, 0, 0, 0.6) !important;
 }
 
 /* Make sure all cropper elements stay within bounds */
-.cropper-wrapper :deep(.cropper-modal),
-.cropper-wrapper :deep(.cropper-bg) {
+.cropper-wrapper .cropper-modal,
+.cropper-wrapper .cropper-bg {
     position: absolute !important;
 }
 </style>

--- a/resources/js/Pages/ProfileProgressBar.vue
+++ b/resources/js/Pages/ProfileProgressBar.vue
@@ -245,16 +245,16 @@ div[id^="phpdebugbar"] { display: none !important; }
     flex-shrink: 0;
 }
 
-.ppb-player-name :deep(.q3c-0),
-.ppb-player-name :deep(.q3c-1),
-.ppb-player-name :deep(.q3c-2),
-.ppb-player-name :deep(.q3c-3),
-.ppb-player-name :deep(.q3c-4),
-.ppb-player-name :deep(.q3c-5),
-.ppb-player-name :deep(.q3c-6),
-.ppb-player-name :deep(.q3c-7),
-.ppb-player-name :deep(.q3c-8),
-.ppb-player-name :deep(.q3c-9) {
+.ppb-player-name .q3c-0,
+.ppb-player-name .q3c-1,
+.ppb-player-name .q3c-2,
+.ppb-player-name .q3c-3,
+.ppb-player-name .q3c-4,
+.ppb-player-name .q3c-5,
+.ppb-player-name .q3c-6,
+.ppb-player-name .q3c-7,
+.ppb-player-name .q3c-8,
+.ppb-player-name .q3c-9 {
     font-weight: inherit;
     font-size: inherit;
     font-family: inherit;


### PR DESCRIPTION
## Summary

Two small follow-ups to the CKEditor/Vite 8 migration that surfaced during the production deploy.

- `deploy.py`: switched `npm install` → `npm ci` so the release folder's `package-lock.json` stays untouched. `npm install` was subtly rewriting the lockfile (folder-name field, platform-specific `libc` arrays under different npm versions), which meant every subsequent `git pull` in `current/` aborted with "Your local changes would be overwritten by merge". `npm ci` installs exactly what the committed lockfile pins, never modifies it, and fails fast when `package.json` and `package-lock.json` drift apart.
- Dropped `:deep()` wrappers from two components (`ProfileProgressBar.vue`, `ImageCropper.vue`) where `<style>` is **unscoped**. `:deep()` is a Vue scoped-CSS construct and is only meaningful inside `<style scoped>` — elsewhere it's invalid CSS. Vite 5's esbuild minifier let it pass silently, Vite 8 uses lightningcss which (correctly) flags it as an unknown pseudo-class. The wrapper was a no-op, removing it leaves selectors with identical semantics (`.ppb-player-name :deep(.q3c-0)` → `.ppb-player-name .q3c-0`). Also means those rules will finally apply at all, since browsers were likely ignoring the invalid selectors. `ClanCard.vue` also uses `:deep()` but inside `<style scoped>` — legitimate, left alone.

## Test plan

- [x] `npm ci` verified manually on production `current/` — clean install, 0 vulnerabilities, `package-lock.json` untouched
- [x] Production deploy ran cleanly with new `deploy.py` — no composer warnings, no package-lock conflicts
- [ ] Next deploy: `git pull origin master` in `current/` should succeed without manual checkout workaround
- [ ] Next deploy: lightningcss warnings about `:deep()` in production build should be gone
- [ ] ProfileProgressBar widget renders Q3-colored player names correctly
- [ ] ImageCropper (avatar crop UI) still styles correctly
