### PR TITLE
Skip session start for bot traffic to stop sessions table bloat

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -32,7 +32,7 @@ class Kernel extends HttpKernel
         'web' => [
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
+            \App\Http\Middleware\BotAwareStartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Http/Middleware/BotAwareStartSession.php
+++ b/app/Http/Middleware/BotAwareStartSession.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\BotDetector;
+use Closure;
+use Illuminate\Session\Middleware\StartSession;
+
+/**
+ * Skip session start for identified bots so their requests don't
+ * create sessions table rows. Bot crawlers rarely persist cookies,
+ * so every request was creating a new row — the sessions table had
+ * grown to ~1.8M rows in 30 days from bot traffic alone.
+ */
+class BotAwareStartSession extends StartSession
+{
+    public function handle($request, Closure $next)
+    {
+        if (BotDetector::isBot($request->userAgent() ?? '')) {
+            return $next($request);
+        }
+
+        return parent::handle($request, $next);
+    }
+}


### PR DESCRIPTION
The sessions table on production had grown to ~1.8M rows over 30 days. Analysis showed ~60k new sessions per day, almost entirely from bot crawlers: every bot request hit web middleware, StartSession created a fresh session row, and since bots don't persist cookies the next request from the same bot created yet another row.

BotAwareStartSession wraps the core StartSession middleware and short-circuits the session lifecycle when BotDetector::isBot() recognizes the user-agent. Detected bots flow through the rest of the middleware stack without a session being loaded, saved, or garbage- collected on their behalf.

Human users keep normal session handling; BotDetector is the same heuristic already used by the existing TrackBots middleware so the bot classification stays consistent with what we log in BotVisit.