### PR TITLE
Prune stale guest sessions daily

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use App\Jobs\GetLastMddRecords;
 use App\Jobs\ScrapeRecords;
 use App\Jobs\TournamentCalculationsJob;
+use Illuminate\Support\Facades\DB;
 
 class Kernel extends ConsoleKernel
 {
@@ -69,6 +70,15 @@ class Kernel extends ConsoleKernel
 
         // Check q3defrag.org for new DeFRaG mod releases every Sunday at 12:00
         $schedule->command('wiki:check-defrag-releases')->withoutOverlapping()->weeklyOn(0, '12:00');
+
+        // Prune guest sessions older than 24h so bot traffic doesn't bloat
+        // the sessions table. Logged-in sessions keep the 30-day lifetime.
+        $schedule->call(function () {
+            DB::table('sessions')
+                ->whereNull('user_id')
+                ->where('last_activity', '<', time() - 86400)
+                ->delete();
+        })->daily()->name('prune-guest-sessions')->withoutOverlapping();
     }
 
     /**


### PR DESCRIPTION
BotAwareStartSession catches known bot user-agents, but modern scrapers spoof real Firefox/Chrome UAs and slip through the detector. Those fake-human sessions still create DB rows on every uncookie'd request, so even with Cloudflare Bot Fight Mode and ASN-level filtering the sessions table can still grow.

A nightly prune cleans up guest sessions (user_id IS NULL) older than 24h, keeping the table bounded even if some bot traffic leaks through. Logged-in sessions aren't touched — they keep the 30-day SESSION_LIFETIME as a fallback against remember-me cookie loss.