### PR TITLE
API auth + monitoring, community task fairness, profile UX polish

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -54,6 +54,13 @@ class Kernel extends ConsoleKernel
         // recalc so the page never serves a cold cache to a visitor.
         $schedule->command('mapstats:rebuild')->withoutOverlapping()->dailyAt('04:00');
 
+        // Auto-prune api_call_log rows older than 30 days. The retention
+        // policy lives on the App\Models\ApiCallLog::prunable() scope —
+        // model:prune calls that and deletes whatever matches.
+        $schedule->command('model:prune', ['--model' => [\App\Models\ApiCallLog::class]])
+            ->withoutOverlapping()
+            ->dailyAt('03:30');
+
         // Unlock demos stuck in 'processing' for more than 15 minutes and re-queue them
         $schedule->command('demos:unlock-stuck')->withoutOverlapping()->everyFiveMinutes();
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,9 @@
 
 namespace App\Exceptions;
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Inertia\Inertia;
 use Throwable;
@@ -19,6 +21,24 @@ class Handler extends ExceptionHandler
         'password',
         'password_confirmation',
     ];
+
+    /**
+     * Authentication failures on /api/* are always returned as a JSON 401,
+     * regardless of the request's Accept header. The default framework
+     * behaviour redirects to /login when the Accept header isn't JSON,
+     * which produces a useless HTML redirect for AJAX calls that
+     * forgot to set the header.
+     */
+    protected function unauthenticated($request, AuthenticationException $exception)
+    {
+        if ($request->is('api/*')) {
+            return response()->json([
+                'message' => $exception->getMessage(),
+            ], 401);
+        }
+
+        return parent::unauthenticated($request, $exception);
+    }
 
     /**
      * Register the exception handling callbacks for the application.

--- a/app/Filament/Resources/ApiCallLogResource.php
+++ b/app/Filament/Resources/ApiCallLogResource.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ApiCallLogResource\Pages;
+use App\Models\ApiCallLog;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ApiCallLogResource extends Resource
+{
+    protected static ?string $model = ApiCallLog::class;
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
+    protected static ?string $navigationGroup = 'Moderation';
+    protected static ?string $navigationLabel = 'API call log';
+    protected static ?int $navigationSort = 50;
+    protected static bool $shouldSkipAuthorization = true;
+
+    public static function canAccess(): bool
+    {
+        $user = auth()->user();
+        return $user && ($user->admin || $user->is_moderator);
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = ApiCallLog::where('created_at', '>=', now()->subDay())->count();
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'gray';
+    }
+
+    public static function getWidgets(): array
+    {
+        return [
+            \App\Filament\Resources\ApiCallLogResource\Widgets\ApiCallStatsOverview::class,
+        ];
+    }
+
+    /**
+     * The main list page aggregates one row per user — total calls in
+     * the visible window, last activity. Clicking the user drills into
+     * the per-endpoint breakdown for that user.
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => ApiCallLog::query()
+                ->selectRaw('user_id, COUNT(*) as call_count, MAX(created_at) as last_call, SUM(CASE WHEN response_status >= 400 THEN 1 ELSE 0 END) as error_count, SUM(CASE WHEN token_id IS NOT NULL THEN 1 ELSE 0 END) as token_call_count')
+                ->groupBy('user_id')
+            )
+            ->defaultSort('call_count', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('User')
+                    ->searchable()
+                    ->formatStateUsing(fn (?string $state): string => $state ? UserResource::q3tohtml($state) : '')
+                    ->html(),
+                Tables\Columns\TextColumn::make('call_count')
+                    ->label('Total calls')
+                    ->sortable()
+                    ->numeric()
+                    ->color(fn ($state) => $state > 5000 ? 'danger' : ($state > 1000 ? 'warning' : 'gray')),
+                Tables\Columns\TextColumn::make('token_call_count')
+                    ->label('Via token')
+                    ->numeric()
+                    ->color('info')
+                    ->tooltip('Calls made with an API Bearer token (vs browser session)'),
+                Tables\Columns\TextColumn::make('error_count')
+                    ->label('Errors')
+                    ->numeric()
+                    ->color(fn ($state) => $state > 0 ? 'warning' : 'gray'),
+                Tables\Columns\TextColumn::make('last_call')
+                    ->label('Last call')
+                    ->dateTime('Y-m-d H:i:s')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('viewActivity')
+                    ->label('Detail')
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->color('primary')
+                    ->url(fn ($record) => Pages\ViewUserActivity::getUrl(['user' => $record->user_id])),
+                Tables\Actions\Action::make('viewProfile')
+                    ->label('Profile')
+                    ->icon('heroicon-o-user-circle')
+                    ->color('gray')
+                    ->url(fn ($record) => "/profile/{$record->user_id}")
+                    ->openUrlInNewTab(),
+            ])
+            ->filters([
+                Tables\Filters\Filter::make('last_24h')
+                    ->label('Last 24h')
+                    ->query(fn ($query) => $query->where('created_at', '>=', now()->subDay())),
+                Tables\Filters\Filter::make('last_7d')
+                    ->label('Last 7 days')
+                    ->default()
+                    ->query(fn ($query) => $query->where('created_at', '>=', now()->subDays(7))),
+                Tables\Filters\Filter::make('errors_only')
+                    ->label('Had errors')
+                    ->query(fn ($query) => $query->havingRaw('SUM(CASE WHEN response_status >= 400 THEN 1 ELSE 0 END) > 0')),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'              => Pages\ListApiCallLogs::route('/'),
+            'user-activity'      => Pages\ViewUserActivity::route('/users/{user}'),
+            'endpoint-activity'  => Pages\ViewUserEndpointActivity::route('/users/{user}/endpoint'),
+            'view-call'          => Pages\ViewApiCall::route('/calls/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Pages/ListApiCallLogs.php
+++ b/app/Filament/Resources/ApiCallLogResource/Pages/ListApiCallLogs.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Pages;
+
+use App\Filament\Resources\ApiCallLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListApiCallLogs extends ListRecords
+{
+    protected static string $resource = ApiCallLogResource::class;
+
+    public function getTableRecordKey($record): string
+    {
+        // The main list aggregates GROUP BY user_id, so rows have no
+        // primary id. user_id is unique per row and works as the key.
+        return (string) ($record->user_id ?? '0');
+    }
+
+    protected function getHeaderWidgets(): array
+    {
+        return ApiCallLogResource::getWidgets();
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Pages/ViewApiCall.php
+++ b/app/Filament/Resources/ApiCallLogResource/Pages/ViewApiCall.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Pages;
+
+use App\Filament\Resources\ApiCallLogResource;
+use App\Models\ApiCallLog;
+use Filament\Resources\Pages\Page;
+
+class ViewApiCall extends Page
+{
+    protected static string $resource = ApiCallLogResource::class;
+    protected static string $view = 'filament.api-call-log.view-call';
+
+    public ?ApiCallLog $call = null;
+
+    public function mount(int $record): void
+    {
+        $this->call = ApiCallLog::with('user', 'token')->findOrFail($record);
+    }
+
+    public function getTitle(): string
+    {
+        return "API call #{$this->call->id}";
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ApiCallLogResource::getUrl()                                                   => 'API call log',
+            ApiCallLogResource::getUrl('user-activity', ['user' => $this->call->user_id]) => $this->call->user?->plain_name ?? "user #{$this->call->user_id}",
+            '#'                                                                            => "call #{$this->call->id}",
+        ];
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Pages/ViewUserActivity.php
+++ b/app/Filament/Resources/ApiCallLogResource/Pages/ViewUserActivity.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Pages;
+
+use App\Filament\Resources\ApiCallLogResource;
+use App\Filament\Resources\UserResource;
+use App\Models\ApiCallLog;
+use App\Models\User;
+use Filament\Resources\Pages\Page;
+use Filament\Tables;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Drill-down page for one user. Lists their API calls grouped by route
+ * with counts + average response time. Clicking a route opens a modal
+ * with the raw entries (timestamp + query string + status + ms).
+ */
+class ViewUserActivity extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string $resource = ApiCallLogResource::class;
+    protected static string $view = 'filament.api-call-log.view-user-activity';
+
+    public int $user;
+    public ?User $userModel = null;
+
+    public function mount(int $user): void
+    {
+        $this->user = $user;
+        $this->userModel = User::find($user);
+    }
+
+    public function getTitle(): string
+    {
+        $name = $this->userModel?->plain_name ?? $this->userModel?->username ?? "user #{$this->user}";
+        return "API activity — {$name}";
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ApiCallLogResource::getUrl() => 'API call log',
+            '#' => $this->userModel?->plain_name ?? "user #{$this->user}",
+        ];
+    }
+
+    public function getTableRecordKey($record): string
+    {
+        return (string) ($record->route ?? '0');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => ApiCallLog::query()
+                ->selectRaw('
+                    route,
+                    method,
+                    COUNT(*) as call_count,
+                    MAX(created_at) as last_call,
+                    AVG(response_ms) as avg_ms,
+                    SUM(CASE WHEN response_status >= 400 THEN 1 ELSE 0 END) as error_count
+                ')
+                ->where('user_id', $this->user)
+                ->groupBy('route', 'method')
+            )
+            ->defaultSort('call_count', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('method')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('route')
+                    ->wrap(),
+                Tables\Columns\TextColumn::make('call_count')
+                    ->label('Calls')
+                    ->numeric()
+                    ->sortable()
+                    ->color(fn ($state) => $state > 1000 ? 'danger' : ($state > 200 ? 'warning' : 'gray')),
+                Tables\Columns\TextColumn::make('error_count')
+                    ->label('Errors')
+                    ->numeric()
+                    ->color(fn ($state) => $state > 0 ? 'warning' : 'gray'),
+                Tables\Columns\TextColumn::make('avg_ms')
+                    ->label('Avg ms')
+                    ->formatStateUsing(fn ($state) => $state !== null ? round((float) $state) : '—')
+                    ->color(fn ($state) => $state !== null && (float) $state > 1000 ? 'warning' : 'gray'),
+                Tables\Columns\TextColumn::make('last_call')
+                    ->label('Last call')
+                    ->dateTime('Y-m-d H:i:s')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->recordUrl(fn ($record) => ApiCallLogResource::getUrl('endpoint-activity', [
+                'user'   => $this->user,
+                'route'  => $record->route,
+                'method' => $record->method,
+            ]))
+            ->filters([
+                Tables\Filters\Filter::make('last_24h')
+                    ->label('Last 24h')
+                    ->query(fn ($query) => $query->where('created_at', '>=', now()->subDay())),
+                Tables\Filters\Filter::make('last_7d')
+                    ->label('Last 7 days')
+                    ->default()
+                    ->query(fn ($query) => $query->where('created_at', '>=', now()->subDays(7))),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Pages/ViewUserEndpointActivity.php
+++ b/app/Filament/Resources/ApiCallLogResource/Pages/ViewUserEndpointActivity.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Pages;
+
+use App\Filament\Resources\ApiCallLogResource;
+use App\Models\ApiCallLog;
+use App\Models\User;
+use Filament\Resources\Pages\Page;
+use Filament\Tables;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Drill-down for one user + endpoint combination. Lists the raw call
+ * rows so the admin can see every individual query (?q=xyz etc) and
+ * click through to a single-call detail.
+ *
+ * No GROUP BY here — rows have real primary keys, so standard Filament
+ * row actions / URLs work without the headache.
+ */
+class ViewUserEndpointActivity extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string $resource = ApiCallLogResource::class;
+    protected static string $view = 'filament.api-call-log.view-user-endpoint-activity';
+
+    public int $user;
+    public string $route;
+    public string $method;
+    public ?User $userModel = null;
+
+    public function mount(int $user): void
+    {
+        $this->user      = $user;
+        $this->route     = (string) request('route', '/');
+        $this->method    = (string) request('method', 'GET');
+        $this->userModel = User::find($user);
+    }
+
+    public function getTitle(): string
+    {
+        return "{$this->method} {$this->route}";
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ApiCallLogResource::getUrl()                                                   => 'API call log',
+            ApiCallLogResource::getUrl('user-activity', ['user' => $this->user]) => $this->userModel?->plain_name ?? "user #{$this->user}",
+            '#'                                                                            => "{$this->method} {$this->route}",
+        ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => ApiCallLog::query()
+                ->where('user_id', $this->user)
+                ->where('route', $this->route)
+                ->where('method', $this->method)
+            )
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('When')
+                    ->dateTime('Y-m-d H:i:s')
+                    ->since()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('query_string')
+                    ->label('Query')
+                    ->formatStateUsing(fn (?string $state) => $state ? '?' . $state : '—')
+                    ->wrap()
+                    ->fontFamily('mono'),
+                Tables\Columns\TextColumn::make('response_status')
+                    ->label('Status')
+                    ->badge()
+                    ->color(fn (?int $state) => match (true) {
+                        $state === null => 'gray',
+                        $state >= 500   => 'danger',
+                        $state >= 400   => 'warning',
+                        $state >= 200   => 'success',
+                        default         => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('response_ms')
+                    ->label('ms')
+                    ->numeric()
+                    ->sortable()
+                    ->color(fn (?int $state) => match (true) {
+                        $state === null => 'gray',
+                        $state > 2000   => 'danger',
+                        $state > 500    => 'warning',
+                        default         => 'success',
+                    }),
+                Tables\Columns\TextColumn::make('ip')
+                    ->fontFamily('mono')
+                    ->copyable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('token_id')
+                    ->label('Auth')
+                    ->state(fn ($record) => $record->token_id ? "token #{$record->token_id}" : 'session')
+                    ->badge()
+                    ->color(fn ($state) => str_starts_with((string) $state, 'token') ? 'info' : 'gray'),
+            ])
+            ->recordUrl(fn ($record) => ApiCallLogResource::getUrl('view-call', ['record' => $record->id]))
+            ->paginated([25, 50, 100, 200]);
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Widgets/ApiCallStatsOverview.php
+++ b/app/Filament/Resources/ApiCallLogResource/Widgets/ApiCallStatsOverview.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Widgets;
+
+use App\Models\ApiCallLog;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class ApiCallStatsOverview extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    protected function getStats(): array
+    {
+        $last24h = ApiCallLog::where('created_at', '>=', now()->subDay())->count();
+        $last7d  = ApiCallLog::where('created_at', '>=', now()->subDays(7))->count();
+        $errors  = ApiCallLog::where('created_at', '>=', now()->subDay())
+            ->where('response_status', '>=', 400)
+            ->count();
+        $byToken = ApiCallLog::where('created_at', '>=', now()->subDay())
+            ->whereNotNull('token_id')
+            ->count();
+
+        return [
+            Stat::make('Last 24h', number_format($last24h))
+                ->description('all API hits')
+                ->color('primary'),
+            Stat::make('Last 7d', number_format($last7d))
+                ->description('all API hits')
+                ->color('gray'),
+            Stat::make('Errors 24h', number_format($errors))
+                ->description('4xx + 5xx responses')
+                ->color($errors > 0 ? 'warning' : 'success'),
+            Stat::make('Token-auth 24h', number_format($byToken))
+                ->description('Bearer-token calls (vs browser session)')
+                ->color('info'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Widgets/ApiTopEndpoints.php
+++ b/app/Filament/Resources/ApiCallLogResource/Widgets/ApiTopEndpoints.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Widgets;
+
+use App\Models\ApiCallLog;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+
+class ApiTopEndpoints extends BaseWidget
+{
+    protected static ?int $sort = 3;
+    protected static ?string $heading = 'Top endpoints (last 7 days)';
+    protected int | string | array $columnSpan = 1;
+
+    public function getTableRecordKey($record): string
+    {
+        return (string) ($record->route ?? '0');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->paginated(false)
+            ->query(function (): Builder {
+                return ApiCallLog::query()
+                    ->selectRaw('route, COUNT(*) as call_count, AVG(response_ms) as avg_ms')
+                    ->where('created_at', '>=', now()->subDays(7))
+                    ->groupBy('route')
+                    ->orderByDesc('call_count')
+                    ->limit(10);
+            })
+            ->columns([
+                Tables\Columns\TextColumn::make('route'),
+                Tables\Columns\TextColumn::make('call_count')
+                    ->label('Calls')
+                    ->numeric()
+                    ->color(fn ($state) => $state > 5000 ? 'danger' : ($state > 1000 ? 'warning' : 'gray')),
+                Tables\Columns\TextColumn::make('avg_ms')
+                    ->label('Avg ms')
+                    ->formatStateUsing(fn ($state) => $state !== null ? round((float) $state) : '—')
+                    ->color(fn ($state) => $state !== null && (float) $state > 1000 ? 'warning' : 'gray'),
+            ])
+            ->recordUrl(fn ($record) => "/defraghq/api-call-logs?tableFilters[route][value]=" . urlencode($record->route));
+    }
+}

--- a/app/Filament/Resources/ApiCallLogResource/Widgets/ApiTopUsers.php
+++ b/app/Filament/Resources/ApiCallLogResource/Widgets/ApiTopUsers.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources\ApiCallLogResource\Widgets;
+
+use App\Filament\Resources\UserResource;
+use App\Models\ApiCallLog;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Last 7-day "who hit the API the most" leaderboard.
+ *
+ * We group by user_id rather than per-token because the goal is to
+ * spot users (potential scrapers); per-token detail is available in
+ * the main list table via filters.
+ */
+class ApiTopUsers extends BaseWidget
+{
+    protected static ?int $sort = 2;
+    protected static ?string $heading = 'Top users (last 7 days)';
+    protected int | string | array $columnSpan = 1;
+
+    public function getTableRecordKey($record): string
+    {
+        // GROUP BY query has no real primary id — use user_id as the key.
+        return (string) ($record->user_id ?? '0');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->paginated(false)
+            ->query(function (): Builder {
+                return ApiCallLog::query()
+                    ->selectRaw('user_id, COUNT(*) as call_count, MAX(created_at) as last_call')
+                    ->where('created_at', '>=', now()->subDays(7))
+                    ->groupBy('user_id')
+                    ->orderByDesc('call_count')
+                    ->limit(10);
+            })
+            ->columns([
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('User')
+                    ->formatStateUsing(fn (?string $state): string => $state ? UserResource::q3tohtml($state) : '')
+                    ->html()
+                    ->url(fn ($record) => $record->user_id ? "/profile/{$record->user_id}" : null),
+                Tables\Columns\TextColumn::make('call_count')
+                    ->label('Calls')
+                    ->numeric()
+                    ->color(fn ($state) => $state > 1000 ? 'danger' : ($state > 200 ? 'warning' : 'gray')),
+                Tables\Columns\TextColumn::make('last_call')
+                    ->label('Last call')
+                    ->dateTime('Y-m-d H:i')
+                    ->since(),
+            ])
+            ->recordUrl(fn ($record) => "/defraghq/api-call-logs?tableFilters[user_id][value]={$record->user_id}");
+    }
+}

--- a/app/Filament/Resources/CommunityTaskReviewResource.php
+++ b/app/Filament/Resources/CommunityTaskReviewResource.php
@@ -187,6 +187,55 @@ class CommunityTaskReviewResource extends Resource
                     })
                     ->modalWidth('lg'),
 
+                Tables\Actions\Action::make('viewMapRecords')
+                    ->label('Map records')
+                    ->icon('heroicon-o-table-cells')
+                    ->color('warning')
+                    ->modalHeading(fn (CommunityTaskVote $record) => "Records on {$record->demo?->map_name}")
+                    ->modalDescription('All records on the demo\'s map+gametype. Use the time difference column to find the rival run.')
+                    ->modalWidth('6xl')
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Close')
+                    ->modalContent(function (CommunityTaskVote $record) {
+                        $demo = $record->demo;
+                        if (!$demo) {
+                            return new \Illuminate\Support\HtmlString(
+                                '<div class="p-4 text-red-300">Demo not found.</div>'
+                            );
+                        }
+
+                        // Records.gametype is a `run_<physics>` string
+                        // (matches Map\Record convention). The demo's
+                        // own `gametype` is often a mod string ("mdf",
+                        // ...), so duplicate the public flow's
+                        // resolveGametype() logic here.
+                        $resolvedGametype = ($demo->gametype && str_starts_with($demo->gametype, 'run_'))
+                            ? $demo->gametype
+                            : ('run_' . strtolower($demo->physics ?? 'vq3'));
+
+                        $records = \App\Models\Record::query()
+                            ->where('mapname', $demo->map_name)
+                            ->where('gametype', $resolvedGametype)
+                            ->whereNull('deleted_at')
+                            ->with([
+                                'user:id,name',
+                                'uploadedDemos:id,record_id',
+                                'renderedVideos:id,record_id',
+                            ])
+                            ->orderBy('time')
+                            ->limit(200)
+                            ->get();
+
+                        return view('filament.community-task-review.map-records-modal', [
+                            'mapName'         => $demo->map_name,
+                            'physics'         => $demo->physics,
+                            'gametype'        => $resolvedGametype,
+                            'demoTimeMs'      => $demo->time_ms,
+                            'demoPlayerHtml'  => $demo->player_name ? UserResource::q3tohtml($demo->player_name) : '—',
+                            'records'         => $records,
+                        ]);
+                    }),
+
                 Tables\Actions\Action::make('assignRecord')
                     ->label('Assign')
                     ->icon('heroicon-o-link')

--- a/app/Http/Controllers/ApiTokenController.php
+++ b/app/Http/Controllers/ApiTokenController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * JSON API for the api-tokens partial form in profile settings.
+ * Each token is a Sanctum personal access token whose `name` is prefixed
+ * with "api:" so we can filter for API tokens without adding another
+ * column to the shared personal_access_tokens table. Mirrors the launcher
+ * tokens flow — same pattern, different prefix + ability.
+ */
+class ApiTokenController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+
+        $tokens = $user->tokens()
+            ->where('name', 'like', 'api:%')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn ($t) => [
+                'id'           => $t->id,
+                'label'        => substr($t->name, strlen('api:')),
+                'last_used_at' => $t->last_used_at,
+                'created_at'   => $t->created_at,
+            ]);
+
+        return response()->json(['tokens' => $tokens]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'label' => 'required|string|max:50',
+        ]);
+
+        $user = Auth::user();
+        $token = $user->createToken('api:' . $data['label'], ['api:read']);
+
+        return response()->json([
+            'id'           => $token->accessToken->id,
+            'label'        => $data['label'],
+            'created_at'   => $token->accessToken->created_at,
+            'last_used_at' => null,
+            // Plaintext token — only returned once, never persisted in cleartext.
+            'plain_text_token' => $token->plainTextToken,
+        ]);
+    }
+
+    public function destroy(Request $request, int $tokenId)
+    {
+        $user = Auth::user();
+
+        $token = $user->tokens()
+            ->where('id', $tokenId)
+            ->where('name', 'like', 'api:%')
+            ->firstOrFail();
+
+        $token->delete();
+
+        return response()->json(['ok' => true]);
+    }
+}

--- a/app/Http/Controllers/CommunityTasksController.php
+++ b/app/Http/Controllers/CommunityTasksController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\CommunityHelperScore;
+use App\Models\CommunityTaskMapSkip;
 use App\Models\CommunityTaskSession;
 use App\Models\CommunityTaskVote;
 use App\Models\Map;
@@ -79,6 +80,24 @@ class CommunityTasksController extends Controller
             return response()->json(['error' => 'Already voted on this demo'], 422);
         }
 
