### PR TITLE
Notifications WR fix; open demo downloads; Filament UploadedDemos

### DIFF
--- a/app/Filament/Resources/ApiCallLogResource.php
+++ b/app/Filament/Resources/ApiCallLogResource.php
@@ -13,7 +13,7 @@ class ApiCallLogResource extends Resource
 {
     protected static ?string $model = ApiCallLog::class;
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
-    protected static ?string $navigationGroup = 'Moderation';
+    protected static ?string $navigationGroup = 'Content';
     protected static ?string $navigationLabel = 'API call log';
     protected static ?int $navigationSort = 50;
     protected static bool $shouldSkipAuthorization = true;

--- a/app/Filament/Resources/ServerOwnerApplicationResource.php
+++ b/app/Filament/Resources/ServerOwnerApplicationResource.php
@@ -18,7 +18,7 @@ class ServerOwnerApplicationResource extends Resource
 {
     protected static ?string $model = ServerOwnerApplication::class;
     protected static ?string $navigationIcon = 'heroicon-o-server-stack';
-    protected static ?string $navigationGroup = 'Moderation';
+    protected static ?string $navigationGroup = 'Content';
     protected static ?string $navigationLabel = 'Server hosting applications';
     protected static ?int $navigationSort = 30;
     protected static bool $shouldSkipAuthorization = true;

--- a/app/Filament/Resources/SftpCredentialResource.php
+++ b/app/Filament/Resources/SftpCredentialResource.php
@@ -16,7 +16,7 @@ class SftpCredentialResource extends Resource
 {
     protected static ?string $model = SftpCredential::class;
     protected static ?string $navigationIcon = 'heroicon-o-key';
-    protected static ?string $navigationGroup = 'Moderation';
+    protected static ?string $navigationGroup = 'Content';
     protected static ?string $navigationLabel = 'SFTP credentials';
     protected static ?int $navigationSort = 31;
     protected static bool $shouldSkipAuthorization = true;

--- a/app/Filament/Resources/UploadedDemoResource.php
+++ b/app/Filament/Resources/UploadedDemoResource.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UploadedDemoResource\Pages;
+use App\Models\UploadedDemo;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class UploadedDemoResource extends Resource
+{
+    protected static ?string $model = UploadedDemo::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-film';
+
+    protected static ?string $navigationLabel = 'Uploaded Demos';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?int $navigationSort = 6;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasModeratorPermission('demo_reports') ?? false;
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->with(['user', 'record', 'record.user', 'suggestedUser']);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->searchable()
+                    ->sortable()
+                    ->copyable(),
+
+                Tables\Columns\TextColumn::make('original_filename')
+                    ->label('Filename')
+                    ->searchable()
+                    ->limit(35)
+                    ->tooltip(fn ($record) => $record->original_filename),
+
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Uploader')
+                    ->searchable(query: function (Builder $query, string $search): Builder {
+                        return $query->whereHas('user', fn ($q) => $q->where('name', 'like', "%{$search}%"));
+                    })
+                    ->formatStateUsing(fn ($state) => strip_tags(preg_replace('/\^[0-9]/', '', $state ?? '')))
+                    ->placeholder('—'),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable()
+                    ->color(fn (string $state): string => match ($state) {
+                        'assigned'             => 'success',
+                        'fallback-assigned'    => 'info',
+                        'processed'            => 'gray',
+                        'uploaded'             => 'gray',
+                        'processing'           => 'warning',
+                        'failed'               => 'danger',
+                        'failed-validity'      => 'danger',
+                        'unsupported-version'  => 'danger',
+                        default                => 'gray',
+                    }),
+
+                Tables\Columns\TextColumn::make('map_name')
+                    ->label('Map')
+                    ->searchable()
+                    ->limit(25)
+                    ->placeholder('—'),
+
+                Tables\Columns\TextColumn::make('physics')
+                    ->badge()
+                    ->color(fn (?string $state) => str_contains($state ?? '', 'cpm') ? 'purple' : 'info')
+                    ->placeholder('—'),
+
+                Tables\Columns\TextColumn::make('time_ms')
+                    ->label('Time')
+                    ->formatStateUsing(function ($state) {
+                        if (! $state) return '—';
+                        $m = floor($state / 60000);
+                        $s = floor(($state % 60000) / 1000);
+                        $ms = $state % 1000;
+                        return sprintf('%d:%02d.%03d', $m, $s, $ms);
+                    })
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('record_id')
+                    ->label('Record')
+                    ->placeholder('—')
+                    ->url(fn ($record) => $record->record_id
+                        ? url("/profile/mdd/" . ($record->record?->mdd_id ?? 0))
+                        : null)
+                    ->openUrlInNewTab(),
+
+                Tables\Columns\TextColumn::make('file_size')
+                    ->label('Size')
+                    ->formatStateUsing(fn ($state) => $state ? round($state / 1024, 1) . ' KB' : '—')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                Tables\Columns\IconColumn::make('manually_assigned')
+                    ->label('Manual')
+                    ->boolean()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Uploaded')
+                    ->dateTime('Y-m-d H:i')
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->multiple()
+                    ->options([
+                        'uploaded'             => 'Uploaded',
+                        'processing'           => 'Processing',
+                        'processed'            => 'Processed',
+                        'assigned'             => 'Assigned',
+                        'fallback-assigned'    => 'Fallback Assigned',
+                        'failed'               => 'Failed',
+                        'failed-validity'      => 'Failed Validity',
+                        'unsupported-version'  => 'Unsupported Version',
+                    ]),
+
+                Tables\Filters\SelectFilter::make('physics')
+                    ->options([
+                        'cpm' => 'CPM',
+                        'vq3' => 'VQ3',
+                    ]),
+
+                Tables\Filters\SelectFilter::make('gametype')
+                    ->options([
+                        'mdf' => 'mdf (online df)',
+                        'mfs' => 'mfs (online fs)',
+                        'mfc' => 'mfc (online fc)',
+                        'df'  => 'df (offline)',
+                        'fs'  => 'fs (offline)',
+                        'fc'  => 'fc (offline)',
+                    ]),
+
+                Tables\Filters\TernaryFilter::make('record_id')
+                    ->label('Has record')
+                    ->placeholder('All')
+                    ->trueLabel('Linked to record')
+                    ->falseLabel('Unlinked')
+                    ->queries(
+                        true: fn (Builder $q) => $q->whereNotNull('record_id'),
+                        false: fn (Builder $q) => $q->whereNull('record_id'),
+                    ),
+
+                Tables\Filters\TernaryFilter::make('manually_assigned'),
+
+                Tables\Filters\Filter::make('needs_attention')
+                    ->label('Needs attention (failed / unsupported)')
+                    ->query(fn (Builder $q) => $q->whereIn('status', ['failed', 'failed-validity', 'unsupported-version'])),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->paginated([25, 50, 100, 250]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUploadedDemos::route('/'),
+            'view'  => Pages\ViewUploadedDemo::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/UploadedDemoResource/Pages/ListUploadedDemos.php
+++ b/app/Filament/Resources/UploadedDemoResource/Pages/ListUploadedDemos.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UploadedDemoResource\Pages;
+
+use App\Filament\Resources\UploadedDemoResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUploadedDemos extends ListRecords
+{
+    protected static string $resource = UploadedDemoResource::class;
+}

--- a/app/Filament/Resources/UploadedDemoResource/Pages/ViewUploadedDemo.php
+++ b/app/Filament/Resources/UploadedDemoResource/Pages/ViewUploadedDemo.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace App\Filament\Resources\UploadedDemoResource\Pages;
+
+use App\Filament\Resources\UploadedDemoResource;
+use App\Models\UploadedDemo;
+use Filament\Actions;
+use Filament\Infolists;
+use Filament\Infolists\Infolist;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\HtmlString;
+
+class ViewUploadedDemo extends ViewRecord
+{
+    protected static string $resource = UploadedDemoResource::class;
+
+    public function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Infolists\Components\Section::make('File availability')
+                    ->description('Live check across configured disks. Result cached 5 minutes per demo.')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('file_existence_status')
+                            ->label('Status')
+                            ->state(fn (UploadedDemo $record) => $this->fileExistence($record)['summary'])
+                            ->html(),
+                        Infolists\Components\TextEntry::make('file_path')
+                            ->label('file_path')
+                            ->copyable()
+                            ->placeholder('— empty (legacy demo, no longer downloadable)'),
+                        Infolists\Components\TextEntry::make('processed_filename')
+                            ->label('processed_filename')
+                            ->copyable()
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('file_size')
+                            ->label('Size')
+                            ->formatStateUsing(fn ($state) => $state
+                                ? number_format($state) . ' bytes (' . round($state / 1024, 1) . ' KB)'
+                                : '—'),
+                        Infolists\Components\TextEntry::make('file_hash')
+                            ->label('MD5')
+                            ->copyable()
+                            ->placeholder('—'),
+                    ])->columns(2),
+
+                Infolists\Components\Section::make('Status & source')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('status')
+                            ->badge()
+                            ->color(fn (string $state): string => match ($state) {
+                                'assigned'             => 'success',
+                                'fallback-assigned'    => 'info',
+                                'processed', 'uploaded' => 'gray',
+                                'processing'           => 'warning',
+                                'failed', 'failed-validity', 'unsupported-version' => 'danger',
+                                default                => 'gray',
+                            }),
+                        Infolists\Components\TextEntry::make('source')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('download_count')
+                            ->label('Downloads')
+                            ->formatStateUsing(fn ($state) => (int) ($state ?? 0)),
+                        Infolists\Components\TextEntry::make('manually_assigned')
+                            ->label('Manually assigned')
+                            ->badge()
+                            ->color(fn ($state) => $state ? 'warning' : 'gray')
+                            ->formatStateUsing(fn ($state) => $state ? 'yes' : 'no'),
+                        Infolists\Components\TextEntry::make('processing_output')
+                            ->label('Processing output / log')
+                            ->columnSpanFull()
+                            ->placeholder('—')
+                            ->extraAttributes(['style' => 'white-space: pre-wrap; font-family: monospace; font-size: 12px;']),
+                    ])->columns(4),
+
+                Infolists\Components\Section::make('Run details')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('map_name')->label('Map')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('physics')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('gametype')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('time_ms')
+                            ->label('Time')
+                            ->formatStateUsing(function ($state) {
+                                if (! $state) return '—';
+                                $m = floor($state / 60000);
+                                $s = floor(($state % 60000) / 1000);
+                                $ms = $state % 1000;
+                                return sprintf('%d:%02d.%03d (%s ms)', $m, $s, $ms, number_format($state));
+                            }),
+                        Infolists\Components\TextEntry::make('record_date')
+                            ->label('Record date (from demo)')
+                            ->dateTime('Y-m-d H:i:s')
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('country')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('validity')
+                            ->label('Validity flags')
+                            ->columnSpanFull()
+                            ->formatStateUsing(function ($state) {
+                                if (empty($state)) return '— none';
+                                $arr = is_array($state) ? $state : json_decode($state, true);
+                                if (! $arr) return '—';
+                                return new HtmlString('<pre style="font-size:12px; margin:0;">'
+                                    . e(json_encode($arr, JSON_PRETTY_PRINT))
+                                    . '</pre>');
+                            }),
+                    ])->columns(3),
+
+                Infolists\Components\Section::make('Player as recorded in demo')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('player_name')
+                            ->label('player_name (raw)')
+                            ->copyable()
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('q3df_login_name')
+                            ->label('q3df_login_name')
+                            ->copyable()
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('q3df_login_name_colored')
+                            ->label('q3df_login_name_colored')
+                            ->copyable()
+                            ->placeholder('—'),
+                    ])->columns(3),
+
+                Infolists\Components\Section::make('Matching / auto-assignment')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('match_method')
+                            ->badge()
+                            ->color('info')
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('name_confidence')
+                            ->label('Name confidence')
+                            ->formatStateUsing(fn ($state) => $state === null ? '—' : $state . ' %'),
+                        Infolists\Components\TextEntry::make('matched_alias')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('suggested_user_id')
+                            ->label('Suggested user id')
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('suggestedUser.name')
+                            ->label('Suggested user')
+                            ->formatStateUsing(fn ($state) => $state
+                                ? strip_tags(preg_replace('/\^[0-9]/', '', $state))
+                                : '—')
+                            ->url(fn ($record) => $record->suggested_user_id
+                                ? "/profile/" . $record->suggested_user_id
+                                : null)
+                            ->openUrlInNewTab(),
+                    ])->columns(3),
+
+                Infolists\Components\Section::make('Uploader')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('user_id')
+                            ->label('User ID'),
+                        Infolists\Components\TextEntry::make('user.name')
+                            ->label('Name')
+                            ->formatStateUsing(fn ($state) => $state
+                                ? strip_tags(preg_replace('/\^[0-9]/', '', $state))
+                                : '—')
+                            ->url(fn ($record) => $record->user_id
+                                ? "/profile/" . $record->user_id
+                                : null)
+                            ->openUrlInNewTab(),
+                        Infolists\Components\TextEntry::make('user.email')->label('Email')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('user.mdd_id')->label('MDD ID')->placeholder('—'),
+                    ])->columns(4),
+
+                Infolists\Components\Section::make('Linked online record')
+                    ->visible(fn ($record) => $record->record_id !== null)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('record_id')->label('Record ID'),
+                        Infolists\Components\TextEntry::make('record.name')
+                            ->label('Record player')
+                            ->formatStateUsing(fn ($state) => $state
+                                ? strip_tags(preg_replace('/\^[0-9]/', '', $state))
+                                : '—'),
+                        Infolists\Components\TextEntry::make('record.time')
+                            ->label('Record time')
+                            ->formatStateUsing(function ($state) {
+                                if (! $state) return '—';
+                                $m = floor($state / 60000);
+                                $s = floor(($state % 60000) / 1000);
+                                $ms = $state % 1000;
+                                return sprintf('%d:%02d.%03d', $m, $s, $ms);
+                            }),
+                        Infolists\Components\TextEntry::make('record.rank')->label('Rank')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('record.mapname')->label('Record map')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('record.physics')->label('Record physics')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('record.gametype')->label('Record gametype')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('record.date_set')
+                            ->label('Record date_set')
+                            ->dateTime('Y-m-d H:i')
+                            ->placeholder('—'),
+                    ])->columns(4),
+
+                Infolists\Components\Section::make('Linked offline record')
+                    ->visible(fn ($record) => $record->offlineRecord !== null)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('offlineRecord.id')->label('OfflineRecord ID'),
+                        Infolists\Components\TextEntry::make('offlineRecord.mapname')->label('Map')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('offlineRecord.physics')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('offlineRecord.gametype')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('offlineRecord.time')
+                            ->label('Time')
+                            ->formatStateUsing(function ($state) {
+                                if (! $state) return '—';
+                                $m = floor($state / 60000);
+                                $s = floor(($state % 60000) / 1000);
+                                $ms = $state % 1000;
+                                return sprintf('%d:%02d.%03d', $m, $s, $ms);
+                            }),
+                        Infolists\Components\TextEntry::make('offlineRecord.rank')->label('Rank')->placeholder('—'),
+                    ])->columns(5),
+
+                Infolists\Components\Section::make('Rendered video')
+                    ->visible(fn ($record) => $record->renderedVideo !== null)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('renderedVideo.id')->label('Render ID'),
+                        Infolists\Components\TextEntry::make('renderedVideo.status')->badge(),
+                        Infolists\Components\TextEntry::make('renderedVideo.quality_tier')->placeholder('—'),
+                        Infolists\Components\TextEntry::make('renderedVideo.created_at')
+                            ->label('Render created')
+                            ->dateTime('Y-m-d H:i'),
+                    ])->columns(4),
+
+                Infolists\Components\Section::make('Assignment reports for this demo')
+                    ->visible(fn ($record) => $record->assignmentReports()->count() > 0)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('assignment_reports_summary')
+                            ->label('')
+                            ->columnSpanFull()
+                            ->state(function ($record) {
+                                $rows = $record->assignmentReports()
+                                    ->orderByDesc('created_at')
+                                    ->get(['id', 'report_type', 'status', 'created_at']);
+                                if ($rows->isEmpty()) return '—';
+                                $html = '<table style="width:100%; font-size:12px;"><thead><tr><th align="left">ID</th><th align="left">Type</th><th align="left">Status</th><th align="left">Created</th></tr></thead><tbody>';
+                                foreach ($rows as $r) {
+                                    $url = url('/defraghq/demo-assignment-reports/' . $r->id);
+                                    $html .= '<tr>'
+                                        . '<td><a href="' . e($url) . '" style="color:#60a5fa;">#' . (int) $r->id . '</a></td>'
+                                        . '<td>' . e($r->report_type) . '</td>'
+                                        . '<td>' . e($r->status) . '</td>'
+                                        . '<td>' . e((string) $r->created_at) . '</td>'
+                                        . '</tr>';
+                                }
+                                $html .= '</tbody></table>';
+                                return new HtmlString($html);
+                            }),
+                    ]),
+
+                Infolists\Components\Section::make('Audit')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('created_at')->dateTime('Y-m-d H:i:s'),
+                        Infolists\Components\TextEntry::make('updated_at')->dateTime('Y-m-d H:i:s'),
+                    ])->columns(2),
+            ]);
+    }
+
+    private function fileExistence(UploadedDemo $record): array
+    {
+        $cacheKey = "filament:demo_file_check:{$record->id}";
+
+        return Cache::remember($cacheKey, 300, function () use ($record) {
+            $local = false;
+            $remote = false;
+            $remoteError = null;
+
+            if (! empty($record->file_path)) {
+                try {
+                    $local = Storage::disk('local')->exists($record->file_path);
+                } catch (\Throwable $e) {
+                    // ignore — keep $local = false
+                }
+
+                try {
+                    $remote = Storage::disk('s3')->exists($record->file_path);
+                } catch (\Throwable $e) {
+                    $remoteError = $e->getMessage();
+                }
+            }
+
+            $rows = [];
+            if (empty($record->file_path)) {
+                $rows[] = '<span style="color:#fbbf24;">⚠ file_path is empty — legacy demo, never had a stored file</span>';
+            } else {
+                $rows[] = ($local ? '<span style="color:#34d399;">✓</span>' : '<span style="color:#f87171;">✗</span>')
+                    . ' <strong>Local disk</strong> <code style="font-size:12px;">storage/app/' . e($record->file_path) . '</code>';
+                if ($remoteError) {
+                    $rows[] = '<span style="color:#f87171;">✗</span> <strong>Backblaze (s3)</strong> — error: <code style="font-size:12px;">' . e($remoteError) . '</code>';
+                } else {
+                    $rows[] = ($remote ? '<span style="color:#34d399;">✓</span>' : '<span style="color:#f87171;">✗</span>')
+                        . ' <strong>Backblaze (s3)</strong> <code style="font-size:12px;">' . e($record->file_path) . '</code>';
+                }
+                if (! $local && ! $remote) {
+                    $rows[] = '<div style="margin-top:6px; color:#f87171;"><strong>Download will return 404</strong> — file is missing from both disks.</div>';
+                } elseif ($remote && ! $local) {
+                    $rows[] = '<div style="margin-top:6px; color:#9ca3af;">Will be served from Backblaze.</div>';
+                } elseif ($local && ! $remote) {
+                    $rows[] = '<div style="margin-top:6px; color:#9ca3af;">Will be served from local storage (not yet uploaded to Backblaze).</div>';
+                } else {
+                    $rows[] = '<div style="margin-top:6px; color:#34d399;">File present on both disks.</div>';
+                }
+            }
+
+            return [
+                'local'   => $local,
+                'remote'  => $remote,
+                'summary' => new HtmlString(implode('<br>', $rows)),
+            ];
+        });
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('open_on_site')
+                ->label('Open on site')
+                ->icon('heroicon-o-arrow-top-right-on-square')
+                ->url(fn ($record) => "/demos/{$record->id}")
+                ->openUrlInNewTab(),
+
+            Actions\Action::make('download')
+                ->label('Download')
+                ->icon('heroicon-o-arrow-down-tray')
+                ->color('primary')
+                ->url(fn ($record) => route('demos.download', $record))
+                ->openUrlInNewTab(),
+
+            Actions\Action::make('refresh_file_check')
+                ->label('Re-check files')
+                ->icon('heroicon-o-arrow-path')
+                ->color('gray')
+                ->action(function ($record) {
+                    Cache::forget("filament:demo_file_check:{$record->id}");
+                    Notification::make()->title('Cache cleared, reloading…')->success()->send();
+                    return redirect(request()->header('Referer') ?: url()->current());
+                }),
+
+            Actions\Action::make('detach_from_record')
+                ->label('Detach from record')
+                ->icon('heroicon-o-link-slash')
+                ->color('warning')
+                ->visible(fn ($record) => $record->record_id !== null)
+                ->requiresConfirmation()
+                ->modalHeading('Detach demo from record')
+                ->modalDescription('Sets record_id = null and status = "processed". Demo will be re-considered by demos:rematch-all on the next run.')
+                ->action(function ($record) {
+                    $record->update([
+                        'record_id'          => null,
+                        'status'             => 'processed',
+                        'manually_assigned'  => false,
+                    ]);
+                    Notification::make()->title('Detached from record')->success()->send();
+                }),
+
+            Actions\DeleteAction::make()
+                ->label('Delete demo row')
+                ->modalDescription('Removes the uploaded_demos row. The file on Backblaze/local is NOT deleted.'),
+        ];
+    }
+}

