### PR TITLE
Map stats page + servers / random-map UX polish

### DIFF
--- a/app/Console/Commands/RebuildMapStats.php
+++ b/app/Console/Commands/RebuildMapStats.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\MapStatsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class RebuildMapStats extends Command
+{
+    protected $signature = 'mapstats:rebuild {--export : also write a gzipped JSON snapshot to storage/app/public/exports/maps-stats.json[.gz]}';
+    protected $description = 'Refresh the cached MapStats payload (and optionally export it as a gzipped JSON snapshot).';
+
+    public function handle(MapStatsService $stats): int
+    {
+        $this->info('Clearing MapStats cache...');
+        $stats->clearCache();
+
+        $this->info('Rebuilding aggregates (cold)...');
+        $start = microtime(true);
+        $payload = $stats->all();
+        $ms = (int) round((microtime(true) - $start) * 1000);
+        $this->info("Rebuilt in {$ms} ms — " . count($payload['cpm']) . ' CPM + ' . count($payload['vq3']) . ' VQ3 maps.');
+
+        if (!$this->option('export')) {
+            return self::SUCCESS;
+        }
+
+        // Wired but not scheduled. Snapshot lives under storage/app/public/exports/
+        // so `php artisan storage:link` exposes it under /storage/exports/...
+        // — turn the cron back on once a public consumer needs it.
+        $disk = Storage::disk('public');
+        $disk->makeDirectory('exports');
+
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $disk->put('exports/maps-stats.json', $json);
+        $disk->put('exports/maps-stats.json.gz', gzencode($json, 6));
+
+        $this->info('Wrote storage/app/public/exports/maps-stats.json (' . round(strlen($json) / 1024) . ' kB) and .gz (' . round(strlen(gzencode($json, 6)) / 1024) . ' kB)');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -50,6 +50,10 @@ class Kernel extends ConsoleKernel
         // Recalculate all player profile stats (WRs, totals, avg rank, etc.) daily at 3am
         $schedule->command('process-all-player-stats')->withoutOverlapping()->dailyAt('03:00');
 
+        // Refresh the /maps/stats cache. ~15s, run after the player-stats
+        // recalc so the page never serves a cold cache to a visitor.
+        $schedule->command('mapstats:rebuild')->withoutOverlapping()->dailyAt('04:00');
+
         // Unlock demos stuck in 'processing' for more than 15 minutes and re-queue them
         $schedule->command('demos:unlock-stuck')->withoutOverlapping()->everyFiveMinutes();
 

--- a/app/Http/Controllers/MapStatsController.php
+++ b/app/Http/Controllers/MapStatsController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\MapStatsService;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class MapStatsController extends Controller
+{
+    public function __construct(private MapStatsService $stats) {}
+
+    /**
+     * Public stats dashboard — Plotly-rendered charts on the client.
+     */
+    public function index(Request $request)
+    {
+        return Inertia::render('MapStats', [
+            'stats' => fn () => $this->stats->all(),
+        ]);
+    }
+
+    /**
+     * Raw JSON dump of the cached payload. NOT routed — bandwidth
+     * amplification risk on a 4 MB response with no auth. Wire it up in
+     * routes/web.php with throttle:30,60 if a public consumer needs it:
+     *
+     *   Route::get('/api/stats/maps.json', [MapStatsController::class, 'exportJson'])
+     *       ->middleware('throttle:30,60')
+     *       ->name('api.stats.maps');
+     *
+     * ETag + stale-while-revalidate let CDNs and notebook clients
+     * short-circuit repeat reads with 304s.
+     */
+    public function exportJson(Request $request)
+    {
+        $payload     = $this->stats->all();
+        $generatedAt = $payload['generated_at'] ?? now()->toIso8601String();
+        $etag        = '"' . md5($generatedAt) . '"';
+
+        if ($request->headers->get('If-None-Match') === $etag) {
+            return response('', 304)
+                ->header('ETag', $etag)
+                ->header('Cache-Control', 'public, max-age=21600, stale-while-revalidate=86400');
+        }
+
+        return response()->json($payload)
+            ->header('ETag', $etag)
+            ->header('Cache-Control', 'public, max-age=21600, stale-while-revalidate=86400')
+            ->header('X-Content-Type-Options', 'nosniff');
+    }
+}

--- a/app/Services/MapStatsService.php
+++ b/app/Services/MapStatsService.php
@@ -274,30 +274,57 @@ class MapStatsService
 
     /**
      * Weapon presence in maps over time. For each year, what fraction
-     * of new maps include rocket / plasma / grenade / bfg / lg. The
-     * `weapons` column stores comma-or-space-separated keywords.
+     * of new maps include each weapon — counts a map once per weapon
+     * present, so a `gl,pg,rl` map increments grenade + plasma +
+     * rocket all by 1.
      *
-     * @return array<int, array{year:int,total:int,rocket:int,plasma:int,grenade:int,bfg:int,lg:int}>
+     * The `weapons` column stores comma-separated abbreviations
+     * (`rl,pg,gl,lg,rg,sg,bfg,hook,gauntlet,mg`), not full names. Split
+     * on commas and match exact tokens to avoid false positives like
+     * `gauntlet` matching "g" or `pg` matching "p". Token list mirrors
+     * the actual data: rare tokens (`ng`, `cg`, `pml`, `ga` — under
+     * 30 maps each across the entire 15k library) are dropped from
+     * the chart but still counted toward `total` so percentages are
+     * accurate.
+     *
+     * @return array<int, array<string,int>>
      */
     public function weaponsByYear(): array
     {
         return Cache::remember(self::CACHE_PREFIX.'weapons_by_year', self::CACHE_TTL, function () {
+            // Map[token] => display key. Order matters: this is how
+            // they appear left-to-right in the legend & stack.
+            $tokenMap = [
+                'rl'       => 'rocket',
+                'pg'       => 'plasma',
+                'gl'       => 'grenade',
+                'rg'       => 'rail',
+                'sg'       => 'shotgun',
+                'bfg'      => 'bfg',
+                'lg'       => 'lg',
+                'hook'     => 'hook',
+                'gauntlet' => 'gauntlet',
+                'mg'       => 'machinegun',
+            ];
+
             $rows = DB::table('maps')
                 ->whereNotNull('date_added')
                 ->select(DB::raw('YEAR(date_added) AS year'), 'weapons')
                 ->get();
+
             $byYear = [];
             foreach ($rows as $r) {
                 $y = (int) $r->year;
                 if ($y < 1999 || $y > (int) date('Y')) continue;
-                $byYear[$y] ??= ['year' => $y, 'total' => 0, 'rocket' => 0, 'plasma' => 0, 'grenade' => 0, 'bfg' => 0, 'lg' => 0];
+                if (!isset($byYear[$y])) {
+                    $byYear[$y] = ['year' => $y, 'total' => 0];
+                    foreach ($tokenMap as $key) $byYear[$y][$key] = 0;
+                }
                 $byYear[$y]['total']++;
-                $w = strtolower((string) ($r->weapons ?? ''));
-                if (str_contains($w, 'rocket'))  $byYear[$y]['rocket']++;
-                if (str_contains($w, 'plasma'))  $byYear[$y]['plasma']++;
-                if (str_contains($w, 'grenade')) $byYear[$y]['grenade']++;
-                if (str_contains($w, 'bfg'))     $byYear[$y]['bfg']++;
-                if (str_contains($w, 'lg') || str_contains($w, 'lightning')) $byYear[$y]['lg']++;
+                $tokens = array_map('trim', explode(',', strtolower((string) ($r->weapons ?? ''))));
+                foreach ($tokenMap as $tok => $key) {
+                    if (in_array($tok, $tokens, true)) $byYear[$y][$key]++;
+                }
             }
             ksort($byYear);
             return array_values($byYear);

--- a/app/Services/MapStatsService.php
+++ b/app/Services/MapStatsService.php
@@ -1,0 +1,414 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Aggregates for the public /maps/stats page and the nightly snapshot
+ * export. Every method that touches `records` (646k rows) or runs a JOIN
+ * with `maps` (15k) is wrapped in Cache::remember — once a key is warm,
+ * the page renders in <50ms regardless of DB load.
+ *
+ * Cache TTL is 6 hours: a single new top-1 record per day moves the
+ * scatter plots by less than a pixel, so a stale window of a few hours
+ * is never noticeable to a visitor. The nightly artisan command bypasses
+ * the cache and rebuilds the snapshot directly.
+ */
+class MapStatsService
+{
+    public const CACHE_TTL = 21600; // 6 hours
+    public const CACHE_PREFIX = 'mapstats:';
+
+    /**
+     * Top-1 (fastest) record per (mapname, physics) joined with the map's
+     * release date. Each row is one dot in the big scatter charts.
+     *
+     * Why MIN(time) and not rank=1: the records table tracks separate
+     * ranks per gametype (run / ctf1..3), so a single map can have
+     * multiple rank=1 rows. We want the absolute fastest run per map
+     * per physics, irrespective of gametype.
+     *
+     * @return array<int, array{map:string,author:?string,holder:string,wr_ms:int,date_added:string,date_set:string,finishers:int,physics:string}>
+     */
+    public function wrPoints(string $physics): array
+    {
+        return Cache::remember(self::CACHE_PREFIX."wr_points:$physics", self::CACHE_TTL, function () use ($physics) {
+            $rows = DB::select("
+                SELECT r.mapname, r.time, r.date_set, r.name AS holder,
+                       m.date_added, m.author
+                FROM records r
+                INNER JOIN (
+                    SELECT mapname, MIN(time) AS best_time
+                    FROM records
+                    WHERE deleted_at IS NULL AND physics = ?
+                    GROUP BY mapname
+                ) b ON b.mapname = r.mapname AND b.best_time = r.time
+                INNER JOIN maps m ON m.name = r.mapname
+                WHERE r.deleted_at IS NULL AND r.physics = ?
+                GROUP BY r.mapname
+            ", [$physics, $physics]);
+
+            $finishers = $this->finishersByMap($physics);
+
+            $out = [];
+            foreach ($rows as $r) {
+                if (!$r->date_added || !$r->date_set) continue;
+                $out[] = [
+                    'map'        => $r->mapname,
+                    'author'     => $r->author,
+                    'holder'     => preg_replace('/\^[0-9a-fA-F]/', '', $r->holder ?? ''),
+                    'wr_ms'      => (int) $r->time,
+                    'date_added' => substr((string) $r->date_added, 0, 10),
+                    'date_set'   => substr((string) $r->date_set, 0, 10),
+                    'finishers'  => (int) ($finishers[$r->mapname] ?? 0),
+                    'physics'    => $physics,
+                ];
+            }
+            return $out;
+        });
+    }
+
+    /**
+     * Distinct mdd_id finisher count per map for the given physics. Counts
+     * how many unique players have at least one record on that map —
+     * better signal of popularity than total record count (which would
+     * inflate when one player spams resubmissions).
+     *
+     * @return array<string, int>
+     */
+    public function finishersByMap(string $physics): array
+    {
+        return Cache::remember(self::CACHE_PREFIX."finishers:$physics", self::CACHE_TTL, function () use ($physics) {
+            return DB::table('records')
+                ->whereNull('deleted_at')
+                ->where('physics', $physics)
+                ->whereNotNull('mdd_id')
+                ->groupBy('mapname')
+                ->select('mapname', DB::raw('COUNT(DISTINCT mdd_id) AS finishers'))
+                ->pluck('finishers', 'mapname')
+                ->map(fn ($v) => (int) $v)
+                ->all();
+        });
+    }
+
+    /**
+     * Map releases per year. Anything before 1999 is folded into "1999"
+     * — early Q3 maps occasionally have nonsense dates from filesystem
+     * mtime guessing.
+     *
+     * @return array<int, array{year:int,count:int}>
+     */
+    public function mapsPerYear(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'maps_per_year', self::CACHE_TTL, function () {
+            return DB::table('maps')
+                ->whereNotNull('date_added')
+                ->select(DB::raw('YEAR(date_added) AS year'), DB::raw('COUNT(*) AS count'))
+                ->groupBy('year')
+                ->orderBy('year')
+                ->get()
+                ->map(fn ($r) => ['year' => (int) $r->year, 'count' => (int) $r->count])
+                ->filter(fn ($r) => $r['year'] >= 1999 && $r['year'] <= (int) date('Y'))
+                ->values()
+                ->all();
+        });
+    }
+
+    /**
+     * Author productivity — top N most prolific mappers by visible map
+     * count. Authors with empty/null names are dropped (legacy imports).
+     *
+     * @return array<int, array{author:string,count:int}>
+     */
+    public function topAuthors(int $limit = 30): array
+    {
+        return Cache::remember(self::CACHE_PREFIX."top_authors:$limit", self::CACHE_TTL, function () use ($limit) {
+            return DB::table('maps')
+                ->whereNotNull('author')
+                ->where('author', '!=', '')
+                ->select('author', DB::raw('COUNT(*) AS count'))
+                ->groupBy('author')
+                ->orderByDesc('count')
+                ->limit($limit)
+                ->get()
+                ->map(fn ($r) => ['author' => (string) $r->author, 'count' => (int) $r->count])
+                ->all();
+        });
+    }
+
+    /**
+     * WRs held by country (uses the player's country at the time of
+     * setting the record). Choropleth-friendly. Empty / 'XX' codes are
+     * dropped.
+     *
+     * @return array<int, array{country:string,wrs:int}>
+     */
+    public function wrsByCountry(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'wrs_by_country', self::CACHE_TTL, function () {
+            // Same min-time-per-map-per-physics dance as wrPoints, but
+            // pulling the country instead of the time.
+            $rows = DB::select("
+                SELECT r.country
+                FROM records r
+                INNER JOIN (
+                    SELECT mapname, physics, MIN(time) AS best_time
+                    FROM records
+                    WHERE deleted_at IS NULL
+                    GROUP BY mapname, physics
+                ) b ON b.mapname = r.mapname AND b.physics = r.physics AND b.best_time = r.time
+                WHERE r.deleted_at IS NULL
+                GROUP BY r.mapname, r.physics
+            ");
+
+            $counts = [];
+            foreach ($rows as $r) {
+                $c = strtoupper(trim((string) $r->country));
+                if ($c === '' || $c === 'XX' || strlen($c) !== 2) continue;
+                $counts[$c] = ($counts[$c] ?? 0) + 1;
+            }
+            arsort($counts);
+            $out = [];
+            foreach ($counts as $c => $n) $out[] = ['country' => $c, 'wrs' => $n];
+            return $out;
+        });
+    }
+
+    /**
+     * Pareto-style WR concentration — what share of all WRs is held by
+     * the top N players (by mdd_id). Useful for "is the scene healthy or
+     * dominated by a handful of monsters".
+     *
+     * @return array<int, array{name:string,wrs:int,cumulative_pct:float}>
+     */
+    public function wrConcentration(int $limit = 30): array
+    {
+        return Cache::remember(self::CACHE_PREFIX."wr_concentration:$limit", self::CACHE_TTL, function () use ($limit) {
+            $rows = DB::select("
+                SELECT r.name, r.mdd_id
+                FROM records r
+                INNER JOIN (
+                    SELECT mapname, physics, MIN(time) AS best_time
+                    FROM records
+                    WHERE deleted_at IS NULL
+                    GROUP BY mapname, physics
+                ) b ON b.mapname = r.mapname AND b.physics = r.physics AND b.best_time = r.time
+                WHERE r.deleted_at IS NULL
+                GROUP BY r.mapname, r.physics
+            ");
+
+            $perPlayer = [];
+            $total = 0;
+            foreach ($rows as $r) {
+                $key = (int) ($r->mdd_id ?? 0);
+                if ($key === 0) continue;
+                $perPlayer[$key]['count'] = ($perPlayer[$key]['count'] ?? 0) + 1;
+                $perPlayer[$key]['name']  = preg_replace('/\^[0-9a-fA-F]/', '', (string) $r->name);
+                $total++;
+            }
+            uasort($perPlayer, fn ($a, $b) => $b['count'] <=> $a['count']);
+
+            $out = [];
+            $cum = 0;
+            $i = 0;
+            foreach ($perPlayer as $p) {
+                $cum += $p['count'];
+                $out[] = [
+                    'name'           => $p['name'],
+                    'wrs'            => $p['count'],
+                    'cumulative_pct' => $total > 0 ? round($cum * 100 / $total, 2) : 0,
+                ];
+                if (++$i >= $limit) break;
+            }
+            return $out;
+        });
+    }
+
+    /**
+     * GitHub-style activity heatmap — count of records set per month
+     * across the whole DB. Used for the calendar-style heatmap on the
+     * page.
+     *
+     * @return array<int, array{ym:string,count:int}>
+     */
+    public function activityByMonth(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'activity_by_month', self::CACHE_TTL, function () {
+            return DB::table('records')
+                ->whereNull('deleted_at')
+                ->whereNotNull('date_set')
+                ->select(DB::raw("DATE_FORMAT(date_set, '%Y-%m') AS ym"), DB::raw('COUNT(*) AS count'))
+                ->groupBy('ym')
+                ->orderBy('ym')
+                ->get()
+                ->map(fn ($r) => ['ym' => (string) $r->ym, 'count' => (int) $r->count])
+                ->all();
+        });
+    }
+
+    /**
+     * Distinct active players per year — players who set at least one
+     * record in that calendar year. Tracks community health.
+     *
+     * @return array<int, array{year:int,players:int}>
+     */
+    public function activePlayersByYear(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'active_players_by_year', self::CACHE_TTL, function () {
+            return DB::table('records')
+                ->whereNull('deleted_at')
+                ->whereNotNull('date_set')
+                ->whereNotNull('mdd_id')
+                ->select(DB::raw('YEAR(date_set) AS year'), DB::raw('COUNT(DISTINCT mdd_id) AS players'))
+                ->groupBy('year')
+                ->orderBy('year')
+                ->get()
+                ->map(fn ($r) => ['year' => (int) $r->year, 'players' => (int) $r->players])
+                ->filter(fn ($r) => $r['year'] >= 1999 && $r['year'] <= (int) date('Y'))
+                ->values()
+                ->all();
+        });
+    }
+
+    /**
+     * Weapon presence in maps over time. For each year, what fraction
+     * of new maps include rocket / plasma / grenade / bfg / lg. The
+     * `weapons` column stores comma-or-space-separated keywords.
+     *
+     * @return array<int, array{year:int,total:int,rocket:int,plasma:int,grenade:int,bfg:int,lg:int}>
+     */
+    public function weaponsByYear(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'weapons_by_year', self::CACHE_TTL, function () {
+            $rows = DB::table('maps')
+                ->whereNotNull('date_added')
+                ->select(DB::raw('YEAR(date_added) AS year'), 'weapons')
+                ->get();
+            $byYear = [];
+            foreach ($rows as $r) {
+                $y = (int) $r->year;
+                if ($y < 1999 || $y > (int) date('Y')) continue;
+                $byYear[$y] ??= ['year' => $y, 'total' => 0, 'rocket' => 0, 'plasma' => 0, 'grenade' => 0, 'bfg' => 0, 'lg' => 0];
+                $byYear[$y]['total']++;
+                $w = strtolower((string) ($r->weapons ?? ''));
+                if (str_contains($w, 'rocket'))  $byYear[$y]['rocket']++;
+                if (str_contains($w, 'plasma'))  $byYear[$y]['plasma']++;
+                if (str_contains($w, 'grenade')) $byYear[$y]['grenade']++;
+                if (str_contains($w, 'bfg'))     $byYear[$y]['bfg']++;
+                if (str_contains($w, 'lg') || str_contains($w, 'lightning')) $byYear[$y]['lg']++;
+            }
+            ksort($byYear);
+            return array_values($byYear);
+        });
+    }
+
+    /**
+     * Records-per-player distribution — how skewed is the player base.
+     * Returns histogram buckets (1, 2-5, 6-10, 11-50, 51-100, 100+).
+     *
+     * @return array<int, array{bucket:string,players:int}>
+     */
+    public function recordsPerPlayer(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'records_per_player', self::CACHE_TTL, function () {
+            $counts = DB::table('records')
+                ->whereNull('deleted_at')
+                ->whereNotNull('mdd_id')
+                ->select('mdd_id', DB::raw('COUNT(*) AS n'))
+                ->groupBy('mdd_id')
+                ->get();
+
+            $buckets = ['1' => 0, '2-5' => 0, '6-10' => 0, '11-50' => 0, '51-100' => 0, '100+' => 0];
+            foreach ($counts as $c) {
+                $n = (int) $c->n;
+                if      ($n <= 1)   $buckets['1']++;
+                elseif  ($n <= 5)   $buckets['2-5']++;
+                elseif  ($n <= 10)  $buckets['6-10']++;
+                elseif  ($n <= 50)  $buckets['11-50']++;
+                elseif  ($n <= 100) $buckets['51-100']++;
+                else                 $buckets['100+']++;
+            }
+            $out = [];
+            foreach ($buckets as $k => $v) $out[] = ['bucket' => $k, 'players' => $v];
+            return $out;
+        });
+    }
+
+    /**
+     * Top-level summary numbers shown above the charts. All cheap.
+     *
+     * @return array{total_maps:int,total_records:int,total_wrs:int,total_authors:int,total_players:int,first_record:?string,last_record:?string}
+     */
+    public function summary(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'summary', self::CACHE_TTL, function () {
+            $totalMaps    = (int) DB::table('maps')->count();
+            $totalRecords = (int) DB::table('records')->whereNull('deleted_at')->count();
+            $totalAuthors = (int) DB::table('maps')->whereNotNull('author')->where('author', '!=', '')->distinct()->count('author');
+            $totalPlayers = (int) DB::table('records')->whereNull('deleted_at')->whereNotNull('mdd_id')->distinct()->count('mdd_id');
+            $totalWrs     = (int) DB::scalar("
+                SELECT COUNT(*) FROM (
+                    SELECT mapname, physics FROM records
+                    WHERE deleted_at IS NULL
+                    GROUP BY mapname, physics
+                ) t
+            ");
+            $firstRecord  = DB::table('records')->whereNull('deleted_at')->whereNotNull('date_set')->min('date_set');
+            $lastRecord   = DB::table('records')->whereNull('deleted_at')->whereNotNull('date_set')->max('date_set');
+
+            return [
+                'total_maps'    => $totalMaps,
+                'total_records' => $totalRecords,
+                'total_wrs'     => $totalWrs,
+                'total_authors' => $totalAuthors,
+                'total_players' => $totalPlayers,
+                'first_record'  => $firstRecord ? substr((string) $firstRecord, 0, 10) : null,
+                'last_record'   => $lastRecord  ? substr((string) $lastRecord, 0, 10) : null,
+            ];
+        });
+    }
+
+    /**
+     * Bundle every chart into a single payload for the front-end.
+     * `generated_at` is stamped once and stored alongside the payload so
+     * the value is stable between requests within a cache window — this
+     * lets the API endpoint emit a stable ETag for 304 short-circuiting.
+     */
+    public function all(): array
+    {
+        return Cache::remember(self::CACHE_PREFIX.'all', self::CACHE_TTL, fn () => [
+            'summary'              => $this->summary(),
+            'cpm'                  => $this->wrPoints('cpm'),
+            'vq3'                  => $this->wrPoints('vq3'),
+            'maps_per_year'        => $this->mapsPerYear(),
+            'top_authors'          => $this->topAuthors(),
+            'wrs_by_country'       => $this->wrsByCountry(),
+            'wr_concentration'     => $this->wrConcentration(),
+            'activity_by_month'    => $this->activityByMonth(),
+            'active_players_year'  => $this->activePlayersByYear(),
+            'weapons_by_year'      => $this->weaponsByYear(),
+            'records_per_player'   => $this->recordsPerPlayer(),
+            'generated_at'         => now()->toIso8601String(),
+        ]);
+    }
+
+    /**
+     * Drop every cache key this service controls. Called by the nightly
+     * snapshot command and from tinker when admins want a manual rebuild.
+     */
+    public function clearCache(): void
+    {
+        $keys = [
+            'wr_points:cpm', 'wr_points:vq3',
+            'finishers:cpm', 'finishers:vq3',
+            'maps_per_year', 'top_authors:30',
+            'wrs_by_country', 'wr_concentration:30',
+            'activity_by_month', 'active_players_by_year',
+            'weapons_by_year', 'records_per_player', 'summary',
+            'all',
+        ];
+        foreach ($keys as $k) Cache::forget(self::CACHE_PREFIX.$k);
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,9 +24,13 @@
     to { transform: translate(-90px, 45px); }
 }
 
-/* Make black Q3 text (^0 color code) visible on dark backgrounds */
+/* Q3 color ^0 is true black — render it as such. Containers that show
+ * Q3 nicks (e.g. server cards' player list) provide a warm-glass
+ * backdrop that gives every colour code a legible kontrast. No
+ * outline / halo trickery here: a black glyph reads exactly as it
+ * does in the game scoreboard. */
 .q3c-0 {
-    color: #888 !important;
+    color: #000 !important;
 }
 
 .rotate-animation {

--- a/resources/js/Components/OnlinePlayerData.vue
+++ b/resources/js/Components/OnlinePlayerData.vue
@@ -27,7 +27,7 @@
         <Popper arrow hover :disabled="player.profile == null" style="z-index: 100;">
             <Link :href="getProfile" v-if="player.mdd_id" class="inline-flex items-center gap-1.5">
                 <img v-if="player.country && player.country !== 'XX'" :src="`/images/flags/${player.country}.png`" class="w-4 h-3 rounded shadow-md flex-shrink-0" :title="player.country" onerror="this.src='/images/flags/_404.png'" />
-                <div :class="{'opacity-70 group-hover:opacity-90': spectator}" class="font-bold inline online-player-name-text" style="text-shadow: 1px 1px 2px rgba(0,0,0,0.95), -1px -1px 2px rgba(0,0,0,0.95), 1px -1px 2px rgba(0,0,0,0.95), -1px 1px 2px rgba(0,0,0,0.95);" v-html="q3tohtml(player.name)"></div>
+                <div class="font-bold inline online-player-name-text" v-html="q3tohtml(player.name)"></div>
 
                 <svg v-if="player.profile" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="mb-0.5 ml-1 text-green-500 w-4 h-4 inline">
                     <path fill-rule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clip-rule="evenodd" />
@@ -36,7 +36,7 @@
 
             <div v-else class="inline-flex items-center gap-1.5">
                 <img v-if="player.country && player.country !== 'XX'" :src="`/images/flags/${player.country}.png`" class="w-4 h-3 rounded shadow-md flex-shrink-0" :title="player.country" onerror="this.src='/images/flags/_404.png'" />
-                <div :class="{'opacity-70 group-hover:opacity-90': spectator}" class="font-bold inline online-player-name-text" style="text-shadow: 1px 1px 2px rgba(0,0,0,0.95), -1px -1px 2px rgba(0,0,0,0.95), 1px -1px 2px rgba(0,0,0,0.95), -1px 1px 2px rgba(0,0,0,0.95);" v-html="q3tohtml(player.name)"></div>
+                <div class="font-bold inline online-player-name-text" v-html="q3tohtml(player.name)"></div>
 
                 <svg v-if="player.profile" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="mb-0.5 ml-1 text-green-500 w-4 h-4 inline">
                     <path fill-rule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clip-rule="evenodd" />

--- a/resources/js/Components/ServerCard.vue
+++ b/resources/js/Components/ServerCard.vue
@@ -119,7 +119,13 @@ hr{
 }
 .server-card-wrapper{
     width:100%;
-    background:#161d2b;
+    /* Card body is fully transparent — the thumbnail behind it
+     * (covered + alpha-ramped via .server-background-overlay)
+     * provides the entire visual surface. No second dark slab
+     * stacking on top of the gradient = no hard line under the
+     * thumbnail. */
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.08);
     position: relative;
     overflow: hidden;
 }
@@ -128,13 +134,16 @@ hr{
     top:0;
     left:0;
     width:100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    height:100%;            /* span the whole card so the overlay
+                               gradient can fade thumbnail → glass
+                               continuously instead of stopping at
+                               the bottom of the image */
+    display: block;
     z-index: 0;
 }
 .server-background img{
     width:100%;
+    display:block;
     transition: all .15s linear;
 }
 .server-background .server-background-overlay{
@@ -143,11 +152,17 @@ hr{
     left:0;
     width:100%;
     height: 100%;
-    background: rgb(22,29,43);
-    background: linear-gradient(0deg, #161d2b, #161d2b34, #161d2bad);
+    /* No dark slab anywhere. Just a short gradient at the bottom
+     * edge of the thumbnail itself fading the image into the
+     * transparent card body — so text below it sits directly on
+     * the page background, not on any dark veil. */
+    background: linear-gradient(180deg,
+        rgba(0,0,0,0) 0%,
+        rgba(0,0,0,0) 60%,
+        rgba(11,16,32,0.4) 90%,
+        rgba(11,16,32,0) 100%);
     z-index: 2;
     box-sizing: content-box;
-    border-bottom: 1000px solid #161d2b;
     transition: all .15s linear;
 }
 .server-background .server-background-hover-overlay{
@@ -156,10 +171,9 @@ hr{
     left:0;
     width:100%;
     height: 100%;
-    background: rgb(22,29,43);
+    background: rgba(22,29,43,0.5);
     z-index: 3;
     box-sizing: content-box;
-    border-bottom: 1000px solid #161d2b;
     transition: all .15s linear;
     opacity: 0;
 }

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -39,7 +39,7 @@
             servers: route().current('servers'),
             players: route().current('records') || route().current('clans.*'),
             rankings: route().current('ranking') || route().current('community'),
-            mapsmodels: route().current('maps') || route().current('models.*'),
+            mapsmodels: route().current('maps') || route().current('maps.stats') || route().current('models.*'),
             demos: route().current('demos.*') || route().current('youtube'),
             challenges: route().current('headhunter.*') || route().current('marketplace.*') || route().current('community.tasks'),
             tournaments: route().current('tournaments.*'),
@@ -51,6 +51,7 @@
             ranking: route().current('ranking'),
             community: route().current('community'),
             maps: route().current('maps'),
+            mapsStats: route().current('maps.stats'),
             maplists: route().current('maplists.*'),
             models: route().current('models.*'),
             demosIndex: route().current('demos.*'),
@@ -794,6 +795,7 @@
                                 </template>
                                 <template #content>
                                     <DropdownLink :href="route('maps')" :active="navActive.maps">Maps</DropdownLink>
+                                    <DropdownLink :href="route('maps.stats')" :active="navActive.mapsStats">Map Statistics</DropdownLink>
                                     <DropdownLink href="/models" :active="navActive.models">Models</DropdownLink>
                                 </template>
                             </Dropdown>
@@ -887,6 +889,7 @@
                                         <DropdownLink :href="route('clans.index')" :active="navActive.clans">Clans</DropdownLink>
                                         <div class="px-3 py-1 text-[11px] font-semibold text-gray-500 uppercase tracking-wider mt-1">Maps & Models</div>
                                         <DropdownLink :href="route('maps')" :active="navActive.maps">Maps</DropdownLink>
+                                        <DropdownLink :href="route('maps.stats')" :active="navActive.mapsStats">Map Statistics</DropdownLink>
                                         <DropdownLink href="/models" :active="navActive.models">Models</DropdownLink>
                                         <div class="px-3 py-1 text-[11px] font-semibold text-gray-500 uppercase tracking-wider mt-1">Demos</div>
                                         <DropdownLink :href="route('demos.index')" :active="navActive.demosIndex">Upload & Browse</DropdownLink>

--- a/resources/js/Pages/MapStats.vue
+++ b/resources/js/Pages/MapStats.vue
@@ -206,7 +206,7 @@ const renderAll = async () => {
           y: yrs, type: 'heatmap',
           colorscale: [[0, '#0b1020'], [0.1, '#1e293b'], [0.3, '#1e40af'], [0.7, '#a855f7'], [1, '#f43f5e']],
           hovertemplate: '%{y} %{x}: %{z} records<extra></extra>' }
-    ], { ...DARK, height: Math.max(400, yrs.length * 22),
+    ], { ...DARK, height: Math.max(280, yrs.length * 28),
          xaxis: { ...DARK.xaxis, side: 'top' },
          yaxis: { ...DARK.yaxis, autorange: 'reversed' } }, CFG);
 
@@ -344,7 +344,7 @@ onMounted(renderAll);
 <template>
     <Head title="Map Statistics" />
 
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-8">
             <h1 class="text-3xl font-black text-white mb-2">Map Statistics</h1>
             <p class="text-gray-400 mb-6 text-sm">
                 Aggregates across the whole defrag.racing dataset. Updated every six hours
@@ -436,7 +436,7 @@ onMounted(renderAll);
                 <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Activity heatmap</h2>
                     <p class="text-xs text-gray-500 mb-2">Records set per month, per year. GitHub-style — the brighter the busier.</p>
-                    <div id="chart-heatmap" style="min-height: 600px"></div>
+                    <div id="chart-heatmap"></div>
                 </div>
 
                 <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">

--- a/resources/js/Pages/MapStats.vue
+++ b/resources/js/Pages/MapStats.vue
@@ -1,0 +1,380 @@
+<script setup>
+import { onMounted, ref, computed, nextTick } from 'vue';
+import { Head } from '@inertiajs/vue3';
+
+const props = defineProps({
+    stats: Object,
+});
+
+// Plotly is ~3 MB; loading it from a CDN keeps the main app bundle lean
+// and the browser caches it across pages. The page is graceful while
+// Plotly is in flight — empty containers are placeholders.
+const plotlyReady = ref(false);
+const plotlyError = ref(null);
+
+const ensurePlotly = () => new Promise((resolve, reject) => {
+    if (window.Plotly) return resolve(window.Plotly);
+    const existing = document.querySelector('script[data-plotly]');
+    if (existing) {
+        existing.addEventListener('load', () => resolve(window.Plotly));
+        existing.addEventListener('error', reject);
+        return;
+    }
+    const s = document.createElement('script');
+    s.src = 'https://cdn.plot.ly/plotly-2.35.2.min.js';
+    s.async = true;
+    s.dataset.plotly = '1';
+    s.onload = () => resolve(window.Plotly);
+    s.onerror = () => reject(new Error('Failed to load Plotly from CDN'));
+    document.head.appendChild(s);
+});
+
+const fmtTime = (ms) => {
+    const m = Math.floor(ms / 60000);
+    const s = Math.floor((ms % 60000) / 1000);
+    const msr = ms % 1000;
+    return (m > 0 ? String(m).padStart(2, '0') + ':' : '') +
+        String(s).padStart(2, '0') + '.' + String(msr).padStart(3, '0');
+};
+
+// Theme tokens used across all charts. Matches the rest of the site
+// (dark slate, purple/blue accents).
+const DARK = {
+    paper_bgcolor: 'rgba(0,0,0,0)',
+    plot_bgcolor: 'rgba(0,0,0,0)',
+    font: { color: '#cbd5e1', family: 'ui-sans-serif, system-ui' },
+    xaxis: { gridcolor: 'rgba(148,163,184,0.12)', zerolinecolor: 'rgba(148,163,184,0.2)' },
+    yaxis: { gridcolor: 'rgba(148,163,184,0.12)', zerolinecolor: 'rgba(148,163,184,0.2)' },
+    margin: { t: 20, r: 18, b: 50, l: 60 },
+    legend: { orientation: 'h', y: 1.12 },
+    hovermode: 'closest',
+};
+
+const CFG = { responsive: true, displaylogo: false, modeBarButtonsToRemove: ['lasso2d', 'select2d'] };
+
+const summary = computed(() => props.stats?.summary || {});
+
+const renderAll = async () => {
+    let Plotly;
+    try { Plotly = await ensurePlotly(); }
+    catch (e) { plotlyError.value = e.message; return; }
+    plotlyReady.value = true;
+    await nextTick();
+
+    const data = props.stats;
+    if (!data) return;
+
+    const buildHover = pts => pts.map(p =>
+        `<b>${p.map}</b><br>WR ${fmtTime(p.wr_ms)} · ${p.holder || '?'}<br>released ${p.date_added}<br>finishers ${p.finishers}`
+    );
+
+    // 1. Histogram WR per physics — pre-bucket in JS rather than letting
+    // Plotly histogram + log X handle it. Plotly bins in linear space
+    // before applying the log transform, which produces empty bars when
+    // the data spans 0.5s–1200s. Build log-spaced buckets ourselves.
+    const wrBuckets = [
+        [0,    1,    'sub 1s'],
+        [1,    2,    '1–2s'],
+        [2,    5,    '2–5s'],
+        [5,    10,   '5–10s'],
+        [10,   20,   '10–20s'],
+        [20,   30,   '20–30s'],
+        [30,   45,   '30–45s'],
+        [45,   60,   '45–60s'],
+        [60,   90,   '1–1.5m'],
+        [90,   120,  '1.5–2m'],
+        [120,  180,  '2–3m'],
+        [180,  300,  '3–5m'],
+        [300,  600,  '5–10m'],
+        [600,  1200, '10–20m'],
+        [1200, Infinity, '20m+'],
+    ];
+    const bucketCounts = (pts) => {
+        const counts = wrBuckets.map(() => 0);
+        for (const p of pts) {
+            const s = p.wr_ms / 1000;
+            for (let i = 0; i < wrBuckets.length; i++) {
+                if (s >= wrBuckets[i][0] && s < wrBuckets[i][1]) { counts[i]++; break; }
+            }
+        }
+        return counts;
+    };
+    const labels = wrBuckets.map(b => b[2]);
+    Plotly.newPlot('chart-hist', [
+        { x: labels, y: bucketCounts(data.cpm), type: 'bar', name: 'CPM',
+          marker: { color: '#a855f7' }, opacity: 0.85 },
+        { x: labels, y: bucketCounts(data.vq3), type: 'bar', name: 'VQ3',
+          marker: { color: '#3b82f6' }, opacity: 0.85 },
+    ], { ...DARK, barmode: 'group',
+         xaxis: { ...DARK.xaxis, title: 'WR time bucket' },
+         yaxis: { ...DARK.yaxis, title: 'maps' } }, CFG);
+
+    // 2. Maps per year
+    Plotly.newPlot('chart-yearly', [
+        { x: data.maps_per_year.map(d => d.year), y: data.maps_per_year.map(d => d.count),
+          type: 'bar', marker: { color: '#22c55e' } }
+    ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'year' },
+         yaxis: { ...DARK.yaxis, title: 'maps released' } }, CFG);
+
+    // 3. Active players per year
+    Plotly.newPlot('chart-active-players', [
+        { x: data.active_players_year.map(d => d.year), y: data.active_players_year.map(d => d.players),
+          type: 'bar', marker: { color: '#f59e0b' } }
+    ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'year' },
+         yaxis: { ...DARK.yaxis, title: 'distinct active players' } }, CFG);
+
+    // 4. Top authors
+    const authors = data.top_authors.slice(0, 25).reverse();
+    Plotly.newPlot('chart-authors', [
+        { y: authors.map(a => a.author), x: authors.map(a => a.count),
+          type: 'bar', orientation: 'h', marker: { color: '#ec4899' } }
+    ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'maps' },
+         yaxis: { ...DARK.yaxis, automargin: true },
+         margin: { ...DARK.margin, l: 130 },
+         height: Math.max(400, authors.length * 22) }, CFG);
+
+    // 5. WR concentration (Pareto)
+    const wrc = data.wr_concentration;
+    Plotly.newPlot('chart-pareto', [
+        { x: wrc.map((p, i) => i + 1), y: wrc.map(p => p.wrs),
+          customdata: wrc.map(p => p.name),
+          hovertemplate: 'Rank %{x}: %{customdata}<br>%{y} WRs<extra></extra>',
+          type: 'bar', marker: { color: '#06b6d4' }, name: 'WRs' },
+        { x: wrc.map((p, i) => i + 1), y: wrc.map(p => p.cumulative_pct),
+          type: 'scatter', mode: 'lines+markers', name: 'cumulative %',
+          yaxis: 'y2', line: { color: '#facc15' } },
+    ], { ...DARK,
+         xaxis: { ...DARK.xaxis, title: 'rank (top 30 WR holders)' },
+         yaxis: { ...DARK.yaxis, title: 'WRs held' },
+         yaxis2: { title: 'cumulative %', overlaying: 'y', side: 'right',
+                   gridcolor: 'transparent', range: [0, 100] },
+    }, CFG);
+
+    // 6. WRs by country (choropleth)
+    Plotly.newPlot('chart-countries', [
+        { type: 'choropleth', locationmode: 'ISO-3', locations: data.wrs_by_country.map(c => iso2to3(c.country)),
+          z: data.wrs_by_country.map(c => c.wrs),
+          text: data.wrs_by_country.map(c => `${c.country}: ${c.wrs} WRs`),
+          colorscale: [[0, '#1e293b'], [0.2, '#1e40af'], [0.5, '#7c3aed'], [1, '#f43f5e']],
+          showscale: true,
+          marker: { line: { color: 'rgba(148,163,184,0.3)', width: 0.4 } } }
+    ], { ...DARK,
+         geo: { showframe: false, showcoastlines: true, coastlinecolor: 'rgba(148,163,184,0.2)',
+                projection: { type: 'natural earth' }, bgcolor: 'rgba(0,0,0,0)',
+                landcolor: 'rgba(30,41,59,0.4)' } }, CFG);
+
+    // 7. Activity heatmap (records set per month)
+    const activity = data.activity_by_month;
+    const yrs = [...new Set(activity.map(a => a.ym.slice(0, 4)))].sort();
+    const mos = ['01','02','03','04','05','06','07','08','09','10','11','12'];
+    const z = yrs.map(y => mos.map(m => {
+        const row = activity.find(a => a.ym === `${y}-${m}`);
+        return row ? row.count : 0;
+    }));
+    Plotly.newPlot('chart-heatmap', [
+        { z, x: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+          y: yrs, type: 'heatmap',
+          colorscale: [[0, '#0b1020'], [0.1, '#1e293b'], [0.3, '#1e40af'], [0.7, '#a855f7'], [1, '#f43f5e']],
+          hovertemplate: '%{y} %{x}: %{z} records<extra></extra>' }
+    ], { ...DARK, height: Math.max(400, yrs.length * 22),
+         xaxis: { ...DARK.xaxis, side: 'top' },
+         yaxis: { ...DARK.yaxis, autorange: 'reversed' } }, CFG);
+
+    // 8. Records per player histogram
+    Plotly.newPlot('chart-records-per-player', [
+        { x: data.records_per_player.map(b => b.bucket),
+          y: data.records_per_player.map(b => b.players),
+          type: 'bar', marker: { color: '#14b8a6' },
+          hovertemplate: '%{x} records: %{y} players<extra></extra>' }
+    ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'records per player' },
+         yaxis: { ...DARK.yaxis, title: 'players (log)', type: 'log' } }, CFG);
+
+    // 9. Weapons per year (stacked area)
+    const wy = data.weapons_by_year;
+    const totals = wy.map(w => w.total);
+    const pct = (key) => wy.map((w, i) => totals[i] ? (w[key] / totals[i] * 100) : 0);
+    Plotly.newPlot('chart-weapons', [
+        { x: wy.map(w => w.year), y: pct('rocket'),  name: 'rocket',  type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#ef4444' } },
+        { x: wy.map(w => w.year), y: pct('plasma'),  name: 'plasma',  type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#22c55e' } },
+        { x: wy.map(w => w.year), y: pct('grenade'), name: 'grenade', type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#f59e0b' } },
+        { x: wy.map(w => w.year), y: pct('bfg'),     name: 'bfg',     type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#8b5cf6' } },
+        { x: wy.map(w => w.year), y: pct('lg'),      name: 'lg',      type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#06b6d4' } },
+    ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'year' },
+         yaxis: { ...DARK.yaxis, title: '% of new maps including this weapon' } }, CFG);
+
+    // 10. Scatter: release date × WR time (the big one — webgl-backed)
+    Plotly.newPlot('chart-release-vs-wr', ['cpm','vq3'].map(phys => ({
+        x: data[phys].map(p => p.date_added),
+        y: data[phys].map(p => p.wr_ms / 1000),
+        customdata: buildHover(data[phys]),
+        hovertemplate: '%{customdata}<extra></extra>',
+        mode: 'markers', type: 'scattergl', name: phys.toUpperCase(),
+        marker: { size: 4, opacity: 0.55, color: phys === 'cpm' ? '#a855f7' : '#3b82f6' },
+    })), { ...DARK,
+           xaxis: { ...DARK.xaxis, title: 'map release date', type: 'date' },
+           yaxis: { ...DARK.yaxis, title: 'WR time (seconds, log)', type: 'log' } }, CFG);
+
+    // 11. Scatter: release × #finishers
+    Plotly.newPlot('chart-release-vs-finishers', ['cpm','vq3'].map(phys => ({
+        x: data[phys].map(p => p.date_added),
+        y: data[phys].map(p => p.finishers),
+        customdata: buildHover(data[phys]),
+        hovertemplate: '%{customdata}<extra></extra>',
+        mode: 'markers', type: 'scattergl', name: phys.toUpperCase(),
+        marker: { size: 4, opacity: 0.55, color: phys === 'cpm' ? '#a855f7' : '#3b82f6' },
+    })), { ...DARK,
+           xaxis: { ...DARK.xaxis, title: 'map release date', type: 'date' },
+           yaxis: { ...DARK.yaxis, title: 'unique finishers (log)', type: 'log' } }, CFG);
+
+    // 12. Scatter: release × WR set date
+    Plotly.newPlot('chart-release-vs-wrdate', ['cpm','vq3'].map(phys => ({
+        x: data[phys].map(p => p.date_added),
+        y: data[phys].map(p => p.date_set),
+        customdata: buildHover(data[phys]),
+        hovertemplate: '%{customdata}<extra></extra>',
+        mode: 'markers', type: 'scattergl', name: phys.toUpperCase(),
+        marker: { size: 4, opacity: 0.55, color: phys === 'cpm' ? '#a855f7' : '#3b82f6' },
+    })), { ...DARK,
+           xaxis: { ...DARK.xaxis, title: 'map release date', type: 'date' },
+           yaxis: { ...DARK.yaxis, title: 'WR set date', type: 'date' } }, CFG);
+};
+
+// Plotly's choropleth wants ISO-3 codes; the records table has ISO-2.
+// This is a tiny stub for the most common Defrag countries — anything
+// missing falls through and is silently skipped from the map (it'll
+// still show in the country leaderboard if present).
+const ISO_MAP = {
+    AT:'AUT',AU:'AUS',BE:'BEL',BG:'BGR',BR:'BRA',BY:'BLR',CA:'CAN',CH:'CHE',CL:'CHL',CN:'CHN',
+    CZ:'CZE',DE:'DEU',DK:'DNK',EE:'EST',ES:'ESP',FI:'FIN',FR:'FRA',GB:'GBR',GR:'GRC',HR:'HRV',
+    HU:'HUN',ID:'IDN',IE:'IRL',IL:'ISR',IT:'ITA',JP:'JPN',KR:'KOR',KZ:'KAZ',LT:'LTU',LV:'LVA',
+    MD:'MDA',MX:'MEX',NL:'NLD',NO:'NOR',NZ:'NZL',PE:'PER',PH:'PHL',PL:'POL',PT:'PRT',RO:'ROU',
+    RS:'SRB',RU:'RUS',SE:'SWE',SG:'SGP',SI:'SVN',SK:'SVK',TH:'THA',TR:'TUR',TW:'TWN',UA:'UKR',
+    US:'USA',VN:'VNM',ZA:'ZAF',
+};
+const iso2to3 = (c) => ISO_MAP[c] || c;
+
+onMounted(renderAll);
+</script>
+
+<template>
+    <Head title="Map Statistics" />
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <h1 class="text-3xl font-black text-white mb-2">Map Statistics</h1>
+            <p class="text-gray-400 mb-6 text-sm">
+                Aggregates across the whole defrag.racing dataset. Updated every six hours
+                from the live records database.
+            </p>
+
+            <!-- Top-level summary chips -->
+            <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
+                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <div class="text-2xl font-bold text-white">{{ summary.total_maps?.toLocaleString() }}</div>
+                    <div class="text-xs text-gray-400 uppercase tracking-wider">Maps</div>
+                </div>
+                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <div class="text-2xl font-bold text-white">{{ summary.total_records?.toLocaleString() }}</div>
+                    <div class="text-xs text-gray-400 uppercase tracking-wider">Records</div>
+                </div>
+                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <div class="text-2xl font-bold text-white">{{ summary.total_wrs?.toLocaleString() }}</div>
+                    <div class="text-xs text-gray-400 uppercase tracking-wider">Top-1 runs</div>
+                </div>
+                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <div class="text-2xl font-bold text-white">{{ summary.total_authors?.toLocaleString() }}</div>
+                    <div class="text-xs text-gray-400 uppercase tracking-wider">Mappers</div>
+                </div>
+                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <div class="text-2xl font-bold text-white">{{ summary.total_players?.toLocaleString() }}</div>
+                    <div class="text-xs text-gray-400 uppercase tracking-wider">Players</div>
+                </div>
+                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <div class="text-sm font-bold text-white">{{ summary.first_record }}</div>
+                    <div class="text-xs text-gray-400 uppercase tracking-wider">First record</div>
+                </div>
+            </div>
+
+            <div v-if="plotlyError" class="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-300 mb-6">
+                Failed to load charts: {{ plotlyError }}. Check your network connection or try refreshing.
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <!-- Histograms / bar charts in 2-col -->
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                    <h2 class="text-base font-bold text-white mb-1">WR time distribution</h2>
+                    <p class="text-xs text-gray-500 mb-2">Per-map fastest run, log-scale X. CPM (purple) vs VQ3 (blue).</p>
+                    <div id="chart-hist" style="height: 360px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                    <h2 class="text-base font-bold text-white mb-1">Maps released per year</h2>
+                    <p class="text-xs text-gray-500 mb-2">When was the map library built?</p>
+                    <div id="chart-yearly" style="height: 360px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                    <h2 class="text-base font-bold text-white mb-1">Distinct active players per year</h2>
+                    <p class="text-xs text-gray-500 mb-2">Players who set at least one record that year.</p>
+                    <div id="chart-active-players" style="height: 360px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                    <h2 class="text-base font-bold text-white mb-1">Records per player</h2>
+                    <p class="text-xs text-gray-500 mb-2">Long-tail distribution — most players have a handful, a few have thousands.</p>
+                    <div id="chart-records-per-player" style="height: 360px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">Weapon presence in new maps</h2>
+                    <p class="text-xs text-gray-500 mb-2">% of maps released each year that include each weapon.</p>
+                    <div id="chart-weapons" style="height: 360px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">Top mappers</h2>
+                    <p class="text-xs text-gray-500 mb-2">25 most prolific authors by visible map count.</p>
+                    <div id="chart-authors" style="min-height: 600px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">WR concentration (top 30)</h2>
+                    <p class="text-xs text-gray-500 mb-2">Bar = WRs held, line = cumulative % of all WRs.</p>
+                    <div id="chart-pareto" style="height: 420px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">WRs by country</h2>
+                    <p class="text-xs text-gray-500 mb-2">Choropleth of map-best-time holders.</p>
+                    <div id="chart-countries" style="height: 480px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">Activity heatmap</h2>
+                    <p class="text-xs text-gray-500 mb-2">Records set per month, per year. GitHub-style — the brighter the busier.</p>
+                    <div id="chart-heatmap" style="min-height: 600px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">Map release date × WR time</h2>
+                    <p class="text-xs text-gray-500 mb-2">Each dot is one map. Hover for details.</p>
+                    <div id="chart-release-vs-wr" style="height: 540px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">Map release date × number of finishers</h2>
+                    <p class="text-xs text-gray-500 mb-2">Older maps tend to have more finishers, but viral newer maps stand out.</p>
+                    <div id="chart-release-vs-finishers" style="height: 540px"></div>
+                </div>
+
+                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                    <h2 class="text-base font-bold text-white mb-1">Map release date × WR set date</h2>
+                    <p class="text-xs text-gray-500 mb-2">Diagonal-ish — outliers above the line are late discoveries (WR set years after release).</p>
+                    <div id="chart-release-vs-wrdate" style="height: 540px"></div>
+                </div>
+            </div>
+
+        <p class="text-center text-xs text-gray-600 mt-8">
+            Generated {{ summary.last_record }} · cache refresh every 6h
+        </p>
+    </div>
+</template>

--- a/resources/js/Pages/MapStats.vue
+++ b/resources/js/Pages/MapStats.vue
@@ -43,14 +43,44 @@ const DARK = {
     paper_bgcolor: 'rgba(0,0,0,0)',
     plot_bgcolor: 'rgba(0,0,0,0)',
     font: { color: '#cbd5e1', family: 'ui-sans-serif, system-ui' },
-    xaxis: { gridcolor: 'rgba(148,163,184,0.12)', zerolinecolor: 'rgba(148,163,184,0.2)' },
-    yaxis: { gridcolor: 'rgba(148,163,184,0.12)', zerolinecolor: 'rgba(148,163,184,0.2)' },
-    margin: { t: 20, r: 18, b: 50, l: 60 },
-    legend: { orientation: 'h', y: 1.12 },
+    // Tight margins — defaults reserve generous padding for axis titles
+    // & legend that left huge dead bands around every chart. Pulling
+    // them in claws back ~30% of vertical space for actual data.
+    xaxis: { gridcolor: 'rgba(148,163,184,0.12)', zerolinecolor: 'rgba(148,163,184,0.2)', automargin: true },
+    yaxis: { gridcolor: 'rgba(148,163,184,0.12)', zerolinecolor: 'rgba(148,163,184,0.2)', automargin: true },
+    margin: { t: 4, r: 8, b: 38, l: 50 },
+    legend: { orientation: 'h', y: 1.06, x: 0, xanchor: 'left', yanchor: 'bottom' },
     hovermode: 'closest',
 };
 
 const CFG = { responsive: true, displaylogo: false, modeBarButtonsToRemove: ['lasso2d', 'select2d'] };
+
+// Plotly's default log-axis labelling shows minor ticks (2, 5) between
+// powers of ten, but it strips the decade context — so a "2" between
+// "10" and "100" actually means 20, "5" means 500. Confusing as hell.
+// `dtick: 1` (one log10 step per major tick) plus a `,d` integer format
+// gives clean 1 / 10 / 100 / 1000 labels with no minor noise.
+//
+// Minor gridlines fill in the "empty" space between 1–10 — without them
+// the eye reads the gap as missing data, when in fact the log curve is
+// just compressing 2/3/.../9 into a small visual band near the top of
+// each decade. Subtle gridlines let the user see *where* those ticks
+// land without re-introducing the misleading short labels.
+const LOG_AXIS = {
+    type: 'log',
+    dtick: 1,
+    tickformat: ',d',
+    minor: {
+        tickmode: 'auto',
+        nticks: 9,
+        showgrid: true,
+        gridcolor: 'rgba(148,163,184,0.18)',
+        gridwidth: 1,
+        ticks: 'outside',
+        ticklen: 4,
+        tickcolor: 'rgba(148,163,184,0.5)',
+    },
+};
 
 const summary = computed(() => props.stats?.summary || {});
 
@@ -187,44 +217,99 @@ const renderAll = async () => {
           type: 'bar', marker: { color: '#14b8a6' },
           hovertemplate: '%{x} records: %{y} players<extra></extra>' }
     ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'records per player' },
-         yaxis: { ...DARK.yaxis, title: 'players (log)', type: 'log' } }, CFG);
+         yaxis: { ...DARK.yaxis, title: 'players (log)', ...LOG_AXIS } }, CFG);
 