+        $demo = UploadedDemo::find($demoId);
+
+        // Reject "better match" votes that re-select the currently-assigned
+        // record — that's a no-op gaming the +3 point reward (user clicks
+        // "better match" without actually picking a different rival).
+        if ($voteType === 'better_match') {
+            if (!$request->selected_record_id) {
+                return response()->json([
+                    'error' => '"Better match" requires picking a different record',
+                ], 422);
+            }
+            if ($demo && (int) $demo->record_id === (int) $request->selected_record_id) {
+                return response()->json([
+                    'error' => '"Better match" must be a different record than the one already assigned. Use "Correct" if the current assignment is right.',
+                ], 422);
+            }
+        }
+
         // Create the vote
         $vote = CommunityTaskVote::create([
             'user_id' => $user->id,
@@ -89,7 +108,6 @@ class CommunityTasksController extends Controller
         ]);
 
         $points = 0;
-        $demo = UploadedDemo::find($demoId);
 
         // Handle immediate actions
         switch ($voteType) {
@@ -126,7 +144,9 @@ class CommunityTasksController extends Controller
                         ->whereNull('consensus_status')
                         ->update(['consensus_status' => 'needs_review']);
                 }
-                $points = 1;
+                // Skips don't earn points — they only feed cooldown and
+                // the 3×-trigger consensus logic above.
+                $points = 0;
                 break;
 
             case 'no_match':