--- a/app/Http/Controllers/DemosController.php
+++ b/app/Http/Controllers/DemosController.php
@@ -735,16 +735,14 @@ class DemosController extends Controller
      */
     public function download(UploadedDemo $demo)
     {
-        // Allow download for owner, admins, or if the demo is assigned to a public record (online or offline)
+        // All uploaded demos are public by default — there's no integrity argument
+        // for blocking unlinked freestyle/trick demos, and metadata is already
+        // exposed in listings. Future serverdemos (separate feature) will gate
+        // their own visibility via per-player approval. Owner + admin still get
+        // through unconditionally; everyone else is throttled by the rate limit
+        // below. A missing physical file still returns 404 further down.
         $currentUser = Auth::user();
         $isAdmin = ($currentUser && ((isset($currentUser->is_admin) && $currentUser->is_admin) || (isset($currentUser->admin) && $currentUser->admin)));
-
-        // Allow download if: user is owner, user is admin, demo has online record, or demo has offline record
-        $hasPublicRecord = $demo->record || $demo->offlineRecord;
-
-        if ($demo->user_id !== optional($currentUser)->id && !$hasPublicRecord && !$isAdmin) {
-            abort(403, 'Unauthorized');
-        }
 
         // Rate limiting for downloads (skip for admins and demo owners)
         if (!$isAdmin && $demo->user_id !== optional($currentUser)->id) {

--- a/app/Http/Controllers/NotificationsController.php
+++ b/app/Http/Controllers/NotificationsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 use App\Models\RecordNotification;
@@ -10,22 +11,10 @@ use App\Models\Notification;
 
 class NotificationsController extends Controller
 {
+    private const VALID_RECORD_FILTERS = ['all', 'beaten', 'worldrecords'];
+
     public function records (Request $request) {
-        $recordNotificationsPage = RecordNotification::query()
-            ->where('user_id', $request->user()->id)
-            ->orderBy('created_at', 'DESC')
-            ->paginate(20, ['*'], 'records_page');
-
-        $systemNotificationsPage = Notification::query()
-            ->where('user_id', $request->user()->id)
-            ->orderBy('created_at', 'DESC')
-            ->paginate(30);
-
-        return Inertia::render('NotificationsView')->with([
-            'recordNotificationsPage' => $recordNotificationsPage,
-            'systemNotificationsPage' => $systemNotificationsPage,
-            'activeTab' => 'records'
-        ]);
+        return $this->renderInbox($request, 'records');
     }
 
     public function recordsclear (Request $request) {
@@ -53,20 +42,61 @@ class NotificationsController extends Controller
     }
 
     public function system (Request $request) {
-        $recordNotificationsPage = RecordNotification::query()
-            ->where('user_id', $request->user()->id)
-            ->orderBy('created_at', 'DESC')
-            ->paginate(20, ['*'], 'records_page');
+        return $this->renderInbox($request, 'system');
+    }
+
+    private function renderInbox(Request $request, string $activeTab)
+    {
+        $userId = $request->user()->id;
+
+        $recordFilter = $request->query('record_filter', 'all');
+        if (! in_array($recordFilter, self::VALID_RECORD_FILTERS, true)) {
+            $recordFilter = 'all';
+        }
+
+        $query = RecordNotification::query()
+            ->where('user_id', $userId)
+            ->orderBy('created_at', 'DESC');
+
+        if ($recordFilter === 'beaten') {
+            $query->where('worldrecord', 0);
+        } elseif ($recordFilter === 'worldrecords') {
+            $query->where('worldrecord', 1);
+        }
+
+        $recordNotificationsPage = $query->paginate(20, ['*'], 'records_page')->withQueryString();
 
         $systemNotificationsPage = Notification::query()
-            ->where('user_id', $request->user()->id)
+            ->where('user_id', $userId)
             ->orderBy('created_at', 'DESC')
             ->paginate(20, ['*'], 'system_page');
+
+        // Per-tab unread counts in a single aggregation query (covered by
+        // the (user_id, worldrecord, created_at) index).
+        $counts = DB::table('record_notifications')
+            ->selectRaw('
+                SUM(CASE WHEN `read` = 0 THEN 1 ELSE 0 END) AS unread_all,
+                SUM(CASE WHEN `read` = 0 AND worldrecord = 0 THEN 1 ELSE 0 END) AS unread_beaten,
+                SUM(CASE WHEN `read` = 0 AND worldrecord = 1 THEN 1 ELSE 0 END) AS unread_worldrecords,
+                COUNT(*) AS total_all
+            ')
+            ->where('user_id', $userId)
+            ->first();
+
+        $systemUnread = Notification::where('user_id', $userId)->where('read', 0)->count();
 
         return Inertia::render('NotificationsView')->with([
             'recordNotificationsPage' => $recordNotificationsPage,
             'systemNotificationsPage' => $systemNotificationsPage,
-            'activeTab' => 'system'
+            'activeTab' => $activeTab,
+            'recordFilter' => $recordFilter,
+            'recordCounts' => [
+                'unread_all'          => (int) ($counts->unread_all ?? 0),
+                'unread_beaten'       => (int) ($counts->unread_beaten ?? 0),
+                'unread_worldrecords' => (int) ($counts->unread_worldrecords ?? 0),
+                'total'               => (int) ($counts->total_all ?? 0),
+            ],
+            'systemUnreadCount' => $systemUnread,
         ]);
     }
 

--- a/app/Jobs/ProcessNotificationsJob.php
+++ b/app/Jobs/ProcessNotificationsJob.php
@@ -75,6 +75,12 @@ class ProcessNotificationsJob implements ShouldQueue
         $notification->mapname = $this->record->mapname;
         $notification->date_set = $this->record->date_set;
         $notification->my_time = $currentRecord->time;
+        // WR-beaten = the *recipient* held rank 1 and the new record took it.
+        // processRanks() ran in ScrapeRecords before this job dispatched, so
+        // these ranks reflect the post-beat state: beater is now 1, recipient
+        // dropped to 2.
+        $notification->worldrecord = ($this->record->rank == 1)
+            && ($currentRecord->rank == 2);
 
         $notification->save();
     }

--- a/database/migrations/2026_05_11_000008_backfill_worldrecord_on_record_notifications.php
+++ b/database/migrations/2026_05_11_000008_backfill_worldrecord_on_record_notifications.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Backfill worldrecord flag on historical notifications by matching
+        // each notification to its source record (same map/physics/mode/player/time)
+        // and copying rank==1 over as worldrecord=true.
+        // Records may have been re-ranked since the notification was created,
+        // so the historical accuracy isn't perfect — this reflects current rank.
+        DB::statement("
+            UPDATE record_notifications rn
+            INNER JOIN records r
+                ON r.mapname = rn.mapname
+                AND r.physics = rn.physics
+                AND r.mode = rn.mode
+                AND r.mdd_id = rn.mdd_id
+                AND r.time = rn.time
+                AND r.deleted_at IS NULL
+            SET rn.worldrecord = 1
+            WHERE r.rank = 1
+        ");
+
+        // Mark all existing notifications as read so the backfilled WR ones
+        // don't suddenly resurface as unread; only newly-generated notifications
+        // (post-deploy) should appear unread.
+        DB::statement("UPDATE record_notifications SET `read` = 1");
+    }
+
+    public function down(): void
+    {
+        // Not reversible — we can't tell which notifications were originally
+        // read vs. marked read by this migration. Leave as-is.
+    }
+};

--- a/database/migrations/2026_05_11_000009_add_worldrecord_index_to_record_notifications.php
+++ b/database/migrations/2026_05_11_000009_add_worldrecord_index_to_record_notifications.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('record_notifications', function (Blueprint $table) {
+            // Powers the per-tab listing (?record_filter=beaten|worldrecords)
+            // and per-user counts. Without it the WR tab does a filesort across
+            // every notification the user has received.
+            $table->index(
+                ['user_id', 'worldrecord', 'created_at'],
+                'idx_record_notifications_user_wr_created'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('record_notifications', function (Blueprint $table) {
+            $table->dropIndex('idx_record_notifications_user_wr_created');
+        });
+    }
+};

--- a/database/migrations/2026_05_11_000010_fix_worldrecord_backfill_on_record_notifications.php
+++ b/database/migrations/2026_05_11_000010_fix_worldrecord_backfill_on_record_notifications.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Reset the previous over-eager backfill — earlier migration flagged
+        // every notification whose *beater* is currently WR, which fires even
+        // for users who never held rank 1 themselves.
+        DB::statement("UPDATE record_notifications SET worldrecord = 0");
+
+        // Correct logic: this notification was a WR-beat iff the recipient
+        // held rank 1 at the moment (their `my_time` is currently a rank-2
+        // record) AND the beater is currently rank 1 with that exact time.
+        // Imperfect for cases where either party has improved since — we have
+        // no historical rank table — but accurate for the still-current
+        // state of the leaderboard.
+        DB::statement("
+            UPDATE record_notifications rn
+            INNER JOIN users u ON u.id = rn.user_id
+            INNER JOIN records beater
+                ON beater.mapname = rn.mapname
+                AND beater.physics = rn.physics
+                AND beater.mode = rn.mode
+                AND beater.mdd_id = rn.mdd_id
+                AND beater.time = rn.time
+                AND beater.deleted_at IS NULL
+                AND beater.rank = 1
+            INNER JOIN records recipient
+                ON recipient.mapname = rn.mapname
+                AND recipient.physics = rn.physics
+                AND recipient.mode = rn.mode
+                AND recipient.mdd_id = u.mdd_id
+                AND recipient.time = rn.my_time
+                AND recipient.deleted_at IS NULL
+                AND recipient.rank = 2
+            SET rn.worldrecord = 1
+        ");
+    }
+
+    public function down(): void
+    {
+        // Not reversible without historical rank data.
+    }
+};

--- a/resources/js/Pages/NotificationsView.vue
+++ b/resources/js/Pages/NotificationsView.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import { Head, Link } from '@inertiajs/vue3';
+    import { Head, Link, router } from '@inertiajs/vue3';
     import { ref, computed, onMounted, nextTick } from 'vue';
     import Pagination from '@/Components/Basic/Pagination.vue';
     import axios from 'axios';
@@ -10,6 +10,18 @@
         activeTab: {
             type: String,
             default: 'records'
+        },
+        recordFilter: {
+            type: String,
+            default: 'all'
+        },
+        recordCounts: {
+            type: Object,
+            default: () => ({ unread_all: 0, unread_beaten: 0, unread_worldrecords: 0, total: 0 })
+        },
+        systemUnreadCount: {
+            type: Number,
+            default: 0
         }
     });
 
