### PR TITLE
Fix demo auto-assignment false positives and stranded demos

### DIFF
--- a/app/Console/Commands/RematchAllDemos.php
+++ b/app/Console/Commands/RematchAllDemos.php
@@ -14,7 +14,8 @@ class RematchAllDemos extends Command
 {
     protected $signature = 'demos:rematch-all
         {demo_id? : Optional specific demo ID to rematch}
-        {--chunk=1000 : Batch size for chunkById streaming}';
+        {--chunk=1000 : Batch size for chunkById streaming}
+        {--status= : Filter to demos with this exact status (e.g. processed). When set, the rematch only touches that subset instead of every non-assigned demo. Useful after a targeted cleanup unpaired demos to status=processed.}';
 
     protected $description = 'Rematch all unassigned demos against current user aliases';
 
@@ -22,6 +23,7 @@ class RematchAllDemos extends Command
     {
         $demoId = (int) $this->argument('demo_id') ?: null;
         $chunkSize = max(100, (int) $this->option('chunk'));
+        $statusFilter = $this->option('status') ?: null;
 
         // Single-demo mode bypasses chunking/preload entirely — one demo
         // doesn't justify loading ~650k Records into memory, and verbose
@@ -38,12 +40,16 @@ class RematchAllDemos extends Command
             return 0;
         }
 
-        $this->info('Rematching all unassigned demos...');
-
-        // Rematch all demos that are NOT assigned (includes: uploaded,
-        // processing, processed, failed). player_name is required for
-        // fuzzy-match to do anything useful.
-        $query = UploadedDemo::where('status', '!=', 'assigned')->whereNotNull('player_name');
+        if ($statusFilter) {
+            $this->info("Rematching demos with status={$statusFilter}...");
+            $query = UploadedDemo::where('status', $statusFilter)->whereNotNull('player_name');
+        } else {
+            $this->info('Rematching all unassigned demos...');
+            // Rematch all demos that are NOT assigned (includes: uploaded,
+            // processing, processed, failed). player_name is required for
+            // fuzzy-match to do anything useful.
+            $query = UploadedDemo::where('status', '!=', 'assigned')->whereNotNull('player_name');
+        }
         $total = (clone $query)->count();
         $this->info("Found {$total} demos to rematch");
 
@@ -158,6 +164,26 @@ class RematchAllDemos extends Command
             // leaderboard (parity with DemoProcessorService scénár B).
             if ($demo->file_path) {
                 $demo = $demo->fresh();
+                if ($this->ensureOfflineRecord($demo, $verbose)) {
+                    $assigned++;
+                }
+            }
+        } elseif ($outcome === DemoAutoAssigner::OUTCOME_NONE) {
+            // Parity with DemoProcessorService::autoAssignToRecord: when
+            // Pass 2 fuzzy nick reached a confident-enough user match but
+            // no Record exists at this (map, gametype, time) for that
+            // user, create an offline_record so the run is attributed.
+            // Without this branch demos that we just unpaired (e.g. via
+            // demos:resolve-duplicate-assignments) would never reach the
+            // player's profile through rematch — they'd stay as plain
+            // 'processed' files invisible on the leaderboard.
+            //
+            // Threshold lowered from 100 to 80 so Levenshtein-fuzzy matches
+            // (e.g. demo player "NOOBZ0RN" → user alias "[NOOB]Z0RN" at 80%)
+            // also produce an offline_record. Conservative auto-assignment
+            // to a Record still requires 100% in DemoAutoAssigner Pass 2.
+            $demo = $demo->fresh();
+            if ($demo->file_path && $demo->name_confidence >= 80 && $demo->suggested_user_id) {
                 if ($this->ensureOfflineRecord($demo, $verbose)) {
                     $assigned++;
                 }

--- a/app/Console/Commands/ResolveDuplicateDemoAssignments.php
+++ b/app/Console/Commands/ResolveDuplicateDemoAssignments.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\OfflineRecord;
+use App\Models\UploadedDemo;
+use App\Models\UserAlias;
+use App\Services\NameMatcher;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Repairs historical mis-assignment of uploaded_demos to Records.
+ *
+ * Two sub-categories handled:
+ *
+ * (1) FALSE-POSITIVE PASS 1 — DemoAutoAssigner Pass 1 historically attached
+ *     a demo to its uploader's Record on the same (map, gametype, time)
+ *     WITHOUT verifying that the demo's player_name actually resolves to
+ *     that uploader. Bulk-uploader accounts (admin importing third-party
+ *     demos) thus stamped someone else's run as the uploader's own.
+ *
+ *     Detection: demo.user_id == record.user_id AND
+ *                NameMatcher.findBestMatch(player_name).user_id != demo.user_id
+ *                (with confidence == 100, i.e. NameMatcher is sure the demo
+ *                belongs to a different registered user)
+ *     Action: unpair (record_id = NULL, status = 'processed').
+ *
+ *     Ambiguous sub-case: when multiple registered users share the same
+ *     plain alias (e.g. "n", "b", "UnnamedDefragger"), NameMatcher's
+ *     first-write-wins rule arbitrarily picks one. We still unpair from
+ *     the wrong owner (the demo definitely doesn't belong to neiT just
+ *     because they were the uploader) but skip auto-suggestion so the
+ *     next rematch doesn't crystalize the arbitrary pick. Demo lands as
+ *     a plain 'processed' file for manual review.
+ *
+ * (2) SUPERSEDED RECORD — demo.record_id points at a Record row whose
+ *     `deleted_at` is non-null. The record was soft-deleted because the
+ *     same player set a faster time and the slower one was retired. The
+ *     demo file is a legitimate older attempt; from the UI's perspective
+ *     it currently hangs on a zombie record (frontend hides soft-deleted
+ *     records). After unpair + rematch it gets its own offline_record and
+ *     surfaces under the player's live record as a Time History sibling.
+ *     Action: unpair (record_id = NULL, status = 'processed').
+ */
+class ResolveDuplicateDemoAssignments extends Command
+{
+    protected $signature = 'demos:resolve-duplicate-assignments
+        {--dry-run : Print what would change without writing}
+        {--limit=0 : Cap on the number of items processed (0 = no cap)}';
+
+    protected $description = 'Unpair false-positive Pass 1 assignments and demos on soft-deleted records.';
+
+    public function handle(NameMatcher $matcher)
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $limit = (int) $this->option('limit');
+
+        if ($dryRun) {
+            $this->warn('DRY RUN — no changes will be written.');
+            $this->line('');
+        }
+
+        $this->info('=== Detection ===');
+
+        // (1) candidates whose uploader matches the live record owner
+        $matched = DB::table('uploaded_demos AS ud')
+            ->join('records AS r', function ($j) {
+                $j->on('r.id', '=', 'ud.record_id')->whereNull('r.deleted_at');
+            })
+            ->whereNotNull('ud.record_id')
+            ->whereColumn('ud.user_id', 'r.user_id')
+            ->select(['ud.id AS demo_id', 'ud.user_id AS uploader', 'ud.player_name', 'ud.record_id', 'ud.map_name', 'ud.time_ms', 'ud.status', 'r.user_id AS owner_user_id', 'r.name AS record_name', 'r.gametype AS record_gametype', 'r.time AS record_time'])
+            ->orderBy('ud.id')
+            ->get();
+
+        // (2) demos whose record was soft-deleted (= older attempt, superseded)
+        $superseded = DB::table('uploaded_demos AS ud')
+            ->join('records AS r', 'r.id', '=', 'ud.record_id')
+            ->whereNotNull('ud.record_id')
+            ->whereNotNull('r.deleted_at')
+            ->select(['ud.id AS demo_id', 'ud.user_id AS uploader', 'ud.player_name', 'ud.record_id', 'ud.map_name', 'ud.time_ms', 'ud.status', 'r.deleted_at'])
+            ->orderBy('ud.id')
+            ->get();
+
+        $this->info("Pass-1 candidates (uploader == record owner, live record): {$matched->count()}");
+        $this->info("Superseded demos (record soft-deleted):                    {$superseded->count()}");
+
+        // Classify Pass-1 candidates via NameMatcher and ambiguity check.
+        $aliasOwners = $this->buildAliasOwnerCounts();
+
+        $unique = []; $ambiguous = []; $truePositives = 0; $unmatched = 0;
+        $progressBar = null;
+        if ($matched->count() > 100) {
+            $progressBar = $this->output->createProgressBar($matched->count());
+            $progressBar->start();
+        }
+        foreach ($matched as $c) {
+            $best = $matcher->findBestMatch($c->player_name, null);
+            $bestConf = (int) ($best['confidence'] ?? 0);
+            $bestUid  = (int) ($best['user_id'] ?? 0);
+            if ($bestConf >= 80 && $bestUid === (int) $c->uploader) {
+                $truePositives++;
+            } elseif ($bestConf >= 80 && $bestUid !== (int) $c->uploader && $bestUid > 0) {
+                $key = $this->normalizeAliasKey($c->player_name);
+                $ownerCount = $aliasOwners[$key] ?? 0;
+                $row = (object) [
+                    'demo_id'      => (int) $c->demo_id,
+                    'uploader'     => (int) $c->uploader,
+                    'player_name'  => $c->player_name,
+                    'record_id'    => (int) $c->record_id,
+                    'record_name'  => $c->record_name,
+                    'map_name'     => $c->map_name,
+                    'record_gametype' => $c->record_gametype,
+                    'time_ms'      => (int) $c->time_ms,
+                    'status'       => $c->status,
+                    'best_user_id' => (int) $best['user_id'],
+                    'best_alias'   => $best['matched_name'] ?? null,
+                    'owner_count'  => $ownerCount,
+                ];
+                if ($ownerCount >= 2) {
+                    $ambiguous[] = $row;
+                } else {
+                    $unique[] = $row;
+                }
+            } else {
+                $unmatched++;
+            }
+            if ($progressBar) $progressBar->advance();
+        }
+        if ($progressBar) { $progressBar->finish(); $this->newLine(); }
+
+        $this->info("  true-positive   (NameMatcher → uploader, ≥80%):       {$truePositives}  ⇒ ponechat");
+        $this->info("  unique unpair   (NameMatcher → JINÝ user, ≥80%, alias má 1 vlastníka): " . count($unique) . "  ⇒ unpair + offline_record pro správného usera");
+        $this->info("  ambiguous unpair (alias má ≥2 vlastníky, NameMatcher arbitrární): " . count($ambiguous) . "  ⇒ unpair, NEsuggestovat");
+        $this->info("  unmatched       (NameMatcher confidence < 80% / žádný): {$unmatched}  ⇒ ponechat");
+
+        $totalToProcess = count($unique) + count($ambiguous) + $superseded->count();
+        if ($totalToProcess === 0) {
+            $this->info('Nothing to do.');
+            return 0;
+        }
+
+        if ($limit > 0 && $totalToProcess > $limit) {
+            $this->warn("Limiting to first {$limit} item(s) (--limit={$limit}). Order: unique → ambiguous → superseded.");
+            $remaining = $limit;
+            $unique = array_slice($unique, 0, min($remaining, count($unique)));
+            $remaining -= count($unique);
+            $ambiguous = array_slice($ambiguous, 0, max(0, min($remaining, count($ambiguous))));
+            $remaining -= count($ambiguous);
+            $superseded = $superseded->take(max(0, $remaining));
+        }
+
+        // ---- Apply ----
+        if (!empty($unique)) {
+            $this->line('');
+            $this->info('--- UNIQUE false-positives (unpair + create offline_record for the correct user) ---');
+            foreach ($unique as $u) {
+                $bestUser = \App\Models\User::find($u->best_user_id);
+                $demo = UploadedDemo::find($u->demo_id);
+                $existingLiveRec = \App\Models\Record::where('mapname', $demo->map_name)
+                    ->where('gametype', 'run_' . str_replace('.tr','',strtolower($demo->physics ?? '')))
+                    ->where('time', $demo->time_ms)
+                    ->where('user_id', $u->best_user_id)
+                    ->first(['id', 'time']);
+                $this->line('');
+                $this->line("demo #{$u->demo_id}  {$u->map_name} | {$u->record_gametype} | {$u->time_ms}ms  player='{$u->player_name}'");
+                $this->line("  current: rec={$u->record_id} owner='{$u->record_name}' (user_id={$u->uploader})  status={$u->status}");
+                $this->line("  NameMatcher: → user_id={$u->best_user_id} (" . ($bestUser?->name ?? '?') . ")  alias='{$u->best_alias}'");
+                if ($existingLiveRec) {
+                    $this->line("  action: napárovat na live record {$existingLiveRec->id} (správný vlastník)");
+                    if (!$dryRun) {
+                        DB::transaction(function () use ($u, $existingLiveRec) {
+                            UploadedDemo::where('id', $u->demo_id)->update([
+                                'record_id'        => $existingLiveRec->id,
+                                'status'           => 'assigned',
+                                'name_confidence'  => 100,
+                                'suggested_user_id'=> $u->best_user_id,
+                                'matched_alias'    => $u->best_alias,
+                                'match_method'     => 'fp_cleanup_to_live',
+                            ]);
+                        });
+                    }
+                } else {
+                    $this->line("  action: vytvořit offline_record pod " . ($bestUser?->name ?? '?'));
+                    if (!$dryRun) {
+                        DB::transaction(function () use ($u, $demo) {
+                            // Unpair from neiT and stamp the correct attribution.
+                            UploadedDemo::where('id', $u->demo_id)->update([
+                                'record_id'        => null,
+                                'status'           => 'assigned',
+                                'name_confidence'  => 100,
+                                'suggested_user_id'=> $u->best_user_id,
+                                'matched_alias'    => $u->best_alias,
+                                'match_method'     => 'fp_cleanup_offline',
+                            ]);
+                            $this->createOfflineRecordForDemo($demo, $u->player_name);
+                        });
+                    }
+                }
+            }
+        }
+
+        if (!empty($ambiguous)) {
+            $this->line('');
+            $this->info('--- AMBIGUOUS false-positives (unpair only, no auto-suggest) ---');
+            foreach ($ambiguous as $a) {
+                $bestUser = \App\Models\User::find($a->best_user_id);
+                $this->line('');
+                $this->line("demo #{$a->demo_id}  {$a->map_name} | {$a->record_gametype} | {$a->time_ms}ms  player='{$a->player_name}'");
+                $this->line("  current: rec={$a->record_id} owner='{$a->record_name}' (user_id={$a->uploader})  status={$a->status}");
+                $this->line("  NameMatcher arbitrarily picked: user_id={$a->best_user_id} (" . ($bestUser?->name ?? '?') . ")  but alias '{$a->player_name}' is shared by {$a->owner_count} registered users");
+                $this->line("  action: record_id=NULL, status=processed, suggested_user_id=NULL (ručně dořešit)");
+                if (!$dryRun) {
+                    DB::transaction(function () use ($a) {
+                        UploadedDemo::where('id', $a->demo_id)->update([
+                            'record_id'        => null,
+                            'status'           => 'processed',
+                            'suggested_user_id'=> null,
+                        ]);
+                    });
+                }
+            }
+        }
+
+        if ($superseded->isNotEmpty()) {
+            $this->line('');
+            $this->info('--- SUPERSEDED demos (record soft-deleted) ---');
+            foreach ($superseded as $s) {
+                $this->line('');
+                $this->line("demo #{$s->demo_id}  {$s->map_name} | {$s->time_ms}ms  player='{$s->player_name}'  rec={$s->record_id} (soft-deleted {$s->deleted_at})");
+                $this->line('  action: record_id=NULL, status=processed (rematch potom přiřadí přes Pass 2)');
+                if (!$dryRun) {
+                    DB::transaction(function () use ($s) {
+                        UploadedDemo::where('id', $s->demo_id)->update([
+                            'record_id' => null,
+                            'status'    => 'processed',
+                        ]);
+                    });
+                }
+            }
+        }
+
+        $this->line('');
+        $totalUnpaired = count($unique) + count($ambiguous) + $superseded->count();
+        if ($dryRun) {
+            $this->info("DRY RUN: would unpair {$totalUnpaired} demos (unique:" . count($unique) . " ambiguous:" . count($ambiguous) . " superseded:{$superseded->count()}).");
+        } else {
+            $this->info("Done. Unpaired {$totalUnpaired} demos (unique:" . count($unique) . " ambiguous:" . count($ambiguous) . " superseded:{$superseded->count()}).");
+            $this->info('Run `php artisan demos:rematch-all` afterwards so Pass 2 can attach these demos to the correct users (their existing records or new offline_records).');
+        }
+
+        return 0;
+    }
+
+    /**
+     * Build a map of alias → number of distinct registered users that own
+     * it. Used to detect ambiguous aliases where NameMatcher's
+     * first-write-wins rule produces an arbitrary pick.
+     */
+    protected function buildAliasOwnerCounts(): array
+    {
+        $rows = UserAlias::where('is_approved', true)
+            ->whereNotNull('user_id')
+            ->get(['user_id', 'alias', 'alias_colored']);
+
+        $byKey = [];
+        foreach ($rows as $row) {
+            foreach ([$row->alias, $row->alias_colored] as $name) {
+                if (empty($name)) continue;
+                $key = $this->normalizeAliasKey($name);
+                if ($key === '') continue;
+                $byKey[$key][$row->user_id] = true;
+            }
+        }
+        $counts = [];
+        foreach ($byKey as $k => $users) {
+            $counts[$k] = count($users);
+        }
+        return $counts;
+    }
+
+    /**
+     * Mirror of NameMatcher's stripColorCodes + lowercase used for the
+     * exact-match alias index, so ambiguity counts line up with what
+     * NameMatcher actually keys on.
+     */
+    protected function normalizeAliasKey(string $name): string
+    {
+        return strtolower(trim(preg_replace('/\^[0-9\[\]]/', '', $name)));
+    }
+
+    /**
+     * Create an offline_record for an unpaired false-positive demo so the
+     * historical attempt surfaces under the correct player. Mirrors the rank
+     * cascade in DemoProcessorService::createOfflineRecord but without the
+     * file_path / validity_flag plumbing — these demos already have a stored
+     * file from the original (incorrect) processing.
+     */
+    protected function createOfflineRecordForDemo(UploadedDemo $demo, string $playerName): void
+    {
+        if (!$demo->map_name || !$demo->physics || !$demo->gametype || !$demo->time_ms) {
+            return;
+        }
+        if (OfflineRecord::where('demo_id', $demo->id)->exists()) {
+            return;
+        }
+        $fasterTimes = OfflineRecord::where('map_name', $demo->map_name)
+            ->where('physics', $demo->physics)
+            ->where('gametype', $demo->gametype)
+            ->whereNull('validity_flag')
+            ->where('time_ms', '<', $demo->time_ms)
+            ->count();
+        $offline = OfflineRecord::create([
+            'map_name'    => $demo->map_name,
+            'physics'     => $demo->physics,
+            'gametype'    => $demo->gametype,
+            'time_ms'     => $demo->time_ms,
+            'player_name' => $playerName,
+            'demo_id'     => $demo->id,
+            'rank'        => $fasterTimes + 1,
+            'date_set'    => $demo->record_date ?? $demo->created_at,
+        ]);
+        // Bump rank of any slower offline_records in the same bucket so
+        // ranks stay contiguous (mirrors RematchAllDemos::ensureOfflineRecord).
+        OfflineRecord::where('map_name', $demo->map_name)
+            ->where('physics', $demo->physics)
+            ->where('gametype', $demo->gametype)
+            ->whereNull('validity_flag')
+            ->where('time_ms', '>=', $demo->time_ms)
+            ->where('id', '!=', $offline->id)
+            ->increment('rank');
+    }
+}

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -485,12 +485,24 @@ class MapsController extends Controller
         $cpmFlaggedIds = $cpmRecords->getCollection()->filter(fn ($r) => !empty($r->approved_flags))->pluck('id')->toArray();
         $allCpmFlaggedIds = RecordFlag::where('status', 'approved')->whereNotNull('record_id')
             ->whereIn('record_id', $allCpmRecordsByTime)->pluck('record_id')->unique()->toArray();
-        // Also check flags via demos
+        // Also check flags via demos. Group by record_id so multiple demos
+        // pointing to the same record are all considered (defensive — the
+        // 1-record-1-demo guard in DemoAutoAssigner enforces uniqueness for
+        // new assignments, but legacy duplicates may still exist).
         $cpmDemoFlaggedRecordIds = [];
-        $cpmRecordDemoIds = UploadedDemo::whereIn('record_id', $allCpmRecordsByTime)->whereNotNull('record_id')->pluck('id', 'record_id')->toArray();
-        if (!empty($cpmRecordDemoIds)) {
-            $flaggedDemoIds = RecordFlag::where('status', 'approved')->whereIn('demo_id', array_values($cpmRecordDemoIds))->pluck('demo_id')->unique()->toArray();
-            $cpmDemoFlaggedRecordIds = collect($cpmRecordDemoIds)->filter(fn ($demoId) => in_array($demoId, $flaggedDemoIds))->keys()->toArray();
+        $cpmRecordDemoIdMap = UploadedDemo::whereIn('record_id', $allCpmRecordsByTime)
+            ->whereNotNull('record_id')
+            ->get(['id', 'record_id'])
+            ->groupBy('record_id')
+            ->map(fn ($demos) => $demos->pluck('id')->all())
+            ->toArray();
+        if (!empty($cpmRecordDemoIdMap)) {
+            $allCpmDemoIds = collect($cpmRecordDemoIdMap)->flatten()->unique()->values()->all();
+            $flaggedDemoIds = RecordFlag::where('status', 'approved')->whereIn('demo_id', $allCpmDemoIds)->pluck('demo_id')->unique()->toArray();
+            $cpmDemoFlaggedRecordIds = collect($cpmRecordDemoIdMap)
+                ->filter(fn ($demoIds) => !empty(array_intersect($demoIds, $flaggedDemoIds)))
+                ->keys()
+                ->toArray();
         }
         $allCpmFlaggedIds = array_unique(array_merge($allCpmFlaggedIds, $cpmDemoFlaggedRecordIds));
 
@@ -529,10 +541,19 @@ class MapsController extends Controller
 
         $allVq3FlaggedIds = RecordFlag::where('status', 'approved')->whereNotNull('record_id')
             ->whereIn('record_id', $allVq3RecordsByTime)->pluck('record_id')->unique()->toArray();
-        $vq3RecordDemoIds = UploadedDemo::whereIn('record_id', $allVq3RecordsByTime)->whereNotNull('record_id')->pluck('id', 'record_id')->toArray();
-        if (!empty($vq3RecordDemoIds)) {
-            $flaggedDemoIds = RecordFlag::where('status', 'approved')->whereIn('demo_id', array_values($vq3RecordDemoIds))->pluck('demo_id')->unique()->toArray();
-            $vq3DemoFlaggedRecordIds = collect($vq3RecordDemoIds)->filter(fn ($demoId) => in_array($demoId, $flaggedDemoIds))->keys()->toArray();
+        $vq3RecordDemoIdMap = UploadedDemo::whereIn('record_id', $allVq3RecordsByTime)
+            ->whereNotNull('record_id')
+            ->get(['id', 'record_id'])
+            ->groupBy('record_id')
+            ->map(fn ($demos) => $demos->pluck('id')->all())
+            ->toArray();
+        if (!empty($vq3RecordDemoIdMap)) {
+            $allVq3DemoIds = collect($vq3RecordDemoIdMap)->flatten()->unique()->values()->all();
+            $flaggedDemoIds = RecordFlag::where('status', 'approved')->whereIn('demo_id', $allVq3DemoIds)->pluck('demo_id')->unique()->toArray();
+            $vq3DemoFlaggedRecordIds = collect($vq3RecordDemoIdMap)
+                ->filter(fn ($demoIds) => !empty(array_intersect($demoIds, $flaggedDemoIds)))
+                ->keys()
+                ->toArray();
             $allVq3FlaggedIds = array_unique(array_merge($allVq3FlaggedIds, $vq3DemoFlaggedRecordIds));
         }
 

--- a/app/Models/Record.php
+++ b/app/Models/Record.php
@@ -72,6 +72,31 @@ class Record extends Model
             }
         });
 
