### PR TITLE
Map stats: never block a request on the 100s rebuild

### DIFF
--- a/app/Http/Controllers/MapStatsController.php
+++ b/app/Http/Controllers/MapStatsController.php
@@ -36,8 +36,26 @@ class MapStatsController extends Controller
             return Inertia::render('MapStats', ['stats' => null]);
         }
 
+        // Read straight from Redis — never block a web request on the
+        // cold rebuild (~100s on production, well past the upstream
+        // timeout). If the key is missing, kick off a background
+        // rebuild via the queue and return a "still warming" payload
+        // so the front-end can keep polling.
+        $cached = \Illuminate\Support\Facades\Cache::get(MapStatsService::CACHE_PREFIX.'all');
+
+        if ($cached) {
+            return Inertia::render('MapStats', ['stats' => $cached]);
+        }
+
+        // Cold cache: enqueue a rebuild and tell the client to retry.
+        \Illuminate\Support\Facades\Cache::add(MapStatsService::CACHE_PREFIX.'rebuilding', 1, 300);
+        dispatch(function () {
+            app(MapStatsService::class)->all();
+            \Illuminate\Support\Facades\Cache::forget(MapStatsService::CACHE_PREFIX.'rebuilding');
+        })->afterResponse();
+
         return Inertia::render('MapStats', [
-            'stats' => fn () => $this->stats->all(),
+            'stats' => ['__rebuilding' => true],
         ]);
     }
 

--- a/app/Services/MapStatsService.php
+++ b/app/Services/MapStatsService.php
@@ -18,7 +18,15 @@ use Illuminate\Support\Facades\DB;
  */
 class MapStatsService
 {
-    public const CACHE_TTL = 21600; // 6 hours
+    // 25h TTL paired with the daily 04:00 cron `mapstats:rebuild` —
+    // the cron always refreshes the keys before they can expire, so
+    // a visitor never lands on an empty cache that would force a
+    // ~100s synchronous DB rebuild (production timing — local is
+    // ~14s but production sees 7× slower aggregates on 646k rows).
+    // 6h was the original TTL, but with rebuild taking that long any
+    // mid-day expiry meant the next visitor stalled / 504'd from the
+    // upstream timeout.
+    public const CACHE_TTL = 90000; // 25 hours
     public const CACHE_PREFIX = 'mapstats:';
 
     /**

--- a/deploy.py
+++ b/deploy.py
@@ -71,12 +71,16 @@ def pipeline_cmds(name):
         # leaderboard, server list, map stats endpoint). cache:clear
         # above wiped them and most have TTLs of 12h+, so the first
         # visitor would otherwise pay full DB cost.
-        "curl -s -o /dev/null --max-time 30 https://defrag.racing/ || true",
-        "curl -s -o /dev/null --max-time 30 https://defrag.racing/ranking || true",
-        "curl -s -o /dev/null --max-time 30 https://defrag.racing/records || true",
-        "curl -s -o /dev/null --max-time 30 https://defrag.racing/community || true",
-        "curl -s -o /dev/null --max-time 30 https://defrag.racing/servers || true",
-        "curl -s -o /dev/null --max-time 30 https://defrag.racing/maps/stats || true",
+        #
+        # `-w` prints status + timing per URL so the deploy log
+        # actually shows what got warmed (a silent `-s -o /dev/null`
+        # gives no feedback, which made the warm-up indistinguishable
+        # from "didn't run").
+        'echo "==> Warming public-page caches..."',
+        'for url in / /ranking /records /community /servers /maps/stats; do '
+        'echo "  - https://defrag.racing$url"; '
+        'curl -s -o /dev/null --max-time 30 -w "    HTTP %{http_code}  in %{time_total}s\\n" "https://defrag.racing$url" || echo "    (failed, continuing)"; '
+        'done',
     ]
 
     return cmds
@@ -91,7 +95,14 @@ def deploy():
     subprocess.run(git_clone_cmd, shell=True, cwd=f"{PROJECT_PATH}/releases")
 
     for cmd in cmds:
-        subprocess.run(cmd, shell=True, cwd=f"{PROJECT_PATH}/releases/{name}")
+        # Print the command we're about to run + flag non-zero exits
+        # so warm-up failures (like mapstats:rebuild blowing up
+        # silently) are visible in the deploy log instead of being
+        # swallowed.
+        print(f"\n>>> {cmd}", flush=True)
+        result = subprocess.run(cmd, shell=True, cwd=f"{PROJECT_PATH}/releases/{name}")
+        if result.returncode != 0:
+            print(f"!!! exit {result.returncode} from: {cmd}", flush=True)
 
 if __name__ == "__main__":
     deploy()

--- a/resources/js/Pages/MapStats.vue
+++ b/resources/js/Pages/MapStats.vue
@@ -49,6 +49,14 @@ const fetchStats = () => {
     statsError.value = null;
     const start = Date.now();
     const finishLoading = () => {
+        // Backend returns { __rebuilding: true } when the cache is
+        // cold and a background job is regenerating it. Don't try
+        // to render charts on that payload — keep the skeleton up
+        // and poll again in a few seconds.
+        if (props.stats && props.stats.__rebuilding) {
+            setTimeout(fetchStats, 5000);
+            return;
+        }
         const elapsed = Date.now() - start;
         const wait = Math.max(0, MIN_SKELETON_MS - elapsed);
         setTimeout(() => {


### PR DESCRIPTION
Cold rebuild on production takes ~100s (DB sees 7× slower aggregates than local on the 646k records table), well past both the Octane request timeout and the 100s Cloudflare upstream timeout — so a visitor landing on an empty cache got 504s instead of a page.

Three fixes:

- TTL 6h → 25h. Paired with the existing 04:00 daily `mapstats:rebuild` cron, the keys never expire mid-day. The cron always refreshes them before the previous run's TTL runs out.
- Controller no longer wraps the rebuild in a Cache::remember on the request path. Reads the cached payload directly; if the key is missing (Redis flush, fresh deploy that lost the warm-up step, etc.) it kicks off a background rebuild via dispatch->afterResponse() and returns a `{__rebuilding: true}` marker.
- Vue page sees the marker and re-polls every 5s with the skeleton still up, so the user sees a "warming" state instead of a stalled navigation.

Also added stronger logging to deploy.py: prints each command before running it and flags any non-zero exit codes, so silent failures (which is how the warm-up steps were going unnoticed) show up in the deploy log.