@@ -140,6 +160,8 @@ class CommunityTasksController extends Controller
                         ->whereNull('consensus_status')
                         ->update(['consensus_status' => 'needs_review']);
                 }
+                // Real decision ("none of these records match"), worth 1
+                // like correct/unassign.
                 $points = 1;
                 break;
         }
@@ -220,11 +242,74 @@ class CommunityTasksController extends Controller
 
     // ─── Task generation ───────────────────────────────────
 
+    /** How long (days) to skip ALL demos on a map after the user has
+     *  voted "not_sure" on any demo on that map, or skipped its
+     *  difficulty rating / tagging. Without this, a map with many
+     *  uploads keeps coming back even after the reviewer said "no idea".
+     */
+    private const SKIP_MAP_COOLDOWN_DAYS = 7;
+
+    /**
+     * Map names this user has signalled "no idea about" in the cooldown
+     * window — covers not_sure votes (community_task_votes) AND rating/
+     * tag skips (community_task_map_skips). Both task generators exclude
+     * demos on these maps so the reviewer doesn't see the same map
+     * repeatedly with different demos.
+     */
+    private function getCooldownMapNames(int $userId): \Illuminate\Support\Collection
+    {
+        $since = now()->subDays(self::SKIP_MAP_COOLDOWN_DAYS);
+
+        $fromVotes = DB::table('community_task_votes')
+            ->join('uploaded_demos', 'uploaded_demos.id', '=', 'community_task_votes.demo_id')
+            ->where('community_task_votes.user_id', $userId)
+            ->where('community_task_votes.vote_type', 'not_sure')
+            ->where('community_task_votes.created_at', '>=', $since)
+            ->whereNotNull('uploaded_demos.map_name')
+            ->pluck('uploaded_demos.map_name');
+
+        $fromMapSkips = DB::table('community_task_map_skips')
+            ->join('maps', 'maps.id', '=', 'community_task_map_skips.map_id')
+            ->where('community_task_map_skips.user_id', $userId)
+            ->where('community_task_map_skips.created_at', '>=', $since)
+            ->pluck('maps.name');
+
+        return $fromVotes->merge($fromMapSkips)->unique()->values();
+    }
+
+    /**
+     * Records a rating/tag skip server-side so the map enters the user's
+     * cooldown. Returns 0 points — skips are no-effort and we only
+     * reward actual decisions (rating submitted, tag added, etc.).
+     */
+    public function skip(Request $request)
+    {
+        $request->validate([
+            'map_id' => 'required|integer|exists:maps,id',
+            'kind'   => 'required|in:rating,tag',
+        ]);
+
+        $user = Auth::user();
+
+        CommunityTaskMapSkip::create([
+            'user_id'    => $user->id,
+            'map_id'     => $request->map_id,
+            'kind'       => $request->kind,
+            'created_at' => now(),
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'points'  => 0,
+        ]);
+    }
+
     private function generateAssignmentTasks($user, int $count): array
     {
         // Get demo IDs this user already voted on
         $votedDemoIds = CommunityTaskVote::where('user_id', $user->id)->pluck('demo_id');
         $lockedDemoIds = $this->getLockedDemoIds($user->id);
+        $cooldownMaps = $this->getCooldownMapNames($user->id);
 
         // Priority 1: Demos with "not_sure" votes that need more reviewers (re-review)
         $reReviewDemoIds = DB::table('community_task_votes')
@@ -236,6 +321,15 @@ class CommunityTasksController extends Controller
             ->groupBy('demo_id')
             ->havingRaw('COUNT(*) < 3')
             ->pluck('demo_id');
+
+        // Strip out any re-review demos that sit on a cooled-down map.
+        // The pluck above returns demo ids; we filter via map_name here.
+        if ($cooldownMaps->isNotEmpty() && $reReviewDemoIds->isNotEmpty()) {
+            $reReviewDemoIds = UploadedDemo::query()
+                ->whereIn('id', $reReviewDemoIds)
+                ->whereNotIn('map_name', $cooldownMaps)
+                ->pluck('id');
+        }
 
         // Priority 2: Fresh unassigned demos
         $freshDemos = UploadedDemo::query()
@@ -251,6 +345,7 @@ class CommunityTasksController extends Controller
             ->whereNotIn('id', $votedDemoIds)
             ->whereNotIn('id', $lockedDemoIds)
             ->whereNotIn('id', $reReviewDemoIds)
+            ->when($cooldownMaps->isNotEmpty(), fn ($q) => $q->whereNotIn('map_name', $cooldownMaps))
             ->inRandomOrder()
             ->limit($count * 4)
             ->pluck('id');
@@ -283,6 +378,7 @@ class CommunityTasksController extends Controller
     {
         $votedDemoIds = CommunityTaskVote::where('user_id', $user->id)->pluck('demo_id');
         $lockedDemoIds = $this->getLockedDemoIds($user->id);
+        $cooldownMaps = $this->getCooldownMapNames($user->id);
 
         $confirmedDemoIds = CommunityTaskVote::where('vote_type', 'correct')
             ->distinct()
@@ -297,6 +393,7 @@ class CommunityTasksController extends Controller
             ->whereNotIn('id', $votedDemoIds)
             ->whereNotIn('id', $lockedDemoIds)
             ->whereNotIn('id', $confirmedDemoIds)
+            ->when($cooldownMaps->isNotEmpty(), fn ($q) => $q->whereNotIn('map_name', $cooldownMaps))
             ->where(function ($q) use ($user) {
                 $q->where('user_id', '!=', $user->id)
                   ->orWhereNull('user_id');

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -790,66 +790,6 @@ class ProfileController extends Controller {
         ];
     }
 
-    public function getBeatableRecords($myMddId, $rivalMddId, $physics = 'cpm') {
-        // Find records where:
-        // 1. Rival has a record
-        // 2. You either don't have a record OR your record is worse but within 20% time difference (beatable)
-
-        $beatableRecords = DB::select("
-            SELECT
-                rival.mapname,
-                rival.mode,
-                rival.physics,
-                rival.time as rival_time,
-                rival.rank as rival_rank,
-                me.time as my_time,
-                me.rank as my_rank,
-                rival.date_set as rival_date,
-                CASE
-                    WHEN me.time IS NULL THEN 0
-                    ELSE ABS(rival.time - me.time) / rival.time * 100
-                END as time_diff_percent,
-                CASE
-                    WHEN me.time IS NULL THEN 'no_record'
-                    WHEN me.time > rival.time THEN 'behind'
-                    ELSE 'ahead'
-                END as status
-            FROM records rival
-            LEFT JOIN records me ON rival.mapname = me.mapname
-                AND rival.mode = me.mode
-                AND rival.physics = me.physics
-                AND me.mdd_id = ?
-            WHERE rival.mdd_id = ?
-                AND rival.physics = ?
-                AND rival.deleted_at IS NULL
-                AND (me.deleted_at IS NULL OR me.deleted_at IS NOT NULL)
-                AND (
-                    me.time IS NULL
-                    OR (me.time > rival.time AND (me.time - rival.time) / rival.time <= 0.3)
-                )
-            ORDER BY
-                CASE
-                    WHEN me.time IS NULL THEN 2
-                    ELSE 1
-                END,
-                time_diff_percent ASC
-            LIMIT 50
-        ", [$myMddId, $rivalMddId, $physics]);
-
-        return $beatableRecords;
-    }
-
-    public function beatableRecordsApi($userId, $rivalMddId, Request $request) {
-        $user = User::find($userId);
-        if (!$user || !$user->mdd_id) {
-            return response()->json([]);
-        }
-
-        $physics = $request->input("physics", "cpm");
-        $records = $this->getBeatableRecords($user->mdd_id, $rivalMddId, $physics);
-
-        return response()->json($records);
-    }
 
     public function searchPlayers(Request $request) {
         $query = $request->input('q');

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -49,7 +49,17 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            // Load the session cookie unconditionally for every /api/*
+            // request. We explicitly skip Sanctum's
+            // EnsureFrontendRequestsAreStateful here because that
+            // middleware only activates session loading when a Referer
+            // or Origin header is present — pasting an /api/... URL
+            // into a fresh tab doesn't include either and would 401 an
+            // otherwise logged-in user. Bearer-token clients are
+            // unaffected; the session is just unused for them.
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
@@ -81,5 +91,6 @@ class Kernel extends HttpKernel
         'demome.token' => \App\Http\Middleware\DemomeTokenMiddleware::class,
         'abilities' => \Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
         'ability' => \Laravel\Sanctum\Http\Middleware\CheckForAnyAbility::class,
+        'log.api' => \App\Http\Middleware\LogApiCalls::class,
     ];
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -9,9 +9,17 @@ class Authenticate extends Middleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.
+     *
+     * Any /api/* request is treated as a JSON API client even if the caller
+     * forgot to set Accept: application/json — we always return a 401 there
+     * instead of redirecting to the HTML login page.
      */
     protected function redirectTo(Request $request): ?string
     {
-        return $request->expectsJson() ? null : route('login');
+        if ($request->is('api/*') || $request->expectsJson()) {
+            return null;
+        }
+
+        return route('login');
     }
 }

--- a/app/Http/Middleware/BotAwareStartSession.php
+++ b/app/Http/Middleware/BotAwareStartSession.php
@@ -15,12 +15,27 @@ use Illuminate\Session\Middleware\StartSession;
  */
 class BotAwareStartSession extends StartSession
 {
+    /**
+     * Laravel 10's StartSession does NOT define a `terminate()` method —
+     * session persistence happens inside handle() right before the
+     * response is returned. The original implementation called
+     * `parent::terminate()` which threw "undefined method" on every
+     * request that exercised terminable middleware (logged endlessly to
+     * laravel.log without breaking the response, but noisy).
+     *
+     * Keep the override as a no-op so that:
+     *   a) future Laravel upgrades that *do* add terminate() don't
+     *      retroactively start saving bot sessions,
+     *   b) middleware introspection still recognizes this class as
+     *      terminable (preserves original intent).
+     */
     public function terminate($request, $response)
     {
         if (BotDetector::isBot($request->userAgent() ?? '')) {
             return;
         }
-
-        parent::terminate($request, $response);
+        // Parent has no terminate() in Laravel 10.x — saveSession was
+        // already called from handle() before the response went out, so
+        // there's nothing left to do here.
     }
 }

--- a/app/Http/Middleware/LogApiCalls.php
+++ b/app/Http/Middleware/LogApiCalls.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiCallLog;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * Logs every authenticated /api/* call into the `api_call_log` table
+ * with user_id, token_id (if Bearer-token auth), route, status, and
+ * response time. Used to spot heavy / abusive scrapers on a per-user
+ * (or per-token) basis from Filament.
+ *
+ * Mounted on the `auth:sanctum,web`-protected route group in api.php,
+ * so anonymous requests never reach this middleware. The actual write
+ * happens AFTER the response is built, so it doesn't slow down the
+ * user-facing latency.
+ */
+class LogApiCalls
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $start = microtime(true);
+
+        $response = $next($request);
+
+        // Best-effort: never throw out of here, never block the response.
+        try {
+            $user = $request->user();
+            if ($user) {
+                $token   = method_exists($user, 'currentAccessToken')
+                    ? $user->currentAccessToken()
+                    : null;
+                // currentAccessToken returns TransientToken when the user
+                // authenticated via session cookie — TransientToken has
+                // no id. Only PersonalAccessToken is a real PAT row.
+                $tokenId = $token instanceof \Laravel\Sanctum\PersonalAccessToken
+                    ? $token->id
+                    : null;
+
+                $queryString = $request->getQueryString();
+
+                ApiCallLog::create([
+                    'user_id'         => $user->id,
+                    'token_id'        => $tokenId,
+                    'route'           => substr('/' . ltrim($request->path(), '/'), 0, 191),
+                    'query_string'    => $queryString !== '' && $queryString !== null
+                        ? substr($queryString, 0, 2000)
+                        : null,
+                    'method'          => $request->method(),
+                    'ip'              => $request->ip(),
+                    'response_status' => $response->getStatusCode(),
+                    'response_ms'     => (int) ((microtime(true) - $start) * 1000),
+                ]);
+            }
+        } catch (Throwable $e) {
+            // Logging the logger going wrong — keep response flowing.
+            Log::warning('LogApiCalls write failed', ['error' => $e->getMessage()]);
+        }
+
+        return $response;
+    }
+}

--- a/app/Models/ApiCallLog.php
+++ b/app/Models/ApiCallLog.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+
+class ApiCallLog extends Model
+{
+    use Prunable;
+
+    protected $table = 'api_call_log';
+    public $timestamps = false; // Only created_at, no updated_at
+
+    protected $fillable = [
+        'user_id',
+        'token_id',
+        'route',
+        'query_string',
+        'method',
+        'ip',
+        'response_status',
+        'response_ms',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at'      => 'datetime',
+        'response_status' => 'integer',
+        'response_ms'     => 'integer',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function token()
+    {
+        return $this->belongsTo(\Laravel\Sanctum\PersonalAccessToken::class, 'token_id');
+    }
+
+    /**
+     * Prunable retention: keep 30 days. `php artisan model:prune` runs
+     * daily via Console\Kernel and deletes everything older.
+     */
+    public function prunable(): Builder
+    {
+        return static::where('created_at', '<', now()->subDays(30));
+    }
+}

--- a/app/Models/CommunityTaskMapSkip.php
+++ b/app/Models/CommunityTaskMapSkip.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CommunityTaskMapSkip extends Model
+{
+    protected $table = 'community_task_map_skips';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'map_id',
+        'kind',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function map()
+    {
+        return $this->belongsTo(Map::class);
+    }
+}

--- a/database/migrations/2026_05_11_000005_create_api_call_log_table.php
+++ b/database/migrations/2026_05_11_000005_create_api_call_log_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('api_call_log', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            // Null when the user authenticated via session cookie (browser).
+            // Populated with the Sanctum token's ID when they used a Bearer token.
+            $table->unsignedBigInteger('token_id')->nullable();
+            $table->string('route', 191)->comment('Request URI path, e.g. /api/records/search');
+            $table->string('method', 8)->comment('HTTP verb');
+            $table->ipAddress('ip')->nullable();
+            $table->unsignedSmallInteger('response_status')->nullable();
+            $table->unsignedInteger('response_ms')->nullable()->comment('Server processing time in ms');
+            $table->timestamp('created_at')->useCurrent();
+
+            // Filament filter "show me this user's last week of calls"
+            $table->index(['user_id', 'created_at']);
+            // Filament filter "show me everyone's calls today"
+            $table->index('created_at');
+            // Filament filter "who hit /api/records/search?"
+            $table->index(['route', 'created_at']);
+            // Per-token usage stats
+            $table->index(['token_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('api_call_log');
+    }
+};

--- a/database/migrations/2026_05_11_000006_add_query_string_to_api_call_log_table.php
+++ b/database/migrations/2026_05_11_000006_add_query_string_to_api_call_log_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('api_call_log', function (Blueprint $table) {
+            // Stored separately from `route` so the route dropdown filter
+            // stays useful — only the path goes in the indexable `route`
+            // column, and the noisy per-request query string lives here
+            // for display only.
+            $table->text('query_string')->nullable()->after('route');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('api_call_log', function (Blueprint $table) {
+            $table->dropColumn('query_string');
+        });
+    }
+};

--- a/database/migrations/2026_05_11_000007_create_community_task_map_skips_table.php
+++ b/database/migrations/2026_05_11_000007_create_community_task_map_skips_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('community_task_map_skips', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('map_id')->constrained()->cascadeOnDelete();
+            // 'rating' (skip on difficulty rating) | 'tag' (skip on tagging)
+            $table->string('kind', 16);
+            $table->timestamp('created_at')->useCurrent();
+
+            // Cooldown lookup ("which maps has this user skipped recently?")
+            $table->index(['user_id', 'created_at']);
+            // Daily cap counting
+            $table->index(['user_id', 'kind', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('community_task_map_skips');
+    }
+};

--- a/resources/js/Pages/CommunityTasks.vue
+++ b/resources/js/Pages/CommunityTasks.vue
@@ -201,6 +201,15 @@ async function submitVote(demoId, voteType, taskType, selectedRecordId = null) {
 
 // ─── Assignment logic ──────────────────────────────────
 function selectRecord(task, record) {
+    // In verification flow the same demo already has an assigned record
+    // (shown as MATCHED). Clicking that record as the "better match"
+    // target is meaningless — server rejects it with 422. Block at the
+    // click level so the user gets immediate feedback instead.
+    if (task.current_record?.id === record.id) {
+        assignHints.value[task.demo.id] = 'This record is already matched — use "Correct" to confirm, or pick a different rival.';
+        return;
+    }
+
     if (selectedRecords.value[task.demo.id]?.id === record.id) {
         delete selectedRecords.value[task.demo.id];
     } else {
@@ -444,7 +453,21 @@ async function rateMap(map, level) {
 
 async function skipRating(map) {
     streak.value = 0;
-    awardPoints(1);
+    // Record server-side so the map enters the user's cooldown and the
+    // daily skip-point cap is enforced; trust the server's points value
+    // (0 once user is past the cap, 1 otherwise).
+    let pts = 1;
+    try {
+        const { data } = await axios.post(route('community.tasks.skip'), {
+            map_id: map.id,
+            kind: 'rating',
+        });
+        pts = typeof data.points === 'number' ? data.points : 0;
+    } catch (err) {
+        console.warn('Skip rating failed to record:', err.response?.data?.error || err.message);
+        pts = 0;
+    }
+    awardPoints(pts);
     completedRatings.value++;
     ratingQueue.value.shift();
     if (ratingQueue.value.length <= 1) preloadNextRound();
@@ -525,10 +548,24 @@ async function addTagToMap(tagName) {
 
 async function skipTag() {
     if (taggedCurrentMap.value) {
-        // Already tagged at least once - count as completed
+        // Already tagged at least once - count as completed (no skip recorded)
     } else {
         streak.value = 0;
-        awardPoints(1);
+        const map = currentTagMap.value;
+        let pts = 1;
+        if (map?.id) {
+            try {
+                const { data } = await axios.post(route('community.tasks.skip'), {
+                    map_id: map.id,
+                    kind: 'tag',
+                });
+                pts = typeof data.points === 'number' ? data.points : 0;
+            } catch (err) {
+                console.warn('Skip tag failed to record:', err.response?.data?.error || err.message);
+                pts = 0;
+            }
+        }
+        awardPoints(pts);
     }
     completedTags.value++;
     taggedCurrentMap.value = false;
@@ -1048,7 +1085,7 @@ onUnmounted(() => {
                             </div>
                             <div class="flex items-start gap-2">
                                 <span class="text-indigo-400 mt-0.5 flex-shrink-0">&#x2022;</span>
-                                <p>Not sure? Just <strong class="text-yellow-400">Skip</strong> - you still earn a point!</p>
+                                <p>Not sure? Just <strong class="text-yellow-400">Skip</strong> — no points, but the same map won't come back to you for a week.</p>
                             </div>
                         </div>
                     </div>
@@ -1522,7 +1559,7 @@ onUnmounted(() => {
                                 </div>
                                 <div class="flex items-start gap-2">
                                     <span class="text-purple-400 mt-0.5 flex-shrink-0">&#x2022;</span>
-                                    <p>When in doubt, <strong class="text-white">Skip</strong> is always fine - you still earn a point!</p>
+                                    <p>When in doubt, <strong class="text-white">Skip</strong> is always fine — no points, but it still helps. The same map won't come back for a week.</p>
                                 </div>
                             </div>
                         </div>
@@ -1661,7 +1698,7 @@ onUnmounted(() => {
                                 </div>
                                 <div class="flex items-start gap-2">
                                     <span class="text-amber-400 mt-0.5 flex-shrink-0">&#x2022;</span>
-                                    <p>When in doubt, <strong class="text-white">Skip</strong> is always fine - you still earn a point!</p>
+                                    <p>When in doubt, <strong class="text-white">Skip</strong> is always fine — no points, but it still helps. The same map won't come back for a week.</p>
                                 </div>
                             </div>
                         </div>

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -166,6 +166,14 @@
             return;
         }
 
+        // Rivals/competitors are now gated behind auth — skip the fetch for
+        // anon visitors. The matching template sections check the same flag
+        // and won't render, so there's nothing to fill.
+        if (!page.props.auth?.user) {
+            loadingExtras.value = false;
+            return;
+        }
+
         try {
             const response = await fetch(`/api/profile/${mddId}/extras`);
             if (response.ok) {
@@ -650,9 +658,6 @@
 
     const selectedOption = ref(props.type || 'latest');
     const loading = ref('');
-    const selectedRival = ref(null);
-    const beatableRecords = ref([]);
-    const loadingBeatable = ref(false);
 
     // Direct Competitor Comparison
     const competitorSearch = ref('');
@@ -744,27 +749,6 @@
         onRecordsSearchInput();
     };
 
-    const loadBeatableRecords = async (rivalMddId, rivalName) => {
-        selectedRival.value = { id: rivalMddId, name: rivalName };
-        loadingBeatable.value = true;
-
-        try {
-            const profileId = props.user?.id || props.profile?.id;
-            const response = await fetch(`/api/profile/${profileId}/beatable-records/${rivalMddId}?physics=cpm`);
-            const data = await response.json();
-            beatableRecords.value = data;
-        } catch (error) {
-            console.error('Error loading beatable records:', error);
-            beatableRecords.value = [];
-        } finally {
-            loadingBeatable.value = false;
-        }
-    }
-
-    const closeBeatableRecords = () => {
-        selectedRival.value = null;
-        beatableRecords.value = [];
-    }
 
     // Direct Competitor Comparison Methods
     let searchTimeout = null;
@@ -2366,7 +2350,8 @@
                             <div
                                 v-for="alias in aliases"
                                 :key="alias.alias_colored || alias.alias"
-                                class="px-3 py-1.5 rounded-lg bg-indigo-500/10 border border-indigo-500/20 text-sm text-indigo-300 flex items-center gap-2"
+                                class="px-3 py-1.5 rounded-lg border border-white/10 backdrop-blur-[4px] text-sm flex items-center gap-2"
+                                style="background: rgba(71,85,105,0.55);"
                                 :title="alias.usage_count ? alias.usage_count + ' records with this name' : ''"
                             >
                                 <span v-html="q3tohtml(alias.alias_colored || alias.alias)"></span>
@@ -2753,7 +2738,29 @@
                 </div>
             </div>
             <!-- Competitors & Rivals Section -->
-            <div v-if="showSection('similar_skill_rivals') && (cpmCompetitors || cpmRivals || loadingExtras)" class="bg-black/40 backdrop-blur-sm rounded-xl shadow-2xl border border-white/5 mb-6 overflow-hidden" :style="{ order: sectionOrder('similar_skill_rivals') }">
+            <div v-if="showSection('similar_skill_rivals') && ($page.props.auth.user ? (cpmCompetitors || cpmRivals || loadingExtras) : true)" class="bg-black/40 backdrop-blur-sm rounded-xl shadow-2xl border border-white/5 mb-6 overflow-hidden relative" :style="{ order: sectionOrder('similar_skill_rivals') }">
+                <!-- Anon teaser overlay: blurred skeleton + sign-in CTA -->
+                <div v-if="!$page.props.auth.user" class="absolute inset-0 z-10 flex items-center justify-center bg-black/60 backdrop-blur-md">
+                    <div class="text-center px-6 py-8">
+                        <div class="text-lg font-bold text-white mb-1">Similar skill rivals</div>
+                        <div class="text-sm text-gray-400 mb-4 max-w-sm">Sign in to see who's in this player's league and who they regularly beat (or get beaten by).</div>
+                        <Link :href="route('login')" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/40 text-blue-200 text-sm font-semibold transition">
+                            Sign in to use
+                        </Link>
+                    </div>
+                </div>
+                <!-- Skeleton placeholder behind the overlay so the panel has bulk -->
+                <div v-if="!$page.props.auth.user" class="p-5 opacity-40 pointer-events-none select-none">
+                    <div class="h-5 w-48 bg-white/10 rounded mb-4"></div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div class="space-y-2">
+                            <div v-for="n in 4" :key="'sk1-'+n" class="h-10 bg-white/5 rounded"></div>
+                        </div>
+                        <div class="space-y-2">
+                            <div v-for="n in 4" :key="'sk2-'+n" class="h-10 bg-white/5 rounded"></div>
+                        </div>
+                    </div>
+                </div>
                 <!-- Loading skeleton -->
                 <div v-if="loadingExtras" class="p-5">
                     <div class="animate-pulse space-y-3">
@@ -2789,7 +2796,8 @@
                                 <div class="space-y-1.5">
                                     <Link v-for="player in cpmCompetitors.better" :key="player.id"
                                           :href="route(player.user?.id ? 'profile.index' : 'profile.mdd', player.user?.id || player.id)"
-                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg hover:bg-green-500/10 border border-transparent hover:border-green-500/20 transition-all group cursor-pointer">
+                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg border border-white/10 hover:border-green-500/40 backdrop-blur-[4px] transition-all group cursor-pointer"
+                                          style="background: rgba(71,85,105,0.55);">
                                         <img :src="player.user?.profile_photo_path ? `/storage/${player.user.profile_photo_path}` : '/images/null.jpg'"
                                              class="w-8 h-8 rounded-full" :alt="player.plain_name" />
                                         <div class="flex-1 min-w-0">
@@ -2807,7 +2815,8 @@
                                 <div class="space-y-1.5">
                                     <Link v-for="player in cpmCompetitors.worse" :key="player.id"
                                           :href="route(player.user?.id ? 'profile.index' : 'profile.mdd', player.user?.id || player.id)"
-                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg hover:bg-orange-500/10 border border-transparent hover:border-orange-500/20 transition-all group cursor-pointer">
+                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg border border-white/10 hover:border-orange-500/40 backdrop-blur-[4px] transition-all group cursor-pointer"
+                                          style="background: rgba(71,85,105,0.55);">
                                         <img :src="player.user?.profile_photo_path ? `/storage/${player.user.profile_photo_path}` : '/images/null.jpg'"
                                              class="w-8 h-8 rounded-full" :alt="player.plain_name" />
                                         <div class="flex-1 min-w-0">
@@ -2840,7 +2849,8 @@
                                 <div class="space-y-1.5">
                                     <Link v-for="rival in cpmRivals.beaten" :key="rival.id"
                                           :href="route(rival.user?.id ? 'profile.index' : 'profile.mdd', rival.user?.id || rival.id)"
-                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg hover:bg-blue-500/10 border border-transparent hover:border-blue-500/20 transition-all group cursor-pointer">
+                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg border border-white/10 hover:border-blue-500/40 backdrop-blur-[4px] transition-all group cursor-pointer"
+                                          style="background: rgba(71,85,105,0.55);">
                                         <img :src="rival.user?.profile_photo_path ? `/storage/${rival.user.profile_photo_path}` : '/images/null.jpg'"
                                              class="w-8 h-8 rounded-full" :alt="rival.plain_name" />
                                         <div class="flex-1 min-w-0">
@@ -2858,7 +2868,8 @@
                                 <div class="space-y-1.5">
                                     <Link v-for="rival in cpmRivals.beaten_by" :key="rival.id"
                                           :href="route(rival.user?.id ? 'profile.index' : 'profile.mdd', rival.user?.id || rival.id)"
-                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all group cursor-pointer">
+                                          class="w-full flex items-center gap-2.5 p-2 rounded-lg border border-white/10 hover:border-red-500/40 backdrop-blur-[4px] transition-all group cursor-pointer"
+                                          style="background: rgba(71,85,105,0.55);">
                                         <img :src="rival.user?.profile_photo_path ? `/storage/${rival.user.profile_photo_path}` : '/images/null.jpg'"
                                              class="w-8 h-8 rounded-full" :alt="rival.plain_name" />
                                         <div class="flex-1 min-w-0">
@@ -2875,7 +2886,27 @@
             </div>
 
             <!-- Direct Competitor Comparison -->
-            <div v-if="showSection('competitor_comparison')" class="bg-black/40 backdrop-blur-sm rounded-xl p-6 shadow-2xl border border-white/5 mb-6" :style="{ order: sectionOrder('competitor_comparison') }">
+            <div v-if="showSection('competitor_comparison')" class="bg-black/40 backdrop-blur-sm rounded-xl p-6 shadow-2xl border border-white/5 mb-6 relative" :style="{ order: sectionOrder('competitor_comparison') }">
+                <!-- Anon teaser overlay -->
+                <template v-if="!$page.props.auth.user">
+                    <div class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black/60 backdrop-blur-md">
+                        <div class="text-center px-6 py-8">
+                            <div class="text-lg font-bold text-white mb-1">Direct competitor comparison</div>
+                            <div class="text-sm text-gray-400 mb-4 max-w-sm">Sign in to pick any rival and see the easiest maps where you can grab time on them.</div>
+                            <Link :href="route('login')" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/40 text-blue-200 text-sm font-semibold transition">
+                                Sign in to use
+                            </Link>
+                        </div>
+                    </div>
+                    <div class="opacity-40 pointer-events-none select-none">
+                        <div class="h-5 w-56 bg-white/10 rounded mb-4"></div>
+                        <div class="h-10 bg-white/5 rounded mb-4"></div>
+                        <div class="space-y-2">
+                            <div v-for="n in 5" :key="'cc-sk-'+n" class="h-10 bg-white/5 rounded"></div>
+                        </div>
+                    </div>
+                </template>
+                <template v-else>
                 <h2 class="text-xl font-bold text-white mb-4">
                     Direct Competitor Comparison
                 </h2>
@@ -3052,10 +3083,11 @@
                 <div v-else class="text-center py-5">
                     <svg class="w-12 h-12 mx-auto mb-2 text-gray-700 fill-current opacity-50" viewBox="0 0 20 20">
                         <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
-                        <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+                        <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
                     </svg>
                     <div class="text-sm text-gray-500">Search for a player to see head-to-head comparison</div>
                 </div>
+                </template>
             </div>
 
             <!-- User's Featured Maplists -->

--- a/resources/js/Pages/Profile/Partials/ApiTokensForm.vue
+++ b/resources/js/Pages/Profile/Partials/ApiTokensForm.vue
@@ -1,0 +1,444 @@
+<script setup>
+    import { ref, onMounted } from 'vue';
+    import axios from 'axios';
+
+    // Mirrors LauncherTokensForm.vue. Same Sanctum personal access token
+    // mechanism, but tokens are prefixed "api:" and carry the "api:read"
+    // ability instead of "launcher:upload". Used to authenticate calls to
+    // /api/records/search, /api/profile/*/extras, etc. from external
+    // scripts or third-party tools — the browser frontend continues to
+    // authenticate via session cookie automatically.
+
+    const tokens = ref([]);
+    const loading = ref(true);
+    const error = ref(null);
+
+    const freshToken = ref(null);
+    const copied = ref(false);
+
+    const label = ref('');
+    const creating = ref(false);
+    const showForm = ref(false);
+    const createError = ref(null);
+
+    const fetchTokens = async () => {
+        loading.value = true;
+        try {
+            const { data } = await axios.get(route('api-tokens.index'));
+            tokens.value = data.tokens ?? [];
+        } catch (e) {
+            error.value = 'Failed to load API tokens';
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    onMounted(fetchTokens);
+
+    const createToken = async () => {
+        if (! label.value.trim()) return;
+        creating.value = true;
+        createError.value = null;
+        try {
+            const { data } = await axios.post(route('api-tokens.store'), { label: label.value.trim() });
+            freshToken.value = data;
+            tokens.value.unshift({
+                id: data.id,
+                label: data.label,
+                created_at: data.created_at,
+                last_used_at: null,
+            });
+            label.value = '';
+            showForm.value = false;
+        } catch (e) {
+            createError.value = e.response?.data?.message || 'Failed to create token';
+        } finally {
+            creating.value = false;
+        }
+    };
+
+    // Styled confirm modal state — replaces native window.confirm().
+    const confirmModal = ref({
+        open: false,
+        tokenId: null,
+        label: '',
+    });
+
+    // API documentation modal
+    const docsOpen = ref(false);
+
+    // Endpoints described once and rendered with v-for so adding new
+    // ones later means appending to this array. Examples truncated for
+    // readability; real responses can be longer.
+    const endpoints = [
+        {
+            method: 'GET',
+            path: '/api/records/search',
+            description: 'Search records by map name prefix (or by player name as fallback when nothing matches). Returns up to 500 records.',
+            params: [
+                { name: 'q',    required: true,  desc: 'Search term (min 2 chars). Tried first as map-name prefix, then as player-name substring.' },
+                { name: 'time', required: false, desc: 'Filter to records with time ≤ this value (milliseconds).' },
+            ],
+            example: 'curl -H "Authorization: Bearer <token>" \\\n  "https://defrag.racing/api/records/search?q=bug-w9"',
+            response: `[
+  {
+    "id": 12345,
+    "user_id": 8,
+    "mapname": "bug-w9",
+    "time": 4523,
+    "physics": "cpm",
+    "mode": "run",
+    "gametype": 0,
+    "date_set": "2024-09-12 18:42:00",
+    "user": { "id": 8, "name": "^4[^7gt^4]^7neiT^4." }
+  }
+]`,
+        },
+        {
+            method: 'GET',
+            path: '/api/search-players',
+            description: 'Search MDD profiles by name / plain_name. Returns up to 10 matches.',
+            params: [
+                { name: 'q', required: true, desc: 'Search term (min 2 chars). LIKE match on name + plain_name.' },
+            ],
+            example: 'curl -H "Authorization: Bearer <token>" \\\n  "https://defrag.racing/api/search-players?q=neyo"',
+            response: `[
+  {
+    "id": 2640,
+    "name": "^4[^7gt^4]^7neiT^4.",
+    "plain_name": "[gt]neiT.",
+    "user": { "id": 8, "name": "..." }
+  }
+]`,
+        },
+        {
+            method: 'GET',
+            path: '/api/profile/{mddId}/extras',
+            description: 'Similar-skill competitors + head-to-head rivals for a player. Mirrors the data shown on profile pages.',
+            params: [
+                { name: 'mddId', required: true, desc: 'Path parameter — the target player\'s MDD profile id.' },
+            ],
+            example: 'curl -H "Authorization: Bearer <token>" \\\n  "https://defrag.racing/api/profile/2640/extras"',
+            response: `{
+  "cpm_competitors": {
+    "my_score": 4523,
+    "better": [ { "id":...,  "name":"...", "score":..., "wrs":..., "total_records":... } ],
+    "worse":  [ ... ]
+  },
+  "vq3_competitors": { ... },
+  "cpm_rivals": {
+    "beaten":    [ { "id":..., "name":"...", "maps_beaten":..., "times_beaten":... } ],
+    "beaten_by": [ ... ]
+  },
+  "vq3_rivals": { ... }
+}`,
+        },
+        {
+            method: 'GET',
+            path: '/api/profile/{userId}/compare/{rivalId}',
+            description: 'Head-to-head map-by-map comparison between two users for one physics.',
+            params: [
+                { name: 'userId',  required: true, desc: 'Path — defrag.racing user id of the "me" side.' },
+                { name: 'rivalId', required: true, desc: 'Path — defrag.racing user id of the rival.' },
+                { name: 'physics', required: false, desc: 'cpm | vq3 (default: cpm).' },
+            ],
+            example: 'curl -H "Authorization: Bearer <token>" \\\n  "https://defrag.racing/api/profile/8/compare/42?physics=vq3"',
+            response: `[
+  {
+    "mapname": "bug-w9",
+    "mode": "run",
+    "physics": "vq3",
+    "rival_time": 5012,
+    "rival_rank": 3,
+    "my_time": 4523,
+    "my_rank": 1,
+    "time_diff": 489,
+    "status": "ahead"
+  }
+]`,
+        },
+    ];
+
+    const askRevoke = (token) => {
+        confirmModal.value = {
+            open: true,
+            tokenId: token.id,
+            label: token.label,
+        };
+    };
+
+    const closeConfirm = () => {
+        confirmModal.value = { open: false, tokenId: null, label: '' };
+    };
+
+    const revoke = async () => {
+        const tokenId = confirmModal.value.tokenId;
+        closeConfirm();
+        if (! tokenId) return;
+        try {
+            await axios.delete(route('api-tokens.destroy', tokenId));
+            tokens.value = tokens.value.filter(t => t.id !== tokenId);
+            if (freshToken.value?.id === tokenId) freshToken.value = null;
+        } catch (e) {
+            alert('Failed to revoke token');
+        }
+    };
+
+    const copyToken = async () => {
+        try {
+            await navigator.clipboard.writeText(freshToken.value.plain_text_token);
+            copied.value = true;
+            setTimeout(() => (copied.value = false), 2000);
+        } catch {}
+    };
+
+    const formatDate = (iso) => {
+        if (! iso) return '—';
+        return new Date(iso).toLocaleString();
+    };
+</script>
+
+<template>
+    <div class="p-6 space-y-5">
+        <div class="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+                <h3 class="text-lg font-semibold text-white">API tokens</h3>
+                <p class="mt-1 text-sm text-gray-400 max-w-2xl leading-relaxed">
+                    Personal access tokens for the defrag.racing public API. Send the token as
+                    <code class="text-xs bg-black/40 px-1 rounded">Authorization: Bearer &lt;token&gt;</code>
+                    on requests to <code class="text-xs bg-black/40 px-1 rounded">/api/profile/&lt;id&gt;/extras</code>,
+                    <code class="text-xs bg-black/40 px-1 rounded">/api/records/search</code>, etc.
+                    Rate-limited per token to 60 requests/minute. Revoke any time.
+                </p>
+                <button
+                    type="button"
+                    @click="docsOpen = true"
+                    class="mt-2 inline-flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 underline decoration-dotted underline-offset-2"
+                >
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+                    </svg>
+                    View API documentation
+                </button>
+            </div>
+            <button
+                v-if="!showForm"
+                type="button"
+                @click="showForm = true"
+                class="px-3 py-1.5 text-sm rounded bg-blue-500/20 hover:bg-blue-500/30 text-blue-200 font-semibold"
+            >+ New token</button>
+        </div>
+
+        <!-- Create form -->
+        <form v-if="showForm" @submit.prevent="createToken" class="flex gap-2 items-start bg-black/30 border border-white/[0.06] rounded-lg p-3">
+            <div class="flex-1">
+                <input
+                    v-model="label"
+                    type="text"
+                    placeholder="Token label (e.g. Stats bot, Discord webhook)"
+                    maxlength="50"
+                    class="w-full bg-black/60 border border-white/10 rounded px-3 py-2 text-sm text-white placeholder:text-gray-500"
+                />
+                <p v-if="createError" class="mt-1 text-xs text-red-400">{{ createError }}</p>
+                <p v-else class="mt-1 text-xs text-gray-500">A label so you remember which integration uses this token.</p>
+            </div>
+            <button
+                type="submit"
+                :disabled="creating || !label.trim()"
+                class="px-4 py-2 rounded bg-blue-500/30 hover:bg-blue-500/40 disabled:opacity-50 text-blue-100 text-sm font-semibold"
+            >{{ creating ? 'Generating…' : 'Generate' }}</button>
+            <button
+                type="button"
+                @click="showForm = false; label = ''; createError = null;"
+                class="px-4 py-2 rounded bg-white/5 hover:bg-white/10 text-gray-300 text-sm"
+            >Cancel</button>
+        </form>
+
+        <!-- Fresh token (one-time display) -->
+        <div v-if="freshToken" class="border border-emerald-500/40 bg-emerald-500/5 rounded-lg p-4 space-y-3">
+            <div class="flex items-center gap-2 text-emerald-300 font-semibold text-sm">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+                Token "{{ freshToken.label }}" created — copy it now
+            </div>
+            <p class="text-xs text-gray-400">
+                This is the only time we will show the token in plaintext. Paste it into your script or tool now.
+                If you lose it, revoke this one and generate a new one.
+            </p>
+            <div class="flex gap-2">
+                <input
+                    type="text"
+                    readonly
+                    :value="freshToken.plain_text_token"
+                    class="flex-1 bg-black/60 border border-white/10 rounded px-3 py-2 text-sm font-mono text-white select-all"
+                    @focus="$event.target.select()"
+                />
+                <button
+                    type="button"
+                    @click="copyToken"
+                    class="px-4 py-2 rounded bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-200 text-sm font-semibold whitespace-nowrap"
+                >{{ copied ? 'Copied!' : 'Copy' }}</button>
+            </div>
+        </div>
+
+        <!-- Existing tokens -->
+        <div v-if="loading" class="text-sm text-gray-500 py-4">Loading tokens…</div>
+        <div v-else-if="error" class="text-sm text-red-400 py-4">{{ error }}</div>
+        <div v-else-if="tokens.length" class="bg-black/30 border border-white/[0.06] rounded-lg divide-y divide-white/[0.04]">
+            <div v-for="t in tokens" :key="t.id" class="px-4 py-3 flex items-center justify-between gap-4">
+                <div class="min-w-0">
+                    <div class="text-white font-medium truncate">{{ t.label }}</div>
+                    <div class="text-xs text-gray-500 mt-0.5">
+                        Created {{ formatDate(t.created_at) }} · Last used {{ formatDate(t.last_used_at) }}
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    @click="askRevoke(t)"
+                    class="px-3 py-1.5 text-xs rounded bg-red-500/15 hover:bg-red-500/25 text-red-300 flex-shrink-0"
+                >Revoke</button>
+            </div>
+        </div>
+        <div v-else class="text-sm text-gray-500 py-4 text-center border border-dashed border-white/[0.06] rounded-lg">
+            No tokens yet. Generate one to call the defrag.racing API from your scripts.
+        </div>
+    </div>
+
+    <!-- Styled confirm modal — replaces native window.confirm() -->
+    <Teleport to="body">
+        <transition
+            enter-active-class="transition duration-150 ease-out"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-active-class="transition duration-100 ease-in"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0">
+            <div v-if="confirmModal.open"
+                 class="fixed inset-0 z-[200] flex items-center justify-center px-4"
+                 @click.self="closeConfirm">
+                <div class="absolute inset-0 bg-black/70 backdrop-blur-sm"></div>
+
+                <div class="relative w-full max-w-md rounded-2xl border border-white/10 bg-black/70 backdrop-blur-md shadow-2xl">
+                    <div class="p-6">
+                        <h3 class="text-lg font-semibold text-white mb-2">Revoke this token?</h3>
+                        <p class="text-sm text-gray-400">
+                            Token <span class="font-mono text-gray-200">"{{ confirmModal.label }}"</span> will stop working immediately.
+                            Any script or tool using it will start getting <span class="font-mono">401 Unauthorized</span>
+                            until you generate a new one.
+                        </p>
+                    </div>
+                    <div class="px-6 py-4 border-t border-white/5 flex justify-end gap-2">
+                        <button type="button"
+                                @click="closeConfirm"
+                                class="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm text-gray-300 transition">
+                            Cancel
+                        </button>
+                        <button type="button"
+                                @click="revoke"
+                                class="px-4 py-2 rounded-lg bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 text-sm text-red-200 font-medium transition">
+                            Revoke token
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </transition>
+    </Teleport>
+
+    <!-- API documentation modal -->
+    <Teleport to="body">
+        <transition
+            enter-active-class="transition duration-150 ease-out"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-active-class="transition duration-100 ease-in"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0">
+            <div v-if="docsOpen"
+                 class="fixed inset-0 z-[200] flex items-center justify-center px-4 py-8"
+                 @click.self="docsOpen = false">
+                <div class="absolute inset-0 bg-black/70 backdrop-blur-sm"></div>
+
+                <div class="relative w-full max-w-3xl max-h-full flex flex-col rounded-2xl border border-white/10 bg-black/70 backdrop-blur-md shadow-2xl">
+                    <!-- Header -->
+                    <div class="px-6 py-4 border-b border-white/10 flex items-center justify-between">
+                        <div>
+                            <h3 class="text-lg font-semibold text-white">defrag.racing API</h3>
+                            <p class="text-xs text-gray-500 mt-0.5">Authenticated endpoints — all require an API token in <code>Authorization: Bearer …</code> header.</p>
+                        </div>
+                        <button type="button" @click="docsOpen = false"
+                                class="p-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-white/10 transition">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+                        </button>
+                    </div>
+
+                    <!-- Body -->
+                    <div class="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+                        <!-- Authentication note -->
+                        <div class="rounded-lg border border-blue-500/30 bg-blue-500/5 p-4">
+                            <div class="text-sm font-semibold text-blue-300 mb-1">Authentication</div>
+                            <p class="text-xs text-gray-400 mb-2">
+                                Generate a token above ("+ New token"), then include it in every request:
+                            </p>
+                            <pre class="text-xs bg-black/60 border border-white/10 rounded-lg p-3 overflow-x-auto text-gray-300 font-mono">Authorization: Bearer 5|aB1cD2eF3gH4iJ5kL6mN7oP8…</pre>
+                            <p class="text-xs text-gray-500 mt-2">
+                                <strong class="text-gray-400">Rate limit:</strong> 60 requests per minute per user (shared across all your tokens).
+                                Hitting the limit returns <code>429 Too Many Requests</code>.
+                                All authenticated calls are logged — admins can see per-user / per-endpoint stats.
+                            </p>
+                        </div>
+
+                        <!-- Endpoint cards -->
+                        <div v-for="(e, i) in endpoints" :key="i" class="rounded-lg border border-white/10 bg-white/5">
+                            <div class="px-4 py-3 border-b border-white/10 flex items-center gap-3">
+                                <span class="inline-block px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-300 text-xs font-bold font-mono">{{ e.method }}</span>
+                                <code class="text-sm text-gray-200 font-mono break-all">{{ e.path }}</code>
+                            </div>
+                            <div class="px-4 py-3 space-y-3">
+                                <p class="text-sm text-gray-300">{{ e.description }}</p>
+
+                                <div v-if="e.params.length">
+                                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Parameters</div>
+                                    <table class="w-full text-xs">
+                                        <tbody class="divide-y divide-white/5">
+                                            <tr v-for="p in e.params" :key="p.name">
+                                                <td class="py-1.5 pr-3 align-top w-32">
+                                                    <code class="text-gray-200">{{ p.name }}</code>
+                                                    <span v-if="p.required" class="text-red-400 ml-1">*</span>
+                                                </td>
+                                                <td class="py-1.5 text-gray-400">{{ p.desc }}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+
+                                <div>
+                                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Example</div>
+                                    <pre class="text-xs bg-black/60 border border-white/10 rounded-lg p-3 overflow-x-auto text-gray-300 font-mono whitespace-pre">{{ e.example }}</pre>
+                                </div>
+
+                                <div>
+                                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Response (truncated)</div>
+                                    <pre class="text-xs bg-black/60 border border-white/10 rounded-lg p-3 overflow-x-auto text-gray-300 font-mono whitespace-pre">{{ e.response }}</pre>
+                                </div>
+                            </div>
+                        </div>
+
+                        <p class="text-xs text-gray-500 text-center pt-2">
+                            Need a new endpoint? Open an issue on the
+                            <a href="https://github.com/Defrag-racing/defrag-racing-project" target="_blank" class="text-blue-400 hover:underline">GitHub repo</a>.
+                        </p>
+                    </div>
+
+                    <!-- Footer -->
+                    <div class="px-6 py-3 border-t border-white/10 flex justify-end">
+                        <button type="button" @click="docsOpen = false"
+                                class="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm text-gray-300 transition">
+                            Close
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </transition>
+    </Teleport>
+</template>

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -9,6 +9,7 @@ import TwoFactorAuthenticationForm from '@/Pages/Profile/Partials/TwoFactorAuthe
 import UpdatePasswordForm from '@/Pages/Profile/Partials/UpdatePasswordForm.vue';
 import UpdateSocialMediaForm from '@/Pages/Profile/Partials/UpdateSocialMediaForm.vue';
 import LauncherTokensForm from '@/Pages/Profile/Partials/LauncherTokensForm.vue';
+import ApiTokensForm from '@/Pages/Profile/Partials/ApiTokensForm.vue';
 
 import ManageAliasesForm from '@/Pages/Profile/Partials/ManageAliasesForm.vue';
 import StreamerWidgetForm from '@/Pages/Profile/Partials/StreamerWidgetForm.vue';
@@ -2357,6 +2358,10 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
 
             <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 overflow-hidden">
                 <LauncherTokensForm />
+            </div>
+
+            <div class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 overflow-hidden">
+                <ApiTokensForm />
             </div>
 
             <div v-if="$page.props.jetstream.hasAccountDeletionFeatures" class="rounded-xl bg-gradient-to-br from-red-500/5 to-red-600/5 border border-red-500/30 overflow-hidden">

--- a/resources/views/filament/api-call-log/raw-entries.blade.php
+++ b/resources/views/filament/api-call-log/raw-entries.blade.php
@@ -1,0 +1,53 @@
+<div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+    @if ($entries->isEmpty())
+        <div class="p-6 text-center text-gray-500">No calls recorded.</div>
+    @else
+        <table class="min-w-full text-sm">
+            <thead class="bg-gray-50 dark:bg-gray-800/50 text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                    <th class="px-3 py-2 text-left">When</th>
+                    <th class="px-3 py-2 text-left">Query</th>
+                    <th class="px-3 py-2 text-right">Status</th>
+                    <th class="px-3 py-2 text-right">ms</th>
+                    <th class="px-3 py-2 text-left">IP</th>
+                    <th class="px-3 py-2 text-left">Auth</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                @foreach ($entries as $e)
+                    @php
+                        $statusColor = match (true) {
+                            $e->response_status >= 500 => 'text-red-500',
+                            $e->response_status >= 400 => 'text-yellow-500',
+                            $e->response_status >= 200 => 'text-green-500',
+                            default                    => 'text-gray-500',
+                        };
+                        $msColor = match (true) {
+                            $e->response_ms > 2000 => 'text-red-500',
+                            $e->response_ms > 500  => 'text-yellow-500',
+                            default                => 'text-gray-400',
+                        };
+                        $detailUrl = '/defraghq/api-call-logs/calls/' . $e->id;
+                    @endphp
+                    <tr class="hover:bg-blue-500/5 cursor-pointer transition-colors" onclick="window.location.href='{{ $detailUrl }}'">
+                        <td class="px-3 py-1.5 whitespace-nowrap font-mono text-xs text-gray-600 dark:text-gray-300">{{ $e->created_at?->format('Y-m-d H:i:s') }}</td>
+                        <td class="px-3 py-1.5 font-mono text-xs text-gray-700 dark:text-gray-200 break-all">{{ $e->query_string ? '?' . $e->query_string : '—' }}</td>
+                        <td class="px-3 py-1.5 text-right font-mono text-xs {{ $statusColor }}">{{ $e->response_status }}</td>
+                        <td class="px-3 py-1.5 text-right font-mono text-xs {{ $msColor }}">{{ $e->response_ms }}</td>
+                        <td class="px-3 py-1.5 font-mono text-xs text-gray-500">{{ $e->ip }}</td>
+                        <td class="px-3 py-1.5 text-xs">
+                            @if ($e->token_id)
+                                <span class="inline-block px-2 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-300">token #{{ $e->token_id }}</span>
+                            @else
+                                <span class="inline-block px-2 py-0.5 rounded bg-gray-500/10 text-gray-600 dark:text-gray-300">session</span>
+                            @endif
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+        <div class="px-3 py-2 text-xs text-gray-500 bg-gray-50 dark:bg-gray-800/30">
+            Click any row to open the full call detail.
+        </div>
+    @endif
+</div>

--- a/resources/views/filament/api-call-log/view-call.blade.php
+++ b/resources/views/filament/api-call-log/view-call.blade.php
@@ -1,0 +1,101 @@
+<x-filament-panels::page>
+    @php
+        $c = $this->call;
+        $statusColor = match (true) {
+            $c->response_status >= 500 => 'text-red-500 bg-red-500/10 border-red-500/30',
+            $c->response_status >= 400 => 'text-yellow-500 bg-yellow-500/10 border-yellow-500/30',
+            $c->response_status >= 200 => 'text-green-500 bg-green-500/10 border-green-500/30',
+            default                    => 'text-gray-500 bg-gray-500/10 border-gray-500/30',
+        };
+        $msColor = match (true) {
+            $c->response_ms > 2000 => 'text-red-500',
+            $c->response_ms > 500  => 'text-yellow-500',
+            default                => 'text-green-500',
+        };
+    @endphp
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {{-- When / Who --}}
+        <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-3">When &amp; who</div>
+            <dl class="space-y-2 text-sm">
+                <div class="flex justify-between gap-3">
+                    <dt class="text-gray-500">Timestamp</dt>
+                    <dd class="font-mono text-gray-900 dark:text-gray-100">{{ $c->created_at?->format('Y-m-d H:i:s') }}</dd>
+                </div>
+                <div class="flex justify-between gap-3">
+                    <dt class="text-gray-500">Relative</dt>
+                    <dd class="text-gray-600 dark:text-gray-300">{{ $c->created_at?->diffForHumans() }}</dd>
+                </div>
+                <div class="flex justify-between gap-3">
+                    <dt class="text-gray-500">User</dt>
+                    <dd>
+                        <a href="/profile/{{ $c->user_id }}" target="_blank" class="text-blue-500 hover:underline">
+                            {{ $c->user?->plain_name ?? "user #{$c->user_id}" }}
+                        </a>
+                    </dd>
+                </div>
+                <div class="flex justify-between gap-3">
+                    <dt class="text-gray-500">Auth</dt>
+                    <dd>
+                        @if ($c->token_id)
+                            <span class="inline-block px-2 py-0.5 rounded bg-blue-500/10 text-blue-600 dark:text-blue-300">
+                                token #{{ $c->token_id }} ({{ $c->token?->name ?? '?' }})
+                            </span>
+                        @else
+                            <span class="inline-block px-2 py-0.5 rounded bg-gray-500/10 text-gray-600 dark:text-gray-300">session cookie</span>
+                        @endif
+                    </dd>
+                </div>
+                <div class="flex justify-between gap-3">
+                    <dt class="text-gray-500">IP</dt>
+                    <dd class="font-mono text-gray-700 dark:text-gray-200">{{ $c->ip ?? '—' }}</dd>
+                </div>
+            </dl>
+        </div>
+
+        {{-- Request --}}
+        <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5">
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-3">Request</div>
+            <dl class="space-y-2 text-sm">
+                <div class="flex justify-between gap-3">
+                    <dt class="text-gray-500">Method</dt>
+                    <dd>
+                        <span class="inline-block px-2 py-0.5 rounded bg-gray-500/10 font-mono text-xs">{{ $c->method }}</span>
+                    </dd>
+                </div>
+                <div>
+                    <dt class="text-gray-500 mb-1">Route</dt>
+                    <dd class="font-mono text-xs text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 rounded p-2 break-all">{{ $c->route }}</dd>
+                </div>
+                @if ($c->query_string)
+                    <div>
+                        <dt class="text-gray-500 mb-1">Query string</dt>
+                        <dd class="font-mono text-xs text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 rounded p-2 break-all">?{{ $c->query_string }}</dd>
+                    </div>
+                @endif
+                <div>
+                    <dt class="text-gray-500 mb-1">Full URL (reconstructed)</dt>
+                    <dd class="font-mono text-xs text-blue-500 hover:underline bg-gray-100 dark:bg-gray-800 rounded p-2 break-all">
+                        <a href="{{ $c->route }}{{ $c->query_string ? '?' . $c->query_string : '' }}" target="_blank">{{ $c->route }}{{ $c->query_string ? '?' . $c->query_string : '' }}</a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+
+        {{-- Response --}}
+        <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 p-5 md:col-span-2">
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-3">Response</div>
+            <div class="flex flex-wrap gap-3 items-center">
+                <div class="px-4 py-2 rounded-lg border {{ $statusColor }}">
+                    <div class="text-xs uppercase tracking-wide opacity-70">Status</div>
+                    <div class="text-2xl font-bold font-mono">{{ $c->response_status }}</div>
+                </div>
+                <div class="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700">
+                    <div class="text-xs uppercase tracking-wide text-gray-500">Duration</div>
+                    <div class="text-2xl font-bold font-mono {{ $msColor }}">{{ $c->response_ms }} ms</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/api-call-log/view-user-activity.blade.php
+++ b/resources/views/filament/api-call-log/view-user-activity.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/resources/views/filament/api-call-log/view-user-endpoint-activity.blade.php
+++ b/resources/views/filament/api-call-log/view-user-endpoint-activity.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/resources/views/filament/community-task-review/map-records-modal.blade.php
+++ b/resources/views/filament/community-task-review/map-records-modal.blade.php
@@ -1,0 +1,103 @@
+@php
+    use App\Filament\Resources\UserResource;
+
+    $demoTime = $demoTimeMs ?? 0;
+
+    $fmtTime = function (?int $ms): string {
+        if ($ms === null) return '—';
+        $m = intdiv($ms, 60000);
+        $s = intdiv($ms % 60000, 1000);
+        $rest = $ms % 1000;
+        return sprintf('%02d:%02d.%03d', $m, $s, $rest);
+    };
+@endphp
+
+<div class="space-y-3 text-sm">
+    {{-- Header strip. Avoids dark:-prefixed classes since they don't
+         consistently fire inside Filament's teleported modal — instead
+         we use translucent overlays (bg-black/20, ring-white/10) and
+         opacity-based labels that inherit the panel's base text color. --}}
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs rounded-lg ring-1 ring-white/10 bg-black/20 p-3">
+        <div>
+            <div class="uppercase tracking-wide opacity-60 mb-0.5">Map</div>
+            <div class="font-mono">{{ $mapName }}</div>
+        </div>
+        <div>
+            <div class="uppercase tracking-wide opacity-60 mb-0.5">Physics / Gametype</div>
+            <div class="font-mono">{{ strtoupper($physics ?? '?') }} / {{ $gametype ?? '?' }}</div>
+        </div>
+        <div>
+            <div class="uppercase tracking-wide opacity-60 mb-0.5">Demo player</div>
+            <div class="font-mono">{!! $demoPlayerHtml !!}</div>
+        </div>
+        <div>
+            <div class="uppercase tracking-wide opacity-60 mb-0.5">Demo time</div>
+            <div class="font-mono">{{ $fmtTime($demoTime) }}</div>
+        </div>
+    </div>
+
+    @if ($records->isEmpty())
+        <div class="rounded-lg ring-1 ring-yellow-500/30 bg-yellow-500/5 p-4 text-yellow-300 text-sm">
+            No records found for <code>{{ $mapName }}</code> (gametype <code>{{ $gametype }}</code>).
+            If the public map page does have records, the demo's physics/mode might not match — check the demo metadata.
+        </div>
+    @else
+        <div class="text-xs opacity-70 mb-1">
+            {{ $records->count() }} record(s) on this map. Rows closest to the demo time are highlighted yellow.
+            Click a Record ID to copy it, then paste into <em>Assign</em>.
+        </div>
+        <div class="overflow-x-auto rounded-lg ring-1 ring-white/10">
+            <table class="min-w-full text-sm">
+                <thead class="bg-white/5 text-xs uppercase tracking-wide opacity-70">
+                    <tr>
+                        <th class="px-3 py-2 text-left">Rank</th>
+                        <th class="px-3 py-2 text-left">Player</th>
+                        <th class="px-3 py-2 text-right">Time</th>
+                        <th class="px-3 py-2 text-right">Δ vs demo</th>
+                        <th class="px-3 py-2 text-left">Date set</th>
+                        <th class="px-3 py-2 text-center">Assets</th>
+                        <th class="px-3 py-2 text-right">Record ID</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach ($records as $r)
+                        @php
+                            $diffMs    = $r->time - $demoTime;
+                            $absMs     = abs($diffMs);
+                            $threshold = max(200, (int) round($demoTime * 0.01));
+                            $highlight = $absMs <= $threshold;
+                            $diffSign  = $diffMs > 0 ? '+' : ($diffMs < 0 ? '−' : '');
+                            $diffColor = $absMs <= $threshold
+                                ? 'text-yellow-400 font-semibold'
+                                : ($absMs <= max(1000, (int) round($demoTime * 0.05)) ? 'text-orange-400' : 'opacity-60');
+
+                            $playerName = $r->user?->name ?? $r->name ?? '?';
+                            $playerHtml = UserResource::q3tohtml($playerName);
+
+                            $hasDemo  = $r->uploadedDemos && $r->uploadedDemos->count() > 0;
+                            $hasVideo = $r->renderedVideos && $r->renderedVideos->count() > 0;
+                        @endphp
+                        <tr class="{{ $highlight ? 'bg-yellow-500/10' : '' }}">
+                            <td class="px-3 py-1.5 font-mono text-xs">#{{ $r->rank ?? '—' }}</td>
+                            <td class="px-3 py-1.5">
+                                <div class="font-mono text-xs">{!! $playerHtml !!}</div>
+                                <div class="text-[10px] opacity-50">mdd_id: {{ $r->mdd_id ?? '—' }}</div>
+                            </td>
+                            <td class="px-3 py-1.5 text-right font-mono text-xs">{{ $fmtTime($r->time) }}</td>
+                            <td class="px-3 py-1.5 text-right font-mono text-xs {{ $diffColor }}">{{ $diffSign }}{{ $fmtTime($absMs) }}</td>
+                            <td class="px-3 py-1.5 font-mono text-xs opacity-60">{{ optional($r->date_set)->format('Y-m-d') ?? '—' }}</td>
+                            <td class="px-3 py-1.5 text-center text-xs">
+                                @if ($hasDemo)<span class="inline-block px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-300 mr-1" title="Has demo">.dm</span>@endif
+                                @if ($hasVideo)<span class="inline-block px-1.5 py-0.5 rounded bg-red-500/20 text-red-300" title="Has rendered video">▶</span>@endif
+                                @if (!$hasDemo && !$hasVideo)<span class="opacity-50">—</span>@endif
+                            </td>
+                            <td class="px-3 py-1.5 text-right font-mono text-xs">
+                                <span class="px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-300 select-all cursor-pointer" onclick="navigator.clipboard?.writeText('{{ $r->id }}')">{{ $r->id }}</span>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,11 +29,20 @@ Route::prefix('launcher')
         Route::post('/upload-demo', [\App\Http\Controllers\Api\LauncherController::class, 'uploadDemo']);
     });
 
-Route::get('/profile/{userId}/beatable-records/{rivalMddId}', [\App\Http\Controllers\ProfileController::class, 'beatableRecordsApi']);
-Route::get('/profile/{mddId}/extras', [\App\Http\Controllers\ProfileController::class, 'profileExtras']);
-Route::get('/search-players', [\App\Http\Controllers\ProfileController::class, 'searchPlayers']);
-Route::get('/profile/{userId}/compare/{rivalId}', [\App\Http\Controllers\ProfileController::class, 'comparePlayer']);
-Route::get('/records/search', [\App\Http\Controllers\RecordsController::class, 'search']);
+// Profile + records AJAX endpoints used by the SPA frontend and (optionally)
+// by external clients via personal API tokens. `auth:sanctum,web` accepts
+// either a Bearer token in the Authorization header OR a session cookie
+// from a logged-in browser. Anonymous requests get a 401 — the frontend
+// hides the matching panels client-side so anon profile pages stay clean.
+//
+// Per-user rate-limit kicks in automatically because `throttle:api` keys
+// by user_id when authenticated.
+Route::middleware(['auth:sanctum,web', 'log.api'])->group(function () {
+    Route::get('/profile/{mddId}/extras', [\App\Http\Controllers\ProfileController::class, 'profileExtras']);
+    Route::get('/search-players', [\App\Http\Controllers\ProfileController::class, 'searchPlayers']);
+    Route::get('/profile/{userId}/compare/{rivalId}', [\App\Http\Controllers\ProfileController::class, 'comparePlayer']);
+    Route::get('/records/search', [\App\Http\Controllers\RecordsController::class, 'search']);
+});
 
 // Demome renderer API
 Route::prefix('demome')->middleware('demome.token')->withoutMiddleware('throttle:api')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,7 @@ Route::get('/community', [CommunityLeaderboardController::class, 'index'])->name
 Route::get('/community-tasks', [CommunityTasksController::class, 'index'])->middleware(['auth', 'verified'])->name('community.tasks');
 Route::post('/community-tasks/refresh', [CommunityTasksController::class, 'refresh'])->middleware(['auth', 'verified'])->name('community.tasks.refresh');
 Route::post('/community-tasks/vote', [CommunityTasksController::class, 'vote'])->middleware(['auth', 'verified'])->name('community.tasks.vote');
+Route::post('/community-tasks/skip', [CommunityTasksController::class, 'skip'])->middleware(['auth', 'verified'])->name('community.tasks.skip');
 Route::post('/community-tasks/save-session', [CommunityTasksController::class, 'saveSession'])->middleware(['auth', 'verified'])->name('community.tasks.save');
 Route::get('/community-tasks/leaderboard', [CommunityTasksController::class, 'fullLeaderboard'])->middleware(['auth', 'verified'])->name('community.tasks.leaderboard');
 Route::post('/community-tasks/request-render', [CommunityTasksController::class, 'requestDifficultyRender'])->middleware(['auth', 'verified'])->name('community.tasks.request-render');
@@ -286,6 +287,11 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/user/launcher-tokens', [\App\Http\Controllers\LauncherTokenController::class, 'index'])->name('launcher-tokens.index');
     Route::post('/user/launcher-tokens', [\App\Http\Controllers\LauncherTokenController::class, 'store'])->name('launcher-tokens.store');
     Route::delete('/user/launcher-tokens/{tokenId}', [\App\Http\Controllers\LauncherTokenController::class, 'destroy'])->name('launcher-tokens.destroy');
+
+    // General-purpose personal API access tokens (api:read ability)
+    Route::get('/user/api-tokens', [\App\Http\Controllers\ApiTokenController::class, 'index'])->name('api-tokens.index');
+    Route::post('/user/api-tokens', [\App\Http\Controllers\ApiTokenController::class, 'store'])->name('api-tokens.store');
+    Route::delete('/user/api-tokens/{tokenId}', [\App\Http\Controllers\ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
 
     // Server hosting (SFTP serverdemo credentials)
     Route::get('/server-hosting', [\App\Http\Controllers\ServerHostingController::class, 'index'])->name('server-hosting.index');


### PR DESCRIPTION
## Summary

### API access + monitoring
- Lock `/api/profile/{id}/extras`, `/search-players`, `/compare`, `/records/search` behind `auth:sanctum,web`. Anonymous calls get a JSON 401 (Authenticate + Handler updated to never redirect /api/* to /login).
- `api` middleware group loads session explicitly so browser-session auth works even when Referer/Origin is missing (paste-into-new-tab case Sanctum's stateful middleware bailed on).
- BotAwareStartSession::terminate() no longer calls parent::terminate() (doesn't exist in Laravel 10.x StartSession) — was throwing on every request.
- New `/user/settings?tab=security` → API tokens: generate/copy/revoke with a styled glass confirm modal and a popup of API documentation (curl + response shapes per endpoint).
- New `api_call_log` table + `LogApiCalls` middleware records user_id, token_id (null = session), route, query_string, status, response_ms per authed `/api/*` call. 30-day prune via `model:prune` cron.
- Filament admin at `/defraghq/api-call-logs` with three-level drill-down: aggregated users → endpoints per user → raw calls with query strings → single-call detail page. Stats widget on top.

### Community tasks fairness
- New `community_task_map_skips` table powers a 7-day per-map cooldown after `not_sure` on a demo OR Skip on rating/tag — same map no longer follows the reviewer around (fix for the "hgb-shitmap24 is every third map" report).
- `not_sure`, skip-rating and skip-tag now award **0 points** (still recorded for cooldown). `no_match`, `correct`, `unassign` unchanged (those are decisions, not skips).
- `better_match` requires a `selected_record_id` that differs from the demo's currently assigned record — server returns 422 if equal. UI blocks clicking the MATCHED row with a hint pointing at the **Correct** action.

### Admin: task review map context
- `/defraghq/community-task-reviews` row action **Map records** lists every record on the demo's map+gametype (resolved via `run_<physics>` to match the public voter flow), highlights rows close to the demo time, lets the admin copy a record ID for the Assign action.

### Profile UX
- Similar Skill Rivals, Your Rivals, Known Aliases each tile/chip now uses the translucent slate bubble from the Servers page (`rgba(71,85,105,0.55)` + `backdrop-blur`), keeping the colour-coded hover borders.
- Anonymous visitors of `/profile/{id}` see a glass teaser overlay on the social panels with a **Sign in to use** CTA instead of a hidden section.
- Removed dead `beatable-records` endpoint, controller methods and JS helpers — nothing in the UI was triggering them.

## Test plan

- [ ] `php artisan migrate` runs the 3 new migrations cleanly
- [ ] Anonymous `curl https://defrag.racing/api/records/search?q=foo` → 401 JSON
- [ ] Logged-in browser navigation to `/api/records/search?q=foo` returns 200 JSON in a new tab without re-login
- [ ] `/user/settings?tab=security` → API tokens section: generate, copy, revoke, and the docs modal all work
- [ ] Bearer token in `Authorization: Bearer …` on any of the 4 endpoints succeeds
- [ ] `/defraghq/api-call-logs` shows aggregated users, drills into endpoints, then raw calls, then single-call detail; throttle bucket is per-user (60/min)
- [ ] Community tasks: vote `not_sure` on a demo of map M → reload tasks → no demos on map M for 7 days; same for Skip on rating/tag
- [ ] Community tasks: pick the MATCHED record in verification flow → UI shows hint, server refuses with 422
- [ ] `/defraghq/community-task-reviews` row action **Map records** lists records with diff highlighting; copying a record ID into Assign works
- [ ] Anonymous profile page renders the social-panel teaser overlay; logged-in user sees the real panels with translucent bubbles