+        // Before delete (soft or hard), detach any UploadedDemos pointing at
+        // this Record. Otherwise demos would dangle on a soft-deleted record
+        // (frontend hides soft-deleted records, so the demo would vanish
+        // from the UI). After detach, the next demos:rematch-all run will
+        // attribute the demo to its real player via Pass 2 (fuzzy nick) and
+        // create an offline_record so the historical attempt surfaces under
+        // the player's current live record as a Time History sibling.
+        static::deleting(function ($record) {
+            $detached = \App\Models\UploadedDemo::where('record_id', $record->id)
+                ->whereIn('status', ['assigned', 'fallback-assigned'])
+                ->update([
+                    'record_id' => null,
+                    'status'    => 'processed',
+                ]);
+            if ($detached > 0) {
+                \Illuminate\Support\Facades\Log::info('Auto-detached uploaded_demos from record being deleted', [
+                    'record_id' => $record->id,
+                    'mapname' => $record->mapname,
+                    'gametype' => $record->gametype,
+                    'time' => $record->time,
+                    'detached_count' => $detached,
+                ]);
+            }
+        });
+
         // On delete, decrement counts and invalidate affected pages
         static::deleted(function ($record) {
             if ($record->mdd_id) {

--- a/app/Models/UserAlias.php
+++ b/app/Models/UserAlias.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\NameMatcher;
 use Illuminate\Database\Eloquent\Model;
 
 class UserAlias extends Model
@@ -12,6 +13,22 @@ class UserAlias extends Model
         'is_approved' => 'boolean',
         'usage_count' => 'integer',
     ];
+
+    /**
+     * Invalidate NameMatcher cache whenever an alias is added, edited or
+     * removed so the in-memory + Cache::-backed alias index reflects the
+     * change immediately. Without this, admins adding a new alias via the
+     * Filament UI would have to wait up to 5 minutes (cache TTL) before a
+     * rematch run can pick it up.
+     */
+    protected static function booted(): void
+    {
+        $invalidate = function () {
+            app(NameMatcher::class)->clearCache();
+        };
+        static::saved($invalidate);
+        static::deleted($invalidate);
+    }
 
     public function user()
     {

--- a/app/Services/DemoAutoAssignContext.php
+++ b/app/Services/DemoAutoAssignContext.php
@@ -40,8 +40,14 @@ class DemoAutoAssignContext
     public static function build(): self
     {
         $index = [];
+        // Exclude soft-deleted records — they're hidden from the frontend
+        // (Record uses SoftDeletes), so attaching demos to them just makes
+        // the demo invisible in the UI. The Eloquent path in
+        // DemoAutoAssigner::findRecordId already respects this via the
+        // SoftDeletes global scope; we mirror that here for the raw query.
         DB::table('records')
             ->select(['id', 'mapname', 'gametype', 'time', 'user_id'])
+            ->whereNull('deleted_at')
             ->orderBy('id')
             ->chunk(20000, function ($chunk) use (&$index) {
                 foreach ($chunk as $r) {

--- a/app/Services/DemoAutoAssigner.php
+++ b/app/Services/DemoAutoAssigner.php
@@ -124,32 +124,52 @@ class DemoAutoAssigner
             }
         }
 
-        // PASS 1: uploader has a Record at this map/gametype/time.
-        // Ignores name entirely — uploader identity is authoritative.
+        // PASS 1: uploader has a Record at this map/gametype/time AND the
+        // demo's player_name actually resolves to that uploader via the
+        // alias system. The name verification guards against bulk-uploader
+        // accounts (e.g. an admin importing third-party demos): without it,
+        // any cizí demo with a time matching one of the uploader's own
+        // Records would be wrongly stamped as the uploader's run.
         if ($demo->user_id) {
             $uploaderRecordId = $this->findRecordId($ctx, $demo->map_name, $gametype, (int) $demo->time_ms, (int) $demo->user_id);
 
             if ($uploaderRecordId !== null) {
-                $this->upgradeOfflineRecordToOnline($demo);
+                $nameMatch = $this->nameMatcher->findBestMatch($demo->player_name, null);
+                $playerMatchesUploader = ($nameMatch['confidence'] === 100 && (int) $nameMatch['user_id'] === (int) $demo->user_id);
 
-                $demo->update([
-                    'record_id'        => $uploaderRecordId,
-                    'status'           => 'assigned',
-                    'name_confidence'  => 100,
-                    'suggested_user_id'=> $demo->user_id,
-                    'matched_alias'    => null,
-                    'match_method'     => 'uploader_record',
-                ]);
+                if ($playerMatchesUploader) {
+                    $this->upgradeOfflineRecordToOnline($demo);
 
-                Log::info('Demo auto-assigned to uploader\'s record', [
+                    $demo->update([
+                        'record_id'        => $uploaderRecordId,
+                        'status'           => 'assigned',
+                        'name_confidence'  => 100,
+                        'suggested_user_id'=> $demo->user_id,
+                        'matched_alias'    => $nameMatch['matched_name'] ?? null,
+                        'match_method'     => 'uploader_record',
+                    ]);
+
+                    Log::info('Demo auto-assigned to uploader\'s record (name verified)', [
+                        'demo_id' => $demo->id,
+                        'record_id' => $uploaderRecordId,
+                        'user_id' => $demo->user_id,
+                        'matched_alias' => $nameMatch['matched_name'] ?? null,
+                        'gametype' => $gametype,
+                    ]);
+
+                    return self::OUTCOME_RECORD;
+                }
+
+                Log::info('Pass 1 skipped: uploader has matching record but demo player_name does not resolve to uploader', [
                     'demo_id' => $demo->id,
-                    'record_id' => $uploaderRecordId,
-                    'user_id' => $demo->user_id,
-                    'gametype' => $gametype,
-                    'file_path' => $demo->file_path,
+                    'uploader_user_id' => $demo->user_id,
+                    'player_name' => $demo->player_name,
+                    'name_match_user_id' => $nameMatch['user_id'] ?? null,
+                    'name_match_confidence' => $nameMatch['confidence'] ?? null,
+                    'candidate_record_id' => $uploaderRecordId,
                 ]);
-
-                return self::OUTCOME_RECORD;
+                // Fall through to Pass 2 (fuzzy nick) — that path will
+                // attribute the demo to the actual player.
             }
         }
 

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1792,9 +1792,10 @@
         />
 
         <!-- Assign Demo to Online Record Modal -->
-        <div v-if="showAssignModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50" @click="closeAssignModal">
-            <div class="bg-gray-900/95 rounded-xl p-8 w-full max-w-3xl max-h-[85vh] overflow-y-auto border border-white/10 shadow-2xl" @click.stop>
-                <div class="flex justify-between items-center mb-6">
+        <div v-if="showAssignModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" @click="closeAssignModal">
+            <div class="bg-gray-900/95 rounded-xl w-full max-w-3xl max-h-[90vh] flex flex-col border border-white/10 shadow-2xl" @click.stop>
+                <!-- Header (fixed) -->
+                <div class="flex justify-between items-center p-6 pb-4 border-b border-white/5">
                     <h3 class="text-xl font-bold text-gray-100">Assign Demo to Online Record</h3>
                     <button @click="closeAssignModal" class="text-gray-400 hover:text-gray-200 transition-colors">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1803,85 +1804,88 @@
                     </button>
                 </div>
 
-                <!-- Demo info -->
-                <div v-if="assigningRecord" class="mb-6 p-4 bg-gray-800/60 rounded-lg border border-white/5">
-                    <div class="grid grid-cols-2 gap-3">
-                        <div class="text-sm"><span class="text-gray-500">Map:</span> <span class="text-gray-200 font-medium">{{ map.name }}</span></div>
-                        <div class="text-sm"><span class="text-gray-500">Physics:</span> <span class="font-medium" :class="assignPhysics === 'CPM' ? 'text-purple-400' : 'text-blue-400'">{{ assignPhysics }}</span></div>
-                        <div class="text-sm"><span class="text-gray-500">Player:</span> <span class="text-gray-200 font-medium" v-html="q3tohtml(assigningRecord.player_name || assigningRecord.name)"></span></div>
-                        <div v-if="assigningRecord.time" class="text-sm"><span class="text-gray-500">Time:</span> <span class="text-gray-200 font-mono font-medium">{{ formatTime(assigningRecord.time) }}</span></div>
+                <!-- Scrollable content -->
+                <div class="flex-1 overflow-y-auto p-6 pt-4 space-y-4">
+                    <!-- Demo info -->
+                    <div v-if="assigningRecord" class="p-3 bg-gray-800/60 rounded-lg border border-white/5">
+                        <div class="grid grid-cols-2 gap-2">
+                            <div class="text-sm"><span class="text-gray-500">Map:</span> <span class="text-gray-200 font-medium">{{ map.name }}</span></div>
+                            <div class="text-sm"><span class="text-gray-500">Physics:</span> <span class="font-medium" :class="assignPhysics === 'CPM' ? 'text-purple-400' : 'text-blue-400'">{{ assignPhysics }}</span></div>
+                            <div class="text-sm"><span class="text-gray-500">Player:</span> <span class="text-gray-200 font-medium" v-html="q3tohtml(assigningRecord.player_name || assigningRecord.name)"></span></div>
+                            <div v-if="assigningRecord.time" class="text-sm"><span class="text-gray-500">Time:</span> <span class="text-gray-200 font-mono font-medium">{{ formatTime(assigningRecord.time) }}</span></div>
+                        </div>
                     </div>
-                </div>
 
-                <!-- Loading -->
-                <div v-if="loadingRecords" class="text-center py-8">
-                    <div class="text-gray-400 text-lg">Loading records...</div>
-                </div>
+                    <!-- Loading -->
+                    <div v-if="loadingRecords" class="text-center py-8">
+                        <div class="text-gray-400 text-lg">Loading records...</div>
+                    </div>
 
-                <!-- Suggested matches -->
-                <div v-if="!loadingRecords && suggestedRecords.length > 0" class="mb-5">
-                    <label class="block text-sm font-medium text-green-400 mb-2">
-                        Closest time matches
-                    </label>
-                    <div class="border border-green-700/30 rounded-lg bg-green-900/10 overflow-hidden">
-                        <button
-                            v-for="record in suggestedRecords"
-                            :key="'suggested-' + record.id"
-                            @click="selectedRecordId = record.id"
-                            :class="[
-                                'w-full text-left px-4 py-3 hover:bg-green-800/20 border-b border-green-800/20 last:border-b-0 transition-all',
-                                selectedRecordId === record.id ? 'bg-green-600/20 ring-1 ring-green-500/50' : ''
-                            ]"
-                        >
-                            <div class="flex justify-between items-center">
-                                <div class="flex items-center gap-3">
-                                    <span class="text-gray-500 font-bold text-sm w-8 text-right">#{{ record.rank }}</span>
-                                    <span class="text-base" v-html="q3tohtml(record.player_name)"></span>
+                    <!-- Suggested matches -->
+                    <div v-if="!loadingRecords && suggestedRecords.length > 0">
+                        <label class="block text-sm font-medium text-green-400 mb-2">
+                            Closest time matches
+                        </label>
+                        <div class="border border-green-700/30 rounded-lg bg-green-900/10 overflow-hidden">
+                            <button
+                                v-for="record in suggestedRecords"
+                                :key="'suggested-' + record.id"
+                                @click="selectedRecordId = record.id"
+                                :class="[
+                                    'w-full text-left px-4 py-2 hover:bg-green-800/20 border-b border-green-800/20 last:border-b-0 transition-all',
+                                    selectedRecordId === record.id ? 'bg-green-600/20 ring-1 ring-green-500/50' : ''
+                                ]"
+                            >
+                                <div class="flex justify-between items-center">
+                                    <div class="flex items-center gap-3">
+                                        <span class="text-gray-500 font-bold text-sm w-8 text-right">#{{ record.rank }}</span>
+                                        <span class="text-base" v-html="q3tohtml(record.player_name)"></span>
+                                    </div>
+                                    <div class="flex items-center gap-3">
+                                        <span class="text-xs text-gray-500" :class="record.timeDiff === 0 ? 'text-green-400 font-bold' : ''">
+                                            {{ record.timeDiff === 0 ? 'EXACT' : (record.timeDiff < 1000 ? record.timeDiff + 'ms' : formatTime(record.timeDiff)) + ' diff' }}
+                                        </span>
+                                        <span class="text-sm font-mono" :class="selectedRecordId === record.id ? 'text-green-300' : 'text-gray-400'">{{ record.formatted_time }}</span>
+                                    </div>
                                 </div>
-                                <div class="flex items-center gap-3">
-                                    <span class="text-xs text-gray-500" :class="record.timeDiff === 0 ? 'text-green-400 font-bold' : ''">
-                                        {{ record.timeDiff === 0 ? 'EXACT' : (record.timeDiff < 1000 ? record.timeDiff + 'ms' : formatTime(record.timeDiff)) + ' diff' }}
-                                    </span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Records list -->
+                    <div v-if="!loadingRecords && availableRecords.length > 0">
+                        <label class="block text-sm font-medium text-gray-400 mb-2">
+                            All records ({{ availableRecords.length }})
+                        </label>
+                        <div class="max-h-[220px] overflow-y-auto border border-gray-700/50 rounded-lg">
+                            <button
+                                v-for="record in availableRecords"
+                                :key="record.id"
+                                @click="selectedRecordId = record.id"
+                                :class="[
+                                    'w-full text-left px-4 py-2 hover:bg-white/5 border-b border-gray-800/50 last:border-b-0 transition-all',
+                                    selectedRecordId === record.id ? 'bg-green-600/20 ring-1 ring-green-500/50' : ''
+                                ]"
+                            >
+                                <div class="flex justify-between items-center">
+                                    <div class="flex items-center gap-3">
+                                        <span class="text-gray-500 font-bold text-sm w-8 text-right">#{{ record.rank }}</span>
+                                        <span class="text-base" v-html="q3tohtml(record.player_name)"></span>
+                                    </div>
                                     <span class="text-sm font-mono" :class="selectedRecordId === record.id ? 'text-green-300' : 'text-gray-400'">{{ record.formatted_time }}</span>
                                 </div>
-                            </div>
-                        </button>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- No records -->
+                    <div v-if="!loadingRecords && availableRecords.length === 0" class="text-center text-gray-400 py-8">
+                        No online records found for {{ map.name }} ({{ assignPhysics }})
                     </div>
                 </div>
 
-                <!-- Records list -->
-                <div v-if="!loadingRecords && availableRecords.length > 0" class="mb-6">
-                    <label class="block text-sm font-medium text-gray-400 mb-3">
-                        All records ({{ availableRecords.length }})
-                    </label>
-                    <div class="max-h-[400px] overflow-y-auto border border-gray-700/50 rounded-lg">
-                        <button
-                            v-for="record in availableRecords"
-                            :key="record.id"
-                            @click="selectedRecordId = record.id"
-                            :class="[
-                                'w-full text-left px-4 py-3 hover:bg-white/5 border-b border-gray-800/50 last:border-b-0 transition-all',
-                                selectedRecordId === record.id ? 'bg-green-600/20 ring-1 ring-green-500/50' : ''
-                            ]"
-                        >
-                            <div class="flex justify-between items-center">
-                                <div class="flex items-center gap-3">
-                                    <span class="text-gray-500 font-bold text-sm w-8 text-right">#{{ record.rank }}</span>
-                                    <span class="text-base" v-html="q3tohtml(record.player_name)"></span>
-                                </div>
-                                <span class="text-sm font-mono" :class="selectedRecordId === record.id ? 'text-green-300' : 'text-gray-400'">{{ record.formatted_time }}</span>
-                            </div>
-                        </button>
-                    </div>
-                </div>
-
-                <!-- No records -->
-                <div v-else class="mb-6 text-center text-gray-400 py-8">
-                    No online records found for {{ map.name }} ({{ assignPhysics }})
-                </div>
-
-                <!-- Action buttons -->
-                <div class="flex justify-end space-x-3 pt-2">
+                <!-- Action buttons (sticky footer) -->
+                <div class="flex justify-end space-x-3 p-6 pt-4 border-t border-white/5">
                     <button @click="closeAssignModal" class="px-5 py-2.5 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors">
                         Cancel
                     </button>


### PR DESCRIPTION
Pass 1 (uploader_record) historically attached any demo whose uploader matched a Record's owner without verifying the demo's player_name. Bulk uploader accounts (admin importing third-party demos) ended up stamping someone else's runs as their own. Pass 1 now verifies via NameMatcher that player_name resolves to the uploader before assigning.

Records use SoftDeletes; demos pointing at a soft-deleted record were hidden from the UI but still attributed to the wrong owner. Added a deleting() observer on Record that auto-detaches paired uploaded_demos (record_id=NULL, status=processed) so future record overrides don't strand demos.

Fixed DemoAutoAssignContext to exclude soft-deleted records from the preloaded index; the raw DB::table query bypassed the SoftDeletes scope, letting batch rematches re-attach demos to dead records.

Added demos:resolve-duplicate-assignments artisan command to clean up the historical mess (false-positive Pass 1 + stranded demos) with NameMatcher-based detection at >=80% confidence; for unique false positives it creates an offline_record under the correct user directly.

RematchAllDemos: --status=X filter for targeted rematches, plus parity with DemoProcessorService - OUTCOME_NONE with >=80% name confidence now creates an offline_record so unpaired demos surface on the right profile.

UserAlias: invalidate NameMatcher cache on save/delete so admins adding aliases through Filament see effects immediately on the next rematch.

MapsController: defensive groupBy when looking up demo IDs by record_id so legitimate alt demos (different file_hash, same time) all contribute to flag detection instead of one collapsing the other.

MapView: refactor Assign Demo modal into flex column layout with sticky header/footer so the Assign button is always visible without scrolling; shrink the All records list height for compact display.