-    // 9. Weapons per year (stacked area)
+    // 9. Weapons per year — line chart (not stacked, since a single
+    // map can carry multiple weapons; stacking would double-count).
+    // Each line shows the % of that year's new maps that include
+    // the given weapon.
     const wy = data.weapons_by_year;
-    const totals = wy.map(w => w.total);
-    const pct = (key) => wy.map((w, i) => totals[i] ? (w[key] / totals[i] * 100) : 0);
-    Plotly.newPlot('chart-weapons', [
-        { x: wy.map(w => w.year), y: pct('rocket'),  name: 'rocket',  type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#ef4444' } },
-        { x: wy.map(w => w.year), y: pct('plasma'),  name: 'plasma',  type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#22c55e' } },
-        { x: wy.map(w => w.year), y: pct('grenade'), name: 'grenade', type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#f59e0b' } },
-        { x: wy.map(w => w.year), y: pct('bfg'),     name: 'bfg',     type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#8b5cf6' } },
-        { x: wy.map(w => w.year), y: pct('lg'),      name: 'lg',      type: 'scatter', mode: 'lines', stackgroup: 'a', line: { color: '#06b6d4' } },
-    ], { ...DARK, xaxis: { ...DARK.xaxis, title: 'year' },
-         yaxis: { ...DARK.yaxis, title: '% of new maps including this weapon' } }, CFG);
+    const pct = (key) => wy.map(w => w.total ? (w[key] / w.total * 100) : 0);
+    const weaponSeries = [
+        ['rocket',     '#ef4444'],
+        ['plasma',     '#22c55e'],
+        ['grenade',    '#f59e0b'],
+        ['rail',       '#facc15'],
+        ['shotgun',    '#fb923c'],
+        ['bfg',        '#8b5cf6'],
+        ['lg',         '#06b6d4'],
+        ['hook',       '#ec4899'],
+        ['gauntlet',   '#a3a3a3'],
+        ['machinegun', '#14b8a6'],
+    ];
+    Plotly.newPlot('chart-weapons',
+        weaponSeries.map(([key, color]) => ({
+            x: wy.map(w => w.year),
+            y: pct(key),
+            name: key,
+            type: 'scatter',
+            mode: 'lines',
+            line: { color, width: 2 },
+            hovertemplate: `${key}: %{y:.1f}%<extra></extra>`,
+        })),
+        { ...DARK, xaxis: { ...DARK.xaxis, title: 'year' },
+          yaxis: { ...DARK.yaxis, title: '% of new maps including this weapon', ticksuffix: '%' } },
+        CFG
+    );
 
-    // 10. Scatter: release date × WR time (the big one — webgl-backed)
+    // 10. Scatter: release date × WR time (the big one — webgl-backed).
+    //
+    // Floor at 1s (sub-second WRs are demo/scoreboard bugs) AND cap
+    // at the 99th percentile to keep the meaningful 1–100s mass from
+    // being squashed by the handful of clearly-broken 10000s+ entries
+    // (3+ hour "WRs" = abandoned runs, scoreboard bugs). The cap is
+    // rounded up to the next decade so axis labels stay clean.
+    const allWrSec = [...data.cpm, ...data.vq3]
+        .map(p => p.wr_ms / 1000)
+        .filter(v => v >= 1)
+        .sort((a, b) => a - b);
+    const wrP99 = allWrSec[Math.floor(allWrSec.length * 0.99)] ?? 1000;
+    const wrCapSec = Math.pow(10, Math.ceil(Math.log10(wrP99)));
     Plotly.newPlot('chart-release-vs-wr', ['cpm','vq3'].map(phys => ({
         x: data[phys].map(p => p.date_added),
-        y: data[phys].map(p => p.wr_ms / 1000),
+        y: data[phys].map(p => Math.min(wrCapSec, Math.max(1, p.wr_ms / 1000))),
         customdata: buildHover(data[phys]),
         hovertemplate: '%{customdata}<extra></extra>',
         mode: 'markers', type: 'scattergl', name: phys.toUpperCase(),
         marker: { size: 4, opacity: 0.55, color: phys === 'cpm' ? '#a855f7' : '#3b82f6' },
     })), { ...DARK,
            xaxis: { ...DARK.xaxis, title: 'map release date', type: 'date' },
-           yaxis: { ...DARK.yaxis, title: 'WR time (seconds, log)', type: 'log' } }, CFG);
+           yaxis: { ...DARK.yaxis, title: `WR time (seconds, log; capped at ${wrCapSec})`, ...LOG_AXIS,
+                    range: [0, Math.log10(wrCapSec) + 0.02], autorange: false } }, CFG);
 
     // 11. Scatter: release × #finishers
+    //
+    // Finisher counts are integers, so plain log scale draws hard
+    // bands at 1, 2, 3, ... — sharp horizontal stripes that mask
+    // overplot density. Solve it with a multiplicative jitter that's
+    // constant-width in log space (±0.18 log10), so a "1" smears to
+    // [1.0, 1.51], a "2" to [1.32, 3.02], etc., with the next
+    // integer's smear overlapping the previous one. Bands dissolve
+    // into clouds at every magnitude.
+    //
+    // Clamp the floor to 1.0 so jittered values never fall below the
+    // bottom axis label (avoids a phantom "gap" between "1" and "2"
+    // when the smear of "1" spills below into the 0.x decade).
+    const logJitter = (v) => {
+        if (!v || v < 1) return 1;
+        const offset = (Math.random() * 2 - 1) * 0.18;
+        return Math.max(1, v * Math.pow(10, offset));
+    };
+    const finishersMax = Math.max(
+        ...data.cpm.map(p => p.finishers || 1),
+        ...data.vq3.map(p => p.finishers || 1)
+    );
     Plotly.newPlot('chart-release-vs-finishers', ['cpm','vq3'].map(phys => ({
         x: data[phys].map(p => p.date_added),
-        y: data[phys].map(p => p.finishers),
+        y: data[phys].map(p => logJitter(p.finishers)),
         customdata: buildHover(data[phys]),
         hovertemplate: '%{customdata}<extra></extra>',
         mode: 'markers', type: 'scattergl', name: phys.toUpperCase(),
         marker: { size: 4, opacity: 0.55, color: phys === 'cpm' ? '#a855f7' : '#3b82f6' },
     })), { ...DARK,
            xaxis: { ...DARK.xaxis, title: 'map release date', type: 'date' },
-           yaxis: { ...DARK.yaxis, title: 'unique finishers (log)', type: 'log' } }, CFG);
+           yaxis: { ...DARK.yaxis, title: 'unique finishers (log)', ...LOG_AXIS,
+                    range: [0, Math.log10(finishersMax) + 0.05], autorange: false } }, CFG);
 
     // 12. Scatter: release × WR set date
     Plotly.newPlot('chart-release-vs-wrdate', ['cpm','vq3'].map(phys => ({
@@ -268,27 +353,27 @@ onMounted(renderAll);
 
             <!-- Top-level summary chips -->
             <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
-                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <div class="text-2xl font-bold text-white">{{ summary.total_maps?.toLocaleString() }}</div>
                     <div class="text-xs text-gray-400 uppercase tracking-wider">Maps</div>
                 </div>
-                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <div class="text-2xl font-bold text-white">{{ summary.total_records?.toLocaleString() }}</div>
                     <div class="text-xs text-gray-400 uppercase tracking-wider">Records</div>
                 </div>
-                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <div class="text-2xl font-bold text-white">{{ summary.total_wrs?.toLocaleString() }}</div>
                     <div class="text-xs text-gray-400 uppercase tracking-wider">Top-1 runs</div>
                 </div>
-                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <div class="text-2xl font-bold text-white">{{ summary.total_authors?.toLocaleString() }}</div>
                     <div class="text-xs text-gray-400 uppercase tracking-wider">Mappers</div>
                 </div>
-                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <div class="text-2xl font-bold text-white">{{ summary.total_players?.toLocaleString() }}</div>
                     <div class="text-xs text-gray-400 uppercase tracking-wider">Players</div>
                 </div>
-                <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <div class="text-sm font-bold text-white">{{ summary.first_record }}</div>
                     <div class="text-xs text-gray-400 uppercase tracking-wider">First record</div>
                 </div>
@@ -300,73 +385,73 @@ onMounted(renderAll);
 
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 <!-- Histograms / bar charts in 2-col -->
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <h2 class="text-base font-bold text-white mb-1">WR time distribution</h2>
                     <p class="text-xs text-gray-500 mb-2">Per-map fastest run, log-scale X. CPM (purple) vs VQ3 (blue).</p>
                     <div id="chart-hist" style="height: 360px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <h2 class="text-base font-bold text-white mb-1">Maps released per year</h2>
                     <p class="text-xs text-gray-500 mb-2">When was the map library built?</p>
                     <div id="chart-yearly" style="height: 360px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <h2 class="text-base font-bold text-white mb-1">Distinct active players per year</h2>
                     <p class="text-xs text-gray-500 mb-2">Players who set at least one record that year.</p>
                     <div id="chart-active-players" style="height: 360px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl">
                     <h2 class="text-base font-bold text-white mb-1">Records per player</h2>
                     <p class="text-xs text-gray-500 mb-2">Long-tail distribution — most players have a handful, a few have thousands.</p>
                     <div id="chart-records-per-player" style="height: 360px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Weapon presence in new maps</h2>
                     <p class="text-xs text-gray-500 mb-2">% of maps released each year that include each weapon.</p>
                     <div id="chart-weapons" style="height: 360px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Top mappers</h2>
                     <p class="text-xs text-gray-500 mb-2">25 most prolific authors by visible map count.</p>
                     <div id="chart-authors" style="min-height: 600px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">WR concentration (top 30)</h2>
                     <p class="text-xs text-gray-500 mb-2">Bar = WRs held, line = cumulative % of all WRs.</p>
                     <div id="chart-pareto" style="height: 420px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">WRs by country</h2>
                     <p class="text-xs text-gray-500 mb-2">Choropleth of map-best-time holders.</p>
                     <div id="chart-countries" style="height: 480px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Activity heatmap</h2>
                     <p class="text-xs text-gray-500 mb-2">Records set per month, per year. GitHub-style — the brighter the busier.</p>
                     <div id="chart-heatmap" style="min-height: 600px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Map release date × WR time</h2>
                     <p class="text-xs text-gray-500 mb-2">Each dot is one map. Hover for details.</p>
                     <div id="chart-release-vs-wr" style="height: 540px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Map release date × number of finishers</h2>
                     <p class="text-xs text-gray-500 mb-2">Older maps tend to have more finishers, but viral newer maps stand out.</p>
                     <div id="chart-release-vs-finishers" style="height: 540px"></div>
                 </div>
 
-                <div class="bg-black/40 border border-white/10 rounded-xl p-4 lg:col-span-2">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-3 shadow-2xl lg:col-span-2">
                     <h2 class="text-base font-bold text-white mb-1">Map release date × WR set date</h2>
                     <p class="text-xs text-gray-500 mb-2">Diagonal-ish — outliers above the line are late discoveries (WR set years after release).</p>
                     <div id="chart-release-vs-wrdate" style="height: 540px"></div>

--- a/resources/js/Pages/Maps.vue
+++ b/resources/js/Pages/Maps.vue
@@ -1,6 +1,6 @@
 <script setup>
     import { ref, computed, onMounted } from 'vue';
-    import { Head, router } from '@inertiajs/vue3';
+    import { Head, Link, router } from '@inertiajs/vue3';
     import Pagination from '@/Components/Basic/Pagination.vue';
     import MapCard from '@/Components/MapCard.vue';
     import MapFiltersSidebar from '@/Components/MapFiltersSidebar.vue';
@@ -170,13 +170,29 @@
         });
     };
 
-    const randomMap = ref({ name: null, copied: false, loading: false, error: null });
+    // `copied` carries which variant was placed on the clipboard last:
+    // 'name' (auto-copy on pick) or 'callvote' (when user hits the
+    // /callvote button). Drives the inline "(copied)" hint label.
+    const randomMap = ref({ name: null, copied: null, loading: false, error: null });
+
+    const copyRandomVariant = async (variant) => {
+        if (!randomMap.value.name) return;
+        const text = variant === 'callvote'
+            ? `/callvote map ${randomMap.value.name}`
+            : randomMap.value.name;
+        try {
+            await navigator.clipboard.writeText(text);
+            randomMap.value.copied = variant;
+        } catch (e) {
+            randomMap.value.copied = null;
+        }
+    };
 
     const pickRandomMap = async () => {
         if (randomMap.value.loading) return;
         randomMap.value.loading = true;
         randomMap.value.error = null;
-        randomMap.value.copied = false;
+        randomMap.value.copied = null;
         try {
             // Reuse the current URL's query string so nested filters (weapons[include][], records_count[])
             // are forwarded to the backend in the exact same format MapFilters expects.
@@ -184,18 +200,23 @@
             const response = await axios.get('/maps/random' + qs);
             const name = response.data.name;
             randomMap.value.name = name;
+            // Auto-copy the bare map name (most common use). Buttons
+            // below let the user re-copy as `/callvote map <name>` if
+            // they're feeding it into Quake's console.
             try {
                 await navigator.clipboard.writeText(name);
-                randomMap.value.copied = true;
+                randomMap.value.copied = 'name';
             } catch (e) {
-                randomMap.value.copied = false;
+                randomMap.value.copied = null;
             }
+            // Stay visible longer than the 4s before — user wants to
+            // click through / re-copy after the auto-copy fires.
             setTimeout(() => {
                 if (randomMap.value.name === name) {
                     randomMap.value.name = null;
-                    randomMap.value.copied = false;
+                    randomMap.value.copied = null;
                 }
-            }, 4000);
+            }, 12000);
         } catch (e) {
             randomMap.value.error = e.response?.data?.error || 'Failed to pick random map';
             setTimeout(() => { randomMap.value.error = null; }, 3000);
@@ -261,9 +282,27 @@
                         </div>
                         <div v-if="randomMap.name || randomMap.error" class="mt-1.5 text-xs">
                             <span v-if="randomMap.error" class="text-red-400">{{ randomMap.error }}</span>
-                            <span v-else class="text-green-400">
-                                <span class="font-mono font-bold">{{ randomMap.name }}</span>
-                                <span class="text-gray-400 ml-1">{{ randomMap.copied ? '(copied)' : '' }}</span>
+                            <span v-else class="inline-flex items-center gap-1.5 flex-wrap">
+                                <Link
+                                    :href="`/maps/${encodeURIComponent(randomMap.name)}`"
+                                    class="font-mono font-bold text-green-400 hover:text-green-300 underline decoration-dotted underline-offset-2"
+                                    :title="`Open ${randomMap.name}`"
+                                >{{ randomMap.name }}</Link>
+                                <button
+                                    @click="copyRandomVariant('name')"
+                                    title="Copy map name"
+                                    class="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10 hover:text-white transition-colors">
+                                    name
+                                </button>
+                                <button
+                                    @click="copyRandomVariant('callvote')"
+                                    title="Copy /callvote map command"
+                                    class="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10 hover:text-white transition-colors">
+                                    /callvote
+                                </button>
+                                <span v-if="randomMap.copied" class="text-gray-400">
+                                    (copied {{ randomMap.copied === 'callvote' ? '/callvote' : 'name' }})
+                                </span>
                             </span>
                         </div>
                     </div>
@@ -283,10 +322,28 @@
                                 </svg>
                                 {{ randomMap.loading ? '...' : 'Random' }}
                             </button>
-                            <span v-if="randomMap.name" class="text-xs text-green-400 font-mono w-full">
-                                <span class="font-bold">{{ randomMap.name }}</span>
-                                <span class="text-gray-400 ml-1">{{ randomMap.copied ? '(copied)' : '' }}</span>
-                            </span>
+                            <div v-if="randomMap.name" class="text-xs w-full inline-flex items-center gap-1.5 flex-wrap">
+                                <Link
+                                    :href="`/maps/${encodeURIComponent(randomMap.name)}`"
+                                    class="font-mono font-bold text-green-400 hover:text-green-300 underline decoration-dotted underline-offset-2"
+                                    :title="`Open ${randomMap.name}`"
+                                >{{ randomMap.name }}</Link>
+                                <button
+                                    @click="copyRandomVariant('name')"
+                                    title="Copy map name"
+                                    class="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10 hover:text-white transition-colors">
+                                    name
+                                </button>
+                                <button
+                                    @click="copyRandomVariant('callvote')"
+                                    title="Copy /callvote map command"
+                                    class="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10 hover:text-white transition-colors">
+                                    /callvote
+                                </button>
+                                <span v-if="randomMap.copied" class="text-gray-400">
+                                    (copied {{ randomMap.copied === 'callvote' ? '/callvote' : 'name' }})
+                                </span>
+                            </div>
                             <span v-else-if="randomMap.error" class="text-xs text-red-400 w-full">{{ randomMap.error }}</span>
                         </div>
                         <!-- Tags bar (relative wrapper, expanded is absolute overlay) -->

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -499,16 +499,34 @@ const getFunctionName = (abbr) => {
                     <!-- Background Image - FIXED SIZE, never changes, keeps aspect ratio -->
                     <div class="absolute top-0 left-0 right-0 h-[450px] rounded-t-2xl pointer-events-none">
                         <div class="relative inline-block w-full">
+                            <!-- Soft mask on the image itself: bottom
+                                 ~30% of the thumbnail fades to
+                                 transparent so the image dissolves
+                                 directly into the glass card body.
+                                 No separate overlay slab needed. -->
                             <a v-if="server.map" :href="`/maps/${server.map}`" class="block">
-                                <img :src="`/storage/${server.mapdata?.thumbnail}`" @error="$event.target.src='/images/unknown.jpg'" class="w-full object-contain object-top pointer-events-auto cursor-pointer" style="max-height: 450px;" />
+                                <img :src="`/storage/${server.mapdata?.thumbnail}`" @error="$event.target.src='/images/unknown.jpg'" class="w-full object-contain object-top pointer-events-auto cursor-pointer" style="max-height: 450px; -webkit-mask-image: linear-gradient(to bottom, black 65%, transparent 100%); mask-image: linear-gradient(to bottom, black 65%, transparent 100%);" />
                             </a>
-                            <img v-else :src="`/storage/${server.mapdata?.thumbnail}`" @error="$event.target.src='/images/unknown.jpg'" class="w-full object-contain object-top" style="max-height: 450px;" />
-                            <!-- Fade positioned at bottom of actual image -->
-                            <div :class="['absolute inset-x-0 bottom-0 bg-gradient-to-t to-transparent', hoveredMapServer === server.id ? 'h-6 from-gray-950/90' : 'h-40 from-black via-black/80']"></div>
-                            <!-- Solid dark below the image -->
+                            <img v-else :src="`/storage/${server.mapdata?.thumbnail}`" @error="$event.target.src='/images/unknown.jpg'" class="w-full object-contain object-top" style="max-height: 450px; -webkit-mask-image: linear-gradient(to bottom, black 65%, transparent 100%); mask-image: linear-gradient(to bottom, black 65%, transparent 100%);" />
+                            <!-- Hover state: shrunken bottom fade kept
+                                 because the hover overlay below the
+                                 image needs a visible seam. -->
+                            <div :class="['absolute inset-x-0 bottom-0 bg-gradient-to-t to-transparent transition-all', hoveredMapServer === server.id ? 'h-6 from-gray-950/90 opacity-100' : 'h-0 opacity-0']"></div>
+                            <!-- Solid dark below the image (only when
+                                 the user hovers the map row to reveal
+                                 the metadata overlay) -->
                             <div :class="['absolute inset-x-0 top-full w-full bg-gray-950/90', hoveredMapServer === server.id ? 'h-[300px]' : 'h-0']" style="transition: height 0.3s ease;"></div>
-                            <!-- Reverse fade right below the image -->
-                            <div :class="['absolute inset-x-0 top-full w-full bg-gradient-to-b from-black via-black/80 to-transparent', hoveredMapServer === server.id ? 'h-0 opacity-0' : 'h-[160px] opacity-100']"></div>
+                            <!-- Below the image: no `from-black`
+                                 gradient. Card body's own glass (the
+                                 outer wrapper has bg-black/40
+                                 backdrop-blur-sm) handles readability;
+                                 the previous solid-black-into-glass
+                                 ramp produced a visible dark stripe
+                                 between the thumbnail and the player
+                                 list. Keep this div for the hover
+                                 transition but make it transparent
+                                 in the default state. -->
+                            <div :class="['absolute inset-x-0 top-full w-full bg-gradient-to-b from-black via-black/60 to-transparent', hoveredMapServer === server.id ? 'h-0 opacity-0' : 'h-0 opacity-0']"></div>
                         </div>
                     </div>
 
@@ -615,16 +633,25 @@ const getFunctionName = (abbr) => {
                             </div>
                         </div>
 
-                        <!-- Players List - Always expanded -->
+                        <!-- Players List - Always expanded.
+                             Background uses variant S2 from
+                             /q3-bg-demo.html: slate-700 (#334155) at
+                             88% alpha with a 4px backdrop blur. Solid
+                             enough to read like a panel, but with a
+                             slight bleed of the map thumbnail under
+                             it. Every Q3 colour code stays legible —
+                             black ^0 as a dark silhouette, white ^7
+                             bright, brights (yellow/cyan/magenta)
+                             punchy. -->
                         <div v-if="server.online_players.length > 0" :class="['mb-4 mt-2 map-hover-fade', hoveredMapServer === server.id ? 'opacity-0 pointer-events-none' : 'opacity-100']">
-                            <div class="bg-black/50 rounded-lg p-2 border border-white/10 ">
+                            <div class="rounded-lg p-2 border border-white/10 backdrop-blur-[4px]" style="background: rgba(71,85,105,0.55);">
                                 <div class="space-y-1.5">
                                     <OnlinePlayer v-for="player in server.online_players" :key="player.name" :player="player" />
                                 </div>
                             </div>
                         </div>
                         <div v-else :class="['mb-4 mt-2 map-hover-fade', hoveredMapServer === server.id ? 'opacity-0 pointer-events-none' : 'opacity-100']">
-                            <div class="p-3 bg-black/50 rounded-lg border border-white/10 text-center ">
+                            <div class="p-3 rounded-lg border border-white/10 text-center backdrop-blur-[4px]" style="background: rgba(71,85,105,0.55);">
                                 <span class="text-sm text-gray-300 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]">No players online</span>
                             </div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WebController;
 use App\Http\Controllers\MapsController;
+use App\Http\Controllers\MapStatsController;
 use App\Http\Controllers\BundlesController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\ServersController;
@@ -53,6 +54,7 @@ Route::get('/servers/json', [EndpointController::class, 'index'])->name('servers
 Route::get('/maps', [MapsController::class, 'index'])->name('maps');
 Route::get('/maps/filters', [MapsController::class, 'filters'])->name('maps.filters');
 Route::get('/maps/random', [MapsController::class, 'random'])->name('maps.random');
+Route::get('/maps/stats', [MapStatsController::class, 'index'])->name('maps.stats');
 
 Route::get('/maps/{mapname}/demo-matches', [MapsController::class, 'getDemoMatches'])->name('maps.demoMatches');
 Route::get('/maps/{mapname}/time-history', [MapsController::class, 'timeHistory'])->name('maps.timeHistory');


### PR DESCRIPTION
## Summary
- New `/maps/stats` page with 12 interactive Plotly charts covering aggregates across the whole defrag.racing dataset (15 359 maps, 646 768 records, 28 699 top-1 runs).
- `MapStatsService` caches every aggregate in Redis (6h TTL); nightly `mapstats:rebuild` cron at 04:00 CET so visitors never hit a cold cache.
- Random map button on `/maps` now exposes a clickable result link, a "copy /callvote map <name>" shortcut, and a "copy bare name" re-copy.
- Server cards: thumbnail mask + translucent slate player-list bubble. Q3 `^0` colour code restored to true black across the whole site (was remapped to grey).

## Test plan
- [ ] `/maps/stats` loads, all 12 charts render, hover shows map / author / WR holder
- [ ] Activity heatmap height matches its data, no big empty band below
- [ ] `/maps` Random button: clicks open the map, copy buttons paste the right thing into Quake / clipboard
- [ ] Server cards: thumbnail fades smoothly into the card, no black stripe
- [ ] Black-coded nicks (`^0`) actually look black and stay readable on the player-list bubble
- [ ] Spectator nicks are full-colour, not dimmed
- [ ] After deploy, run `php artisan mapstats:rebuild` once so the first visitor doesn't wait 14s for cold cache
