### PR TITLE
Bug fixes: time format, render badge, header search aliases

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -7,6 +7,7 @@ use App\Models\Map;
 use App\Models\User;
 use App\Models\MddProfile;
 use App\Models\PlayerModel;
+use App\Models\UserAlias;
 
 class SearchController extends Controller
 {
@@ -16,6 +17,8 @@ class SearchController extends Controller
         ]);
 
         $fuzzyPattern = '%' . implode('%', mb_str_split(strtolower(trim($request->search)))) . '%';
+        $rawSearch = trim($request->search);
+        $likeSearch = '%' . $rawSearch . '%';
 
         // Typesense search + DB fuzzy fallback for maps
         $maps = Map::search($request->search)->paginate(25);
@@ -32,6 +35,56 @@ class SearchController extends Controller
         if ($users->isEmpty() && $profiles->isEmpty()) {
             $users = User::where('plain_name', 'LIKE', $fuzzyPattern)->limit(25)->get();
             $profiles = MddProfile::where('name', 'LIKE', $fuzzyPattern)->limit(25)->get();
+        }
+
+        // Alias-based lookup. Names like "uN-DeaD!zatinU" or "Spasibo" only
+        // exist in user_aliases (user changed nick mid-career), so a Typesense
+        // hit on User.plain_name / MddProfile.name will miss them. Pull any
+        // matching alias and fold the owning User / MddProfile into the result
+        // set, remembering the literal alias for `matched_alias` display.
+        // Approved-only — non-approved aliases are noise (auto-generated from
+        // log scrapes, may include impersonations).
+        $aliasMatches = UserAlias::where('is_approved', true)
+            ->where('alias', 'LIKE', $likeSearch)
+            ->orderByDesc('usage_count')
+            ->limit(50)
+            ->get(['user_id', 'mdd_id', 'alias']);
+
+        // Map of mdd_id -> alias and user_id -> alias so we can decorate
+        // existing search hits with their matched_alias even when the primary
+        // hit was via plain_name (covers the case where someone has both a
+        // matching plain name and a matching alias).
+        $aliasByUserId = [];
+        $aliasByMddId  = [];
+        foreach ($aliasMatches as $a) {
+            if ($a->user_id && !isset($aliasByUserId[$a->user_id])) {
+                $aliasByUserId[$a->user_id] = $a->alias;
+            }
+            if ($a->mdd_id && !isset($aliasByMddId[$a->mdd_id])) {
+                $aliasByMddId[$a->mdd_id] = $a->alias;
+            }
+        }
+
+        // Pull users / profiles referenced by aliases that aren't already in
+        // the result set, and merge them in.
+        $existingUserIds = $users->pluck('id')->all();
+        $missingUserIds  = array_diff(array_keys($aliasByUserId), $existingUserIds);
+        if (!empty($missingUserIds)) {
+            $users = $users->merge(User::whereIn('id', $missingUserIds)->get());
+        }
+
+        $existingMddIds = $profiles->pluck('id')->all();
+        // Only fetch mdd profiles whose alias has no user_id — when a
+        // user_id IS set on the alias, we surface the User instead (matches
+        // the existing "linkedUserId → show user, not profile" branch below).
+        $orphanMddIds = [];
+        foreach ($aliasMatches as $a) {
+            if ($a->mdd_id && !$a->user_id && !in_array($a->mdd_id, $existingMddIds, true)) {
+                $orphanMddIds[$a->mdd_id] = true;
+            }
+        }
+        if (!empty($orphanMddIds)) {
+            $profiles = $profiles->merge(MddProfile::whereIn('id', array_keys($orphanMddIds))->get());
         }
 
         $players = [];
@@ -52,6 +105,7 @@ class SearchController extends Controller
                         'profile_photo_path'    => $linkedUser->profile_photo_path,
                         'mdd'                   => false,
                         'mdd_name'              => $profile->name,
+                        'matched_alias'         => $aliasByUserId[$linkedUser->id] ?? $aliasByMddId[$profile->id] ?? null,
                     ];
                 }
                 continue;
@@ -62,11 +116,12 @@ class SearchController extends Controller
                 'name'                  => $profile->name,
                 'country'               => $profile->country,
                 'profile_photo_path'    => NULL,
-                'mdd'                   => true
+                'mdd'                   => true,
+                'matched_alias'         => $aliasByMddId[$profile->id] ?? null,
             ];
         }
 