@@ -34,17 +46,36 @@
     });
 
     const activeSystemTab = ref('all');
-    const activeRecordTab = ref('all');
+    const activeRecordTab = ref(props.recordFilter);
 
     const timeDiff = (time, bettertime) => {
         return Math.abs(bettertime - time);
     };
 
     const totalCount = computed(() => {
-        const unreadRecords = (props.recordNotificationsPage?.data || []).filter(n => !n.read).length;
-        const unreadSystem = (props.systemNotificationsPage?.data || []).filter(n => !n.read).length;
-        return unreadRecords + unreadSystem;
+        return (props.recordCounts?.unread_all || 0) + (props.systemUnreadCount || 0);
     });
+
+    const setRecordTab = (tab) => {
+        if (activeRecordTab.value === tab) return;
+        activeRecordTab.value = tab;
+        const url = props.activeTab === 'system'
+            ? route('notifications.system.index')
+            : route('notifications.index');
+        router.get(url, { record_filter: tab }, {
+            preserveScroll: true,
+            preserveState: true,
+            replace: true,
+        });
+    };
+
+    const refreshCounts = () => {
+        router.reload({
+            preserveScroll: true,
+            preserveState: true,
+            only: ['recordCounts', 'systemUnreadCount'],
+        });
+    };
 
     const toggleNotificationRead = (notificationId) => {
         axios.post(route('notifications.toggle', notificationId)).then((response) => {
@@ -52,18 +83,21 @@
             if (notification) {
                 notification.read = response.data.read;
             }
+            refreshCounts();
         });
     };
 
     const markAllAsRead = () => {
         axios.post(route('notifications.clear')).then(() => {
             props.recordNotificationsPage.data.forEach(n => n.read = true);
+            refreshCounts();
         });
     };
 
     const markAllAsUnread = () => {
         axios.post(route('notifications.mark.unread')).then(() => {
             props.recordNotificationsPage.data.forEach(n => n.read = false);
+            refreshCounts();
         });
     };
 
