### PR TITLE
Skip null player_name in resolve-duplicate-assignments

### DIFF
--- a/app/Console/Commands/ResolveDuplicateDemoAssignments.php
+++ b/app/Console/Commands/ResolveDuplicateDemoAssignments.php
@@ -96,6 +96,14 @@ class ResolveDuplicateDemoAssignments extends Command
             $progressBar->start();
         }
         foreach ($matched as $c) {
+            // Skip rows whose player_name was never extracted (legacy upload
+            // where parsing failed) — NameMatcher requires a string and we
+            // can't reason about ownership without one.
+            if (empty($c->player_name)) {
+                $unmatched++;
+                if ($progressBar) $progressBar->advance();
+                continue;
+            }
             $best = $matcher->findBestMatch($c->player_name, null);
             $bestConf = (int) ($best['confidence'] ?? 0);
             $bestUid  = (int) ($best['user_id'] ?? 0);


### PR DESCRIPTION
NameMatcher::findBestMatch type-hints string, blew up on legacy demo rows whose player_name was never parsed. Treat them as unmatched and move on.