-        $players = array_merge($players, $users->map(function($user) use ($request) {
+        $players = array_merge($players, $users->map(function($user) use ($request, $aliasByUserId) {
             $mddName = null;
             if ($user->mdd_id) {
                 $mddProfile = MddProfile::find($user->mdd_id);
@@ -75,15 +130,22 @@ class SearchController extends Controller
                 }
             }
 
-            // Find matching alias for search term
-            $matchedAlias = null;
-            $search = mb_strtolower($request->search);
-            $aliases = $user->aliases()->where('is_approved', true)->pluck('alias');
-            foreach ($aliases as $alias) {
-                $aliasPlain = preg_replace('/\^[\dA-Fa-f]/', '', $alias);
-                if (str_contains(mb_strtolower($aliasPlain), $search)) {
-                    $matchedAlias = $alias;
-                    break;
+            // Prefer the alias the global lookup already found (already
+            // matches the search term). Fall back to scanning the user's
+            // approved aliases for a substring match — covers edge cases
+            // where the alias lookup didn't hit due to leetspeak / colour
+            // differences but the user's `aliases` relation has a stripped
+            // version that does match.
+            $matchedAlias = $aliasByUserId[$user->id] ?? null;
+            if ($matchedAlias === null) {
+                $search = mb_strtolower($request->search);
+                $aliases = $user->aliases()->where('is_approved', true)->pluck('alias');
+                foreach ($aliases as $alias) {
+                    $aliasPlain = preg_replace('/\^[\dA-Fa-f]/', '', $alias);
+                    if (str_contains(mb_strtolower($aliasPlain), $search)) {
+                        $matchedAlias = $alias;
+                        break;
+                    }
                 }
             }
 

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -75,10 +75,22 @@
     const showRenderConfirm = ref(false);
 
     const renderedVideo = computed(() => {
-        if (props.record.rendered_videos && props.record.rendered_videos.length > 0) {
-            return props.record.rendered_videos[0];
-        }
-        return null;
+        const videos = props.record.rendered_videos;
+        if (!videos || videos.length === 0) return null;
+        if (videos.length === 1) return videos[0];
+
+        // A record can have several rendered_videos (re-render attempts,
+        // updated metadata, server-then-uploader demos that both got rendered).
+        // Picking videos[0] from the latest()-ordered backend list means a
+        // newer 'failed' attempt hides an older 'completed' one — the user
+        // sees a "render failed" badge on a record whose YouTube video is
+        // perfectly fine. Pick the most useful status instead.
+        const priority = { completed: 0, uploading: 1, rendering: 2, pending: 3, failed: 4 };
+        return [...videos].sort((a, b) => {
+            const pa = priority[a.status] ?? 99;
+            const pb = priority[b.status] ?? 99;
+            return pa - pb;
+        })[0];
     });
 
     const needsVerify = computed(() => isLoggedIn.value && !page.props.isVerified);

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -1006,7 +1006,15 @@
     const flagDemoId = ref(null);
 
     const getRenderedVideo = (record) => {
-        return record.rendered_videos?.[0] || record.uploaded_demos?.[0]?.rendered_video || null;
+        // Same status-priority pick as MapRecord.vue — a newer 'failed'
+        // attempt must not hide an older 'completed' one in the badge.
+        const videos = record.rendered_videos;
+        if (videos && videos.length > 0) {
+            if (videos.length === 1) return videos[0];
+            const priority = { completed: 0, uploading: 1, rendering: 2, pending: 3, failed: 4 };
+            return [...videos].sort((a, b) => (priority[a.status] ?? 99) - (priority[b.status] ?? 99))[0];
+        }
+        return record.uploaded_demos?.[0]?.rendered_video || null;
     };
 
     const canRequestRender = (record) => {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -42,26 +42,25 @@ const appName = import.meta.env.VITE_APP_NAME || 'Defrag Racing';
 
 const formatTime = (milliseconds) => {
     milliseconds = Math.max(0, milliseconds);
-  
-    const hours = Math.floor(milliseconds / 3600000);
-    milliseconds %= 3600000;
+
+    // Defrag's smallest practical run is sub-minute and the largest pushes
+    // a couple hours, but the engine itself only ever displays MM:SS.mmm
+    // (minutes rolling past 60, never an "H:" prefix). Match that — a
+    // 1:30:45.123 hh:mm:ss display would just confuse players used to
+    // reading "90:45.123" off the in-game timer.
     const minutes = Math.floor(milliseconds / 60000);
     milliseconds %= 60000;
     const seconds = Math.floor(milliseconds / 1000);
     milliseconds %= 1000;
-  
+
     let formattedTime = '';
-  
-    if (hours > 0) {
-      formattedTime += `${hours}:`;
-    }
-  
-    if (minutes > 0 || hours > 0) {
+
+    if (minutes > 0) {
       formattedTime += `${padZero(minutes)}:`;
     }
-  
+
     formattedTime += `${padZero(seconds)}:${milliseconds.toString().padStart(3, '0')}`;
-  
+
     return formattedTime;
 };
 


### PR DESCRIPTION
## Summary
- Drop the "H:" prefix from `formatTime` so long maps display as `90:45.123` (matching Defrag's in-game timer) instead of `1:30:45.123`.
- Pick the best-status `rendered_video` for a record's badge — a newer `failed` re-render attempt no longer hides an older `completed` YouTube video.
- Header global search now surfaces players whose only matching field is an approved alias (e.g. `zatinU` finds the uN-DeaD player whose primary mdd name is `Tutty.TH`). Works for both User-linked and orphan MDD-only aliases.

## Test plan
- [ ] Open a map with rendered videos that span over an hour — time displays as `MM:SS.mmm` (no hours)
- [ ] Open `hangtime2-3` on production: time-history demo with completed YouTube video shows the YouTube icon, not "render failed"
- [ ] Header search `zatinU` returns Tutty.TH (mdd 10870) with `alias: uN-DeaD!zatinU` shown
- [ ] Header search `Spasibo` still returns w00dy with the alias decoration
- [ ] Header search `Daan` still returns Daan as the primary hit