@@ -74,43 +108,33 @@
             if (notification) {
                 notification.read = response.data.read;
             }
+            refreshCounts();
         });
     };
 
     const markAllSystemAsRead = () => {
         axios.post(route('notifications.system.clear')).then(() => {
             props.systemNotificationsPage.data.forEach(n => n.read = true);
+            refreshCounts();
         });
     };
 
     const markAllSystemAsUnread = () => {
         axios.post(route('notifications.system.mark.unread')).then(() => {
             props.systemNotificationsPage.data.forEach(n => n.read = false);
+            refreshCounts();
         });
     };
 
-    // Filter record notifications by sub-tab category
-    const filteredRecordNotifications = computed(() => {
-        const notifications = props.recordNotificationsPage?.data || [];
+    // Server filters & paginates already; just render what came back.
+    const filteredRecordNotifications = computed(() => props.recordNotificationsPage?.data || []);
 
-        if (activeRecordTab.value === 'beaten') {
-            return notifications.filter(n => !n.worldrecord);
-        } else if (activeRecordTab.value === 'worldrecords') {
-            return notifications.filter(n => n.worldrecord);
-        }
-
-        return notifications;
-    });
-
-    // Count notifications for each record sub-tab (only unread)
-    const recordTabCounts = computed(() => {
-        const notifications = (props.recordNotificationsPage?.data || []).filter(n => !n.read);
-        return {
-            all: notifications.length,
-            beaten: notifications.filter(n => !n.worldrecord).length,
-            worldrecords: notifications.filter(n => n.worldrecord).length
-        };
-    });
+    // Per-tab unread counts come from the server (full user inbox, not just page).
+    const recordTabCounts = computed(() => ({
+        all: props.recordCounts?.unread_all || 0,
+        beaten: props.recordCounts?.unread_beaten || 0,
+        worldrecords: props.recordCounts?.unread_worldrecords || 0,
+    }));
 
     // Filter system notifications by sub-tab category
     const filteredSystemNotifications = computed(() => {
@@ -322,7 +346,7 @@
                     <!-- Sub-tabs -->
                     <div class="flex border-b border-white/10 bg-black/20">
                         <button
-                            @click="activeRecordTab = 'all'"
+                            @click="setRecordTab('all')"
                             class="flex-1 px-4 py-2 text-center text-sm font-semibold transition-all relative group"
                             :class="activeRecordTab === 'all'
                                 ? 'text-orange-400 bg-orange-500/10'
@@ -342,7 +366,7 @@
                         </button>
 
                         <button
-                            @click="activeRecordTab = 'beaten'"
+                            @click="setRecordTab('beaten')"
                             class="flex-1 px-4 py-2 text-center text-sm font-semibold transition-all relative group"
                             :class="activeRecordTab === 'beaten'
                                 ? 'text-blue-400 bg-blue-500/10'
@@ -362,7 +386,7 @@
                         </button>
 
                         <button
-                            @click="activeRecordTab = 'worldrecords'"
+                            @click="setRecordTab('worldrecords')"
                             class="flex-1 px-4 py-2 text-center text-sm font-semibold transition-all relative group"
                             :class="activeRecordTab === 'worldrecords'
                                 ? 'text-yellow-400 bg-yellow-500/10'


### PR DESCRIPTION
## Summary
- **Notifications:** `worldrecord` flag on RecordNotification is now set correctly (recipient held rank 1, beater is now rank 1). Earlier naive backfill is replaced with a re-backfill that only marks true WR-beats. Server-side filter + composite `(user_id, worldrecord, created_at)` index; `?record_filter=all|beaten|worldrecords` drives the sub-tab; counts come from the full inbox, not the current page.
- **Demos:** dropped the 403 in `DemosController::download` for non-owner, non-admin, unlinked demos. All uploaded demos are public by default; rate limit and 404-on-missing-file still apply. Future serverdemos will gate visibility separately.
- **Admin:** new Filament `UploadedDemoResource` for debugging individual demos by ID — list with filters and a "needs attention" preset; detail view with every column, all relationships (uploader, online/offline record, suggested user, assignment reports, rendered video), and a cached live file-existence check across local disk + Backblaze.
- **Navigation:** moved UploadedDemos, ServerOwnerApplications, SftpCredentials, and ApiCallLog from Moderation to Content group.

## Test plan
- [ ] Log in, open `/notifications/records?record_filter=worldrecords` — verify the WR sub-tab returns only true WR-beat events.
- [ ] Run the three notification migrations (`000008`, `000009`, `000010`) and verify counts match: total `worldrecord = 1` notifications dropped from the over-eager first backfill to the corrected subset.
- [ ] As an anonymous user, hit `/demos/{id}/download` for an unlinked freestyle/trick demo (e.g., the one from the Discord report) — must succeed instead of 403.
- [ ] Hit the same endpoint 51 times in a row as an authenticated non-owner — verify rate limit returns 429 at the 51st call.
- [ ] In Filament `/defraghq/uploaded-demos`, search by demo ID, open the detail view — verify all sections render and the File availability section reports local ✓/✗ and Backblaze ✓/✗.
- [ ] Trigger the "Re-check files" header action — verify cache clears and the next render re-queries.