### PR TITLE
Ranking polish: tooltip breakdown, sort/save filters, weight tweak, docs

### DIFF
--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -1765,6 +1765,19 @@ class MapsController extends Controller
             $record->map_score = $score ? round($score->map_score, 2) : null;
             $record->reltime = $score ? round($score->reltime, 4) : null;
             $record->multiplier = $score ? round($score->multiplier, 4) : null;
+            $record->rank_multiplier = $score ? round($score->rank_multiplier ?? 1, 4) : null;
+            // base_score = map_score / (map_mult * rank_mult) — invariant of map/rank,
+            // so the tooltip can show the algorithm breakdown: base × rank × map = score
+            if ($score) {
+                $mapMult = $score->multiplier ?? 1;
+                $rankMult = $score->rank_multiplier ?? 1;
+                $divisor = $mapMult * $rankMult;
+                $record->base_score = $divisor > 0
+                    ? round($score->map_score / $divisor, 2)
+                    : round($score->map_score, 2);
+            } else {
+                $record->base_score = null;
+            }
             $record->is_outlier = $score ? $score->is_outlier : false;
             return $record;
         });

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -76,7 +76,7 @@ class ProfileController extends Controller {
 
         // --- Records (needed for records pagination or full load) ---
         if ($needs('vq3Records') || $needs('cpmRecords')) {
-            $types = ['recentlybeaten', 'tiedranks', 'bestranks', 'besttimes', 'worstranks', 'worsttimes', 'untouchable'];
+            $types = ['recentlybeaten', 'tiedranks', 'bestranks', 'besttimes', 'worstranks', 'worsttimes', 'untouchable', 'bestscore'];
             if (!in_array($type, $types)) {
                 $type = 'latest';
             }
@@ -89,6 +89,7 @@ class ProfileController extends Controller {
                 'worstranks'        => $this->worstRanks($mddId),
                 'worsttimes'        => $this->worstTimes($mddId),
                 'untouchable'       => $this->untouchableWRs($mddId),
+                'bestscore'         => $this->bestScores($mddId),
                 default             => $this->latestRecords($mddId),
             };
 
@@ -294,7 +295,7 @@ class ProfileController extends Controller {
         $mode = $request->input('mode', 'all');
         $search = trim((string) $request->input('search', ''));
 
-        $types = ['recentlybeaten', 'tiedranks', 'bestranks', 'besttimes', 'worstranks', 'worsttimes', 'untouchable'];
+        $types = ['recentlybeaten', 'tiedranks', 'bestranks', 'besttimes', 'worstranks', 'worsttimes', 'untouchable', 'bestscore'];
 
         if (!in_array($type, $types)) {
             $type = 'latest';
@@ -308,6 +309,7 @@ class ProfileController extends Controller {
             'worstranks'        => $this->worstRanks($user->id),
             'worsttimes'        => $this->worstTimes($user->id),
             'untouchable'       => $this->untouchableWRs($user->id),
+            'bestscore'         => $this->bestScores($user->id),
             default             => $this->latestRecords($user->id),
         };
 
@@ -547,6 +549,24 @@ class ProfileController extends Controller {
 
     public function worstRanks($mddId) {
         $records = Record::where('mdd_id', $mddId)->orderBy('rank', 'DESC')->orderBy('date_set', 'DESC');
+
+        return $records;
+    }
+
+    public function bestScores($mddId) {
+        // Sort the player's records by their computed map_score (rating),
+        // descending. INNER JOIN drops records that have no map_score yet
+        // (banned maps, freshly scraped maps before the rating job runs).
+        $records = Record::selectRaw('records.*, pms.map_score AS player_map_score')
+            ->join('player_map_scores AS pms', function ($join) {
+                $join->on('pms.mdd_id', '=', 'records.mdd_id')
+                     ->on('pms.mapname', '=', 'records.mapname')
+                     ->on('pms.physics', '=', 'records.physics')
+                     ->on('pms.mode', '=', 'records.mode');
+            })
+            ->where('records.mdd_id', $mddId)
+            ->where('pms.map_score', '>', 0)
+            ->orderByDesc('pms.map_score');
 
         return $records;
     }
@@ -1186,9 +1206,10 @@ class ProfileController extends Controller {
             $record->is_outlier = $score ? $score->is_outlier : false;
             $record->score_rank = $scoreRanks[$record->mapname] ?? null;
             $record->score_rank_total = $totalMaps;
-            // Weight for this rank position
+            // Weight for this rank position — weight = exp(-D * (rank - 1))
+            // so the best record (rank 1) gets weight 1.0
             if (isset($scoreRanks[$record->mapname])) {
-                $record->score_weight = round(exp(-0.02 * $scoreRanks[$record->mapname]), 4);
+                $record->score_weight = round(exp(-0.02 * ($scoreRanks[$record->mapname] - 1)), 4);
             }
             return $record;
         });
@@ -1257,7 +1278,9 @@ class ProfileController extends Controller {
         $rawBreakdown = [];
 
         foreach ($mapScores->values() as $rank => $score) {
-            $weight = exp(-$CFG_D * ($rank + 1));
+            // weight = exp(-D * (i - 1)) with i = $rank + 1 (1-indexed) → exp(-D * $rank)
+            // best record (rank 0 here, rank 1 user-facing) gets weight 1.0
+            $weight = exp(-$CFG_D * $rank);
             $weightedSum += $score->map_score * $weight;
             $weightSum += $weight;
             $rawBreakdown[] = ['rank' => $rank, 'score' => $score, 'weight' => $weight];

--- a/app/Http/Controllers/SavedMapFilterController.php
+++ b/app/Http/Controllers/SavedMapFilterController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SavedMapFilter;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class SavedMapFilterController extends Controller
+{
+    private const MAX_PER_USER = 50;
+
+    public function index()
+    {
+        $userId = Auth::id();
+        $filters = SavedMapFilter::where('user_id', $userId)
+            ->orderByDesc('created_at')
+            ->get(['id', 'name', 'filter_state', 'created_at']);
+
+        return response()->json(['filters' => $filters]);
+    }
+
+    public function store(Request $request)
+    {
+        $userId = Auth::id();
+
+        $data = $request->validate([
+            'name' => [
+                'required', 'string', 'max:80',
+                Rule::unique('saved_map_filters')->where(fn ($q) => $q->where('user_id', $userId)),
+            ],
+            // filter_state is the raw queries object from the sidebar form.
+            // We don't validate its shape — MapFilters on the read side
+            // tolerates missing/unknown keys, and filters drift over time.
+            'filter_state' => ['required', 'array'],
+        ]);
+
+        // Cap to prevent runaway storage per user.
+        if (SavedMapFilter::where('user_id', $userId)->count() >= self::MAX_PER_USER) {
+            return response()->json([
+                'message' => 'Maximum number of saved filters reached (' . self::MAX_PER_USER . '). Delete an old one first.',
+            ], 422);
+        }
+
+        $filter = SavedMapFilter::create([
+            'user_id' => $userId,
+            'name' => $data['name'],
+            'filter_state' => $data['filter_state'],
+        ]);
+
+        return response()->json([
+            'filter' => $filter->only(['id', 'name', 'filter_state', 'created_at']),
+        ], 201);
+    }
+
+    public function destroy(SavedMapFilter $savedMapFilter)
+    {
+        if ($savedMapFilter->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $savedMapFilter->delete();
+
+        return response()->json(['ok' => true]);
+    }
+}

--- a/app/Jobs/CalculateRatings.php
+++ b/app/Jobs/CalculateRatings.php
@@ -280,12 +280,13 @@ class CalculateRatings implements ShouldQueue
             '));
 
         // compute weights using exp decay
-        // weight = exp(-CFG_D * record_player_rank)
+        // weight = exp(-CFG_D * (record_player_rank - 1))
+        // — so the best record (rank 1) gets weight 1.0
         $query = DB::table(DB::raw("({$query->toSql()}) as sub"))
             ->mergeBindings($query)
             ->addSelect('*')
             ->addSelect(DB::raw('
-                EXP(-' . self::CFG_D . ' * record_player_rank)
+                EXP(-' . self::CFG_D . ' * (record_player_rank - 1))
                 AS weight
             '));
 

--- a/app/Models/SavedMapFilter.php
+++ b/app/Models/SavedMapFilter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SavedMapFilter extends Model
+{
+    protected $fillable = ['user_id', 'name', 'filter_state'];
+
+    protected $casts = [
+        'filter_state' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_05_12_000001_create_saved_map_filters_table.php
+++ b/database/migrations/2026_05_12_000001_create_saved_map_filters_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('saved_map_filters', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->string('name', 80);
+            $table->json('filter_state');
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saved_map_filters');
+    }
+};

--- a/resources/js/Components/Basic/PlayerSelect.vue
+++ b/resources/js/Components/Basic/PlayerSelect.vue
@@ -84,6 +84,17 @@
         emit('update:modelValue', [...selectedOptions.value]);
     }
 
+    const removeOption = (id) => {
+        // Works for both multi and single — just yanks the id out of the
+        // selection. (selectOption with a single-mode component would
+        // re-set the same id rather than remove it.)
+        const idx = selectedOptions.value.indexOf(id);
+        if (idx !== -1) {
+            selectedOptions.value.splice(idx, 1);
+            emit('update:modelValue', [...selectedOptions.value]);
+        }
+    }
+
     watch(isOpen, (value) => {
         if (!value) {
             filterOptions()
@@ -117,6 +128,14 @@
 
         return user.plain_name
     }
+
+    // Map selected ids back to the full profile objects so we can render
+    // chips with name + country flag below the search input.
+    const selectedUsers = computed(() =>
+        selectedOptions.value
+            .map(id => props.options.find(o => o.id === id))
+            .filter(Boolean)
+    );
 </script>
 
 <template>
@@ -135,6 +154,19 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none">
                 <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
             </svg>
+        </div>
+
+        <!-- Selected players chips -->
+        <div v-if="selectedUsers.length > 0" class="mt-1.5 flex flex-wrap gap-1">
+            <span v-for="user in selectedUsers" :key="user.id"
+                class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-500/20 border border-blue-400/40 text-xs text-white">
+                <img :src="`/images/flags/${getCountry(user)}.png`" onerror="this.src='/images/flags/_404.png'" class="w-4 h-3 object-cover rounded flex-shrink-0">
+                <span class="truncate max-w-[140px]" v-html="q3tohtml(getName(user))"></span>
+                <button @click.prevent.stop="removeOption(user.id)" type="button"
+                    class="text-blue-200/70 hover:text-red-300 transition flex-shrink-0" title="Remove">
+                    <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+                </button>
+            </span>
         </div>
 
         <div class="dropdown-modern" v-show="isOpen && search.length > 0">

--- a/resources/js/Components/MapFiltersSidebar.vue
+++ b/resources/js/Components/MapFiltersSidebar.vue
@@ -1,6 +1,6 @@
 <script setup>
     import { ref, onMounted, computed } from 'vue';
-    import { useForm } from '@inertiajs/vue3';
+    import { useForm, usePage } from '@inertiajs/vue3';
     import TextInput from '@/Components/Laravel/TextInput.vue';
     import SpecialRadio from '@/Components/Basic/SpecialRadio.vue';
     import PlayerSelect from '@/Components/Basic/PlayerSelect.vue';
@@ -244,6 +244,114 @@
         form.average_length[1] = sliderToValue(lengthSliderMax.value, 1000);
     };
 
+    // --- Saved filters (per-user, private) -------------------------------
+    const page = usePage();
+    const isLoggedIn = computed(() => !!page.props.auth?.user);
+
+    const savedFilters = ref([]);
+    const savedFiltersLoaded = ref(false);
+    const savedFiltersLoading = ref(false);
+    const showSaveModal = ref(false);
+    const showLoadDropdown = ref(false);
+    const newFilterName = ref('');
+    const saveError = ref('');
+    const saveLoading = ref(false);
+
+    const fetchSavedFilters = async () => {
+        if (!isLoggedIn.value) return;
+        savedFiltersLoading.value = true;
+        try {
+            const { data } = await axios.get('/api/saved-map-filters');
+            savedFilters.value = data.filters || [];
+            savedFiltersLoaded.value = true;
+        } catch (e) {
+            console.error('Failed to load saved filters', e);
+        } finally {
+            savedFiltersLoading.value = false;
+        }
+    };
+
+    const openSaveModal = () => {
+        saveError.value = '';
+        newFilterName.value = '';
+        showSaveModal.value = true;
+    };
+
+    const saveCurrentFilter = async () => {
+        const name = newFilterName.value.trim();
+        if (!name) return;
+        saveError.value = '';
+        saveLoading.value = true;
+        try {
+            const { data } = await axios.post('/api/saved-map-filters', {
+                name,
+                filter_state: form.data(),
+            });
+            savedFilters.value = [data.filter, ...savedFilters.value];
+            showSaveModal.value = false;
+        } catch (e) {
+            if (e.response?.status === 422) {
+                saveError.value = e.response.data.errors?.name?.[0]
+                    || e.response.data.message
+                    || 'Validation error';
+            } else {
+                saveError.value = 'Failed to save filter';
+            }
+        } finally {
+            saveLoading.value = false;
+        }
+    };
+
+    const toggleLoadDropdown = async () => {
+        showLoadDropdown.value = !showLoadDropdown.value;
+        if (showLoadDropdown.value && !savedFiltersLoaded.value) {
+            await fetchSavedFilters();
+        }
+    };
+
+    const applyFilter = (filter) => {
+        const s = filter.filter_state || {};
+        form.sort            = s.sort ?? 'newest';
+        form.search          = s.search ?? '';
+        form.author          = s.author ?? '';
+        form.difficulty      = s.difficulty ?? [];
+        form.gametype        = s.gametype ?? [];
+        form.physics         = s.physics ?? [];
+        form.has_records     = s.has_records ?? [];
+        form.have_no_records = s.have_no_records ?? [];
+        form.world_record    = s.world_record ?? [];
+        form.items           = s.items ?? {};
+        form.weapons         = s.weapons ?? {};
+        form.functions       = s.functions ?? {};
+        form.records_count   = Array.isArray(s.records_count) && s.records_count.length === 2 ? s.records_count : [0, 1000];
+        form.average_length  = Array.isArray(s.average_length) && s.average_length.length === 2 ? s.average_length : [0, 1000];
+        form.rank_min        = s.rank_min ?? 1;
+        form.rank_max        = s.rank_max ?? 999;
+        // resync sliders so the visual thumbs follow the loaded values
+        recordsSliderMin.value = valueToSlider(form.records_count[0], 1000);
+        recordsSliderMax.value = valueToSlider(form.records_count[1], 1000);
+        lengthSliderMin.value  = valueToSlider(form.average_length[0], 1000);
+        lengthSliderMax.value  = valueToSlider(form.average_length[1], 1000);
+        rankSliderMin.value    = rankToSlider(form.rank_min);
+        rankSliderMax.value    = rankToSlider(form.rank_max);
+        showLoadDropdown.value = false;
+        onFilterSubmit();
+    };
+
+    const deleteFilter = async (filter) => {
+        if (!confirm(`Delete saved filter "${filter.name}"?`)) return;
+        try {
+            await axios.delete(`/api/saved-map-filters/${filter.id}`);
+            savedFilters.value = savedFilters.value.filter(f => f.id !== filter.id);
+        } catch (e) {
+            console.error('Delete failed', e);
+        }
+    };
+
+    onMounted(() => {
+        if (isLoggedIn.value) fetchSavedFilters();
+    });
+
 </script>
 
 <template>
@@ -261,6 +369,46 @@
                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
                 Reset
             </button>
+        </div>
+
+        <!-- Save / Load saved filters (auth only) -->
+        <div v-if="isLoggedIn" class="relative px-3 pt-2 pb-2 border-b border-white/5 flex items-center gap-2">
+            <button @click="openSaveModal"
+                class="flex-1 px-2 py-1.5 rounded-md bg-blue-500/15 hover:bg-blue-500/25 border border-blue-400/30 text-[11px] font-semibold text-blue-200 transition flex items-center justify-center gap-1.5">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.75V16.5L12 14.25 7.5 16.5V3.75m9 0H18A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6A2.25 2.25 0 0 1 6 3.75h1.5m9 0h-9" /></svg>
+                Save filter
+            </button>
+            <button @click="toggleLoadDropdown"
+                :class="showLoadDropdown
+                    ? 'bg-amber-500/25 hover:bg-amber-500/30 border-amber-400/50 text-amber-100 ring-2 ring-amber-400/30'
+                    : 'bg-white/5 hover:bg-white/10 border-white/10 text-gray-300'"
+                class="flex-1 px-2 py-1.5 rounded-md border text-[11px] font-semibold transition flex items-center justify-center gap-1.5">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
+                Load<span v-if="savedFiltersLoaded">&nbsp;({{ savedFilters.length }})</span>
+                <svg class="w-3 h-3 transition-transform" :class="showLoadDropdown ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+            </button>
+
+            <!-- Load dropdown -->
+            <div v-if="showLoadDropdown"
+                class="absolute top-full left-3 right-3 mt-2 z-30 bg-amber-950/95 border-2 border-amber-400/60 rounded-lg shadow-[0_8px_32px_rgba(0,0,0,0.7)] ring-2 ring-amber-400/20 max-h-72 overflow-y-auto backdrop-blur-sm">
+                <div class="px-3 py-1.5 border-b border-amber-400/30 bg-amber-500/15 text-[10px] font-bold text-amber-200 uppercase tracking-wider flex items-center gap-1.5 sticky top-0">
+                    <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
+                    Saved filters
+                </div>
+                <div v-if="savedFiltersLoading" class="px-3 py-3 text-[11px] text-amber-200/70 text-center">Loading…</div>
+                <div v-else-if="savedFilters.length === 0" class="px-3 py-3 text-[11px] text-amber-200/60 text-center">No saved filters yet. Configure filters above and click "Save filter".</div>
+                <div v-else class="divide-y divide-amber-400/15">
+                    <div v-for="f in savedFilters" :key="f.id"
+                        class="flex items-center justify-between px-3 py-2 hover:bg-amber-500/20 transition group cursor-pointer"
+                        @click="applyFilter(f)">
+                        <span class="text-xs text-amber-50 truncate flex-1 mr-2 font-medium">{{ f.name }}</span>
+                        <button @click.stop="deleteFilter(f)" title="Delete"
+                            class="text-amber-200/40 hover:text-red-400 transition flex-shrink-0">
+                            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Scrollable sections -->
@@ -404,6 +552,31 @@
             </button>
         </div>
     </div>
+
+    <!-- Save filter modal -->
+    <Teleport to="body">
+        <div v-if="showSaveModal"
+            class="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+            @click.self="showSaveModal = false">
+            <div class="bg-gray-900 border border-white/10 rounded-xl shadow-2xl p-5 w-full max-w-sm mx-4">
+                <h3 class="text-lg font-bold text-white mb-1">Save filter</h3>
+                <p class="text-xs text-gray-400 mb-4">Stores the current filter setup so you can recall it later with one click. Private to you.</p>
+                <input v-model="newFilterName" type="text" maxlength="80"
+                    placeholder='e.g. "Easy CPM trickjumps"'
+                    class="w-full px-3 py-2 rounded-md bg-black/40 border border-white/10 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-400/60"
+                    @keyup.enter="saveCurrentFilter" />
+                <div v-if="saveError" class="mt-2 text-xs text-red-400">{{ saveError }}</div>
+                <div class="mt-4 flex gap-2 justify-end">
+                    <button @click="showSaveModal = false"
+                        class="px-4 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-sm text-gray-300 transition">Cancel</button>
+                    <button @click="saveCurrentFilter" :disabled="saveLoading || !newFilterName.trim()"
+                        class="px-4 py-1.5 rounded-md bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 text-sm font-semibold text-white transition">
+                        {{ saveLoading ? 'Saving…' : 'Save' }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </Teleport>
 </template>
 
 <style scoped>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -901,7 +901,7 @@
             <div v-if="record.map_score"
                 class="text-sm font-black tabular-nums text-yellow-400/80 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] w-full cursor-help"
                 style="line-height: 16px;"
-                @mouseenter="$emit('scoreHover', { score: record.map_score, reltime: record.reltime, multiplier: record.multiplier, el: $event.target })"
+                @mouseenter="$emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
                 @mouseleave="$emit('scoreHover', null)">
                 {{ Math.round(record.map_score) }}
             </div>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -2113,9 +2113,11 @@
         <Teleport to="body">
             <div v-if="scoreTooltip" :style="scoreTooltipStyle"
                 class="px-3 py-2 rounded-lg bg-gray-900 border border-white/15 text-[10px] text-gray-300 whitespace-nowrap shadow-2xl pointer-events-none">
-                <div>Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
                 <div>Reltime: <span class="text-blue-400">{{ scoreTooltip.reltime }}</span></div>
-                <div v-if="scoreTooltip.multiplier != null">Multiplier: <span class="text-green-400">{{ scoreTooltip.multiplier }}</span></div>
+                <div v-if="scoreTooltip.base_score != null">Base score: <span class="text-gray-100">{{ scoreTooltip.base_score }}</span></div>
+                <div v-if="scoreTooltip.rank_multiplier != null">Rank mult: <span class="text-purple-400">× {{ scoreTooltip.rank_multiplier }}</span></div>
+                <div v-if="scoreTooltip.multiplier != null">Map mult: <span class="text-green-400">× {{ scoreTooltip.multiplier }}</span></div>
+                <div class="border-t border-white/10 mt-1 pt-1">Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
             </div>
         </Teleport>
     </div>

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -569,6 +569,11 @@
             icon: 'trophy',
             color: 'text-yellow-400'
         },
+        'bestscore': {
+            label: 'Best Score',
+            icon: 'linegraph',
+            color: 'text-purple-400'
+        },
         'bestranks': {
             label: 'Best Ranks',
             icon: 'fire',
@@ -1225,9 +1230,10 @@
                                     Manually assigned {{ assignedDemoCounts.offline + assignedDemoCounts.online }} {{ (assignedDemoCounts.offline + assignedDemoCounts.online) === 1 ? 'demo' : 'demos' }} to records
                                 </div>
                             </div>
-                            <!-- Player Rank -->
+                            <!-- Player Rank (overall run rank, VQ3 + CPM) -->
                             <div v-if="hasPlayerRank && showHeaderItem('player_rank') && headerItemRow('player_rank') === 1" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-orange-950/70 border border-orange-400/50 shadow-xl backdrop-blur-sm group relative" :style="{ order: headerItemOrder('player_rank') }">
                                 <svg class="w-4 h-4 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5-6L16.5 21m0 0L12 16.5m4.5 4.5V7.5" /></svg>
+                                <span class="text-xs font-bold text-orange-300 uppercase tracking-wider">Rank</span>
                                 <span v-if="vq3RunRank" class="text-xs font-semibold text-blue-300 uppercase tracking-wider">VQ3</span>
                                 <span v-if="vq3RunRank" class="text-sm font-black text-orange-400">#{{ vq3RunRank }}</span>
                                 <span v-if="cpmRunRank && vq3RunRank" class="text-gray-600">|</span>
@@ -1362,9 +1368,10 @@
                                     Manually assigned {{ assignedDemoCounts.offline + assignedDemoCounts.online }} {{ (assignedDemoCounts.offline + assignedDemoCounts.online) === 1 ? 'demo' : 'demos' }} to records
                                 </div>
                             </div>
-                            <!-- Player Rank -->
+                            <!-- Player Rank (overall run rank, VQ3 + CPM) -->
                             <div v-if="hasPlayerRank && showHeaderItem('player_rank') && headerItemRow('player_rank') === 2" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-orange-950/70 border border-orange-400/50 shadow-xl backdrop-blur-sm group relative" :style="{ order: headerItemOrder('player_rank') }">
                                 <svg class="w-4 h-4 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5-6L16.5 21m0 0L12 16.5m4.5 4.5V7.5" /></svg>
+                                <span class="text-xs font-bold text-orange-300 uppercase tracking-wider">Rank</span>
                                 <span v-if="vq3RunRank" class="text-xs font-semibold text-blue-300 uppercase tracking-wider">VQ3</span>
                                 <span v-if="vq3RunRank" class="text-sm font-black text-orange-400">#{{ vq3RunRank }}</span>
                                 <span v-if="cpmRunRank && vq3RunRank" class="text-gray-600">|</span>
@@ -1526,9 +1533,10 @@
                                     Manually assigned {{ assignedDemoCounts.offline + assignedDemoCounts.online }} {{ (assignedDemoCounts.offline + assignedDemoCounts.online) === 1 ? 'demo' : 'demos' }} to records
                                 </div>
                             </div>
-                            <!-- Player Rank -->
+                            <!-- Player Rank (overall run rank, VQ3 + CPM) -->
                             <div v-if="hasPlayerRank && showHeaderItem('player_rank') && headerItemRow('player_rank') === 3" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-orange-950/70 border border-orange-400/50 shadow-xl backdrop-blur-sm group relative" :style="{ order: headerItemOrder('player_rank') }">
                                 <svg class="w-4 h-4 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5-6L16.5 21m0 0L12 16.5m4.5 4.5V7.5" /></svg>
+                                <span class="text-xs font-bold text-orange-300 uppercase tracking-wider">Rank</span>
                                 <span v-if="vq3RunRank" class="text-xs font-semibold text-blue-300 uppercase tracking-wider">VQ3</span>
                                 <span v-if="vq3RunRank" class="text-sm font-black text-orange-400">#{{ vq3RunRank }}</span>
                                 <span v-if="cpmRunRank && vq3RunRank" class="text-gray-600">|</span>
@@ -1837,15 +1845,15 @@
                                         <td class="px-3 py-1.5 text-right font-mono" :class="row.reltime <= 1.05 ? 'text-green-400' : row.reltime <= 1.25 ? 'text-yellow-400' : row.reltime <= 2 ? 'text-orange-400' : 'text-red-400'">
                                             {{ row.reltime.toFixed(4) }}
                                         </td>
-                                        <td class="px-3 py-1.5 text-right font-mono text-gray-400">{{ row.base_score?.toFixed(1) || row.map_score.toFixed(1) }}</td>
+                                        <td class="px-3 py-1.5 text-right font-mono text-gray-400">{{ row.base_score?.toFixed(2) || row.map_score.toFixed(2) }}</td>
                                         <td class="px-3 py-1.5 text-right font-mono" :class="(row.rank_multiplier ?? 1) >= 0.9 ? 'text-green-400' : (row.rank_multiplier ?? 1) >= 0.5 ? 'text-yellow-400' : 'text-red-400'">
-                                            {{ ((row.rank_multiplier ?? 1) * 100).toFixed(1) }}%
+                                            {{ ((row.rank_multiplier ?? 1) * 100).toFixed(2) }}%
                                         </td>
                                         <td class="px-3 py-1.5 text-right font-mono" :class="row.multiplier >= 0.9 ? 'text-green-400' : row.multiplier >= 0.5 ? 'text-yellow-400' : 'text-red-400'">
-                                            {{ (row.multiplier * 100).toFixed(1) }}%
+                                            {{ (row.multiplier * 100).toFixed(2) }}%
                                         </td>
                                         <td class="px-3 py-1.5 text-right font-mono font-bold" :class="row.map_score >= 800 ? 'text-green-400' : row.map_score >= 500 ? 'text-yellow-400' : 'text-gray-400'">
-                                            {{ row.map_score.toFixed(1) }}
+                                            {{ row.map_score.toFixed(2) }}
                                         </td>
                                         <td class="px-3 py-1.5 text-right font-mono text-gray-500">{{ row.weight.toFixed(4) }}</td>
                                         <td class="px-3 py-1.5 text-right font-mono text-orange-400/80">{{ row.contribution.toFixed(2) }}</td>
@@ -2413,20 +2421,18 @@
                         <div class="mb-4">
                             <h3 class="text-xs font-bold text-gray-400 uppercase mb-3 px-1">Mode</h3>
                             <div class="space-y-2">
-                                <!-- All Modes -->
-                                <button @click="sortByMode('all')" :class="mode === 'all' ? 'bg-gradient-to-r from-white/30 to-white/20 text-white shadow-lg' : 'bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white border border-white/10'" class="w-full px-4 py-2.5 rounded-lg transition-all text-sm font-bold">
-                                    ALL
-                                </button>
-
-                                <!-- Run Mode -->
-                                <button @click="sortByMode('run')" :class="mode === 'run' ? 'bg-gradient-to-r from-green-600/80 to-green-500/60 text-white shadow-lg' : 'bg-white/5 hover:bg-green-600/20 text-gray-400 hover:text-white border border-green-500/20'" class="w-full px-4 py-2.5 rounded-lg transition-all text-sm font-bold">
-                                    RUN
-                                </button>
-
-                                <!-- All CTF -->
-                                <button @click="sortByMode('ctf')" :class="mode === 'ctf' ? 'bg-gradient-to-r from-red-600/80 to-red-500/60 text-white shadow-lg' : 'bg-white/5 hover:bg-red-600/20 text-gray-400 hover:text-white border border-red-500/20'" class="w-full px-4 py-2.5 rounded-lg transition-all text-sm font-bold">
-                                    CTF
-                                </button>
+                                <!-- ALL / RUN / CTF on one row -->
+                                <div class="grid grid-cols-3 gap-2">
+                                    <button @click="sortByMode('all')" :class="mode === 'all' ? 'bg-gradient-to-r from-white/30 to-white/20 text-white shadow-lg' : 'bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white border border-white/10'" class="px-2 py-2 rounded-lg transition-all text-sm font-bold">
+                                        ALL
+                                    </button>
+                                    <button @click="sortByMode('run')" :class="mode === 'run' ? 'bg-gradient-to-r from-green-600/80 to-green-500/60 text-white shadow-lg' : 'bg-white/5 hover:bg-green-600/20 text-gray-400 hover:text-white border border-green-500/20'" class="px-2 py-2 rounded-lg transition-all text-sm font-bold">
+                                        RUN
+                                    </button>
+                                    <button @click="sortByMode('ctf')" :class="mode === 'ctf' ? 'bg-gradient-to-r from-red-600/80 to-red-500/60 text-white shadow-lg' : 'bg-white/5 hover:bg-red-600/20 text-gray-400 hover:text-white border border-red-500/20'" class="px-2 py-2 rounded-lg transition-all text-sm font-bold">
+                                        CTF
+                                    </button>
+                                </div>
 
                                 <!-- CTF 1-7 -->
                                 <div class="grid grid-cols-7 gap-1">
@@ -2437,9 +2443,9 @@
                             </div>
                         </div>
 
-                        <!-- Filter Buttons (MOVED BELOW MODES) -->
+                        <!-- Sort options (MOVED BELOW MODES) -->
                         <div class="pt-4 border-t border-white/10">
-                            <h3 class="text-xs font-bold text-gray-400 uppercase mb-3 px-1">Filters</h3>
+                            <h3 class="text-xs font-bold text-gray-400 uppercase mb-3 px-1">Sort by</h3>
                             <div class="space-y-2">
                                 <button v-for="(data, option) in options" :key="option" @click="selectOption(option)"
                                      :class="selectedOption === option

--- a/resources/js/Pages/RankingHowItWorks.vue
+++ b/resources/js/Pages/RankingHowItWorks.vue
@@ -36,7 +36,8 @@ function calcPlayerRating(scores) {
     let weightedSum = 0;
     let weightSum = 0;
     for (let i = 0; i < sorted.length; i++) {
-        const weight = Math.exp(-CFG_D * (i + 1));
+        // weight = exp(-D * (rank - 1)) — best record (rank 1) gets weight 1.0
+        const weight = Math.exp(-CFG_D * i);
         weightedSum += sorted[i] * weight;
         weightSum += weight;
     }
@@ -68,6 +69,17 @@ const exampleScores = [850, 780, 720, 650, 600, 550, 500, 480, 420, 380, 350, 30
 const exampleRating = calcPlayerRating(exampleScores);
 const exampleFewScores = [850, 780, 720];
 const exampleFewRating = calcPlayerRating(exampleFewScores);
+
+// Share of total weight carried by the top-N records, in the limit
+// of a very large record count. Derived from the geometric series:
+// sum_{i=0..N-1} exp(-D*i) / sum_{i=0..inf} exp(-D*i)  =  1 - exp(-D*N).
+// This is the "best case" upper bound on top-N contribution; for a
+// finite roster the share is even higher.
+function topNWeightShare(n) {
+    return (1 - Math.exp(-CFG_D * n)) * 100;
+}
+const top100Share = topNWeightShare(100);
+const top200Share = topNWeightShare(200);
 </script>
 
 <template>
@@ -119,7 +131,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 <h2 class="text-2xl font-bold text-gray-200 mb-3 flex items-center gap-2">
                     <span class="text-blue-400 text-lg font-mono">1.</span> Overview
                 </h2>
-                <p class="mb-3">The ranking system measures how well a player performs across all maps they have records on. The process works in 4 stages:</p>
+                <p class="mb-3">The ranking system measures how well a player performs across all maps they have records on. The process works in 5 stages:</p>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
                         <div class="text-sm font-bold text-green-400 mb-1">1. Relative Time</div>
@@ -134,7 +146,11 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                         <div class="text-xs text-gray-400">Score is scaled by how many players the map has (popular maps count more).</div>
                     </div>
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
-                        <div class="text-sm font-bold text-red-400 mb-1">4. Player Rating</div>
+                        <div class="text-sm font-bold text-pink-400 mb-1">4. Rank Multiplier</div>
+                        <div class="text-xs text-gray-400">Score is further scaled by your rank on the map (beating more players counts more).</div>
+                    </div>
+                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3 sm:col-span-2">
+                        <div class="text-sm font-bold text-red-400 mb-1">5. Player Rating</div>
                         <div class="text-xs text-gray-400">All map scores are combined with exponential weighting into a single rating.</div>
                     </div>
                 </div>
@@ -149,7 +165,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 space-y-2">
                     <div class="flex items-start gap-2">
                         <span class="text-green-400 mt-0.5 font-bold">&#x2713;</span>
-                        <span>At least <strong class="text-white">5 unique players</strong> must have a record on the map</span>
+                        <span>At least <strong class="text-white">5 unique players</strong> must have a record on the map for the given physics (VQ3 and CPM are counted separately)</span>
                     </div>
                     <div class="flex items-start gap-2">
                         <span class="text-green-400 mt-0.5 font-bold">&#x2713;</span>
@@ -171,7 +187,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                     <span class="text-blue-400 text-lg font-mono">3.</span> Relative Time (reltime)
                 </h2>
                 <p class="mb-3">Reltime is the ratio of your time to the <strong class="text-white">fastest time set by someone else</strong>:</p>
-                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-lg text-white mb-3">
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-sm text-white mb-3">
                     reltime = your_time / fastest_other_time
                 </div>
                 <div class="mt-3 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-300 mb-4">
@@ -221,12 +237,12 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
                     <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Parameters</div>
-                    <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
-                        <div><span class="text-white font-mono">A = 1.2</span> <span class="text-gray-500">- amplitude</span></div>
-                        <div><span class="text-white font-mono">B = 1.33</span> <span class="text-gray-500">- steepness</span></div>
-                        <div><span class="text-white font-mono">M = 0.3</span> <span class="text-gray-500">- midpoint shift</span></div>
-                        <div><span class="text-white font-mono">V = 0.1</span> <span class="text-gray-500">- curve shape</span></div>
-                        <div><span class="text-white font-mono">Q = 0.5</span> <span class="text-gray-500">- initial value</span></div>
+                    <div class="space-y-1 text-xs">
+                        <div><span class="text-white font-mono">A = 1.2</span> <span class="text-gray-500">— amplitude</span></div>
+                        <div><span class="text-white font-mono">B = 1.33</span> <span class="text-gray-500">— steepness</span></div>
+                        <div><span class="text-white font-mono">M = 0.3</span> <span class="text-gray-500">— midpoint shift</span></div>
+                        <div><span class="text-white font-mono">V = 0.1</span> <span class="text-gray-500">— curve shape</span></div>
+                        <div><span class="text-white font-mono">Q = 0.5</span> <span class="text-gray-500">— initial value</span></div>
                     </div>
                 </div>
 
@@ -276,10 +292,10 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
                     <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Parameters</div>
                     <div class="space-y-1 text-xs">
-                        <div><span class="text-white font-mono">x</span> = number of unique players on the map</div>
-                        <div><span class="text-white font-mono">k</span> = median(players per map in category) / 2 - the halfway point</div>
-                        <div><span class="text-white font-mono">L = 1.0</span> - maximum multiplier (100%)</div>
-                        <div><span class="text-white font-mono">n = 2.0</span> - steepness of the curve</div>
+                        <div><span class="text-white font-mono">x</span> <span class="text-gray-500">— number of unique players on the map</span></div>
+                        <div><span class="text-white font-mono">k</span> <span class="text-gray-500">— median(players per map in category) / 2 (the halfway point)</span></div>
+                        <div><span class="text-white font-mono">L = 1.0</span> <span class="text-gray-500">— maximum multiplier (100%)</span></div>
+                        <div><span class="text-white font-mono">n = 2.0</span> <span class="text-gray-500">— steepness of the curve</span></div>
                     </div>
                 </div>
 
@@ -348,10 +364,12 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                     rank_mult = (((total_players * v) - your_rank) / ((total_players * v) - 1)) ^ n
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
-                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Current parameters</div>
-                    <div class="text-sm space-y-1">
-                        <div><span class="text-gray-400">n (steepness):</span> <span class="text-white font-mono">{{ RANK_N }}</span></div>
-                        <div><span class="text-gray-400">v (total_players modifier):</span> <span class="text-white font-mono">{{ RANK_V }}</span></div>
+                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Parameters</div>
+                    <div class="space-y-1 text-xs">
+                        <div><span class="text-white font-mono">total_players</span> <span class="text-gray-500">— number of unique players on the map</span></div>
+                        <div><span class="text-white font-mono">your_rank</span> <span class="text-gray-500">— your position on the map leaderboard (1 = WR)</span></div>
+                        <div><span class="text-white font-mono">n = {{ RANK_N }}</span> <span class="text-gray-500">— steepness of the curve</span></div>
+                        <div><span class="text-white font-mono">v = {{ RANK_V }}</span> <span class="text-gray-500">— total_players modifier</span></div>
                     </div>
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
@@ -379,7 +397,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                     <span class="text-blue-400 text-lg font-mono">7.</span> Final Map Score
                 </h2>
                 <p class="mb-3">The final score for each record combines all multipliers:</p>
-                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-lg text-white mb-3">
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-sm text-white mb-3">
                     final_score = base_score * map_multiplier * rank_multiplier
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
@@ -401,15 +419,47 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                 </h2>
                 <p class="mb-3">A player's overall rating is calculated from all their map scores using <strong class="text-white">exponential weighting</strong>:</p>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-sm text-white mb-3 overflow-x-auto">
-                    rating = sum(score_i * exp(-D * i)) / sum(exp(-D * i))
+                    rating = sum(score_i * exp(-D * (i-1))) / sum(exp(-D * (i-1)))
                 </div>
+
+                <!-- Reassurance callout: bad records do NOT lower the rating -->
+                <div class="bg-green-500/10 border border-green-500/30 rounded-xl p-4 mb-3">
+                    <div class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>
+                        <div>
+                            <div class="text-sm font-bold text-green-300 mb-1">Bad records do not lower your rating</div>
+                            <div class="text-xs text-gray-300">Weak runs simply contribute very little weight — they don't subtract anything. Just play the maps you enjoy; you can't hurt your rating by adding a slow time on some map. Practically only your best scores move the number.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
+                    <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Parameters</div>
+                    <div class="space-y-1 text-xs">
+                        <div><span class="text-white font-mono">i</span> <span class="text-gray-500">— rank position in your sorted map scores (1 = your best map)</span></div>
+                        <div><span class="text-white font-mono">score_i</span> <span class="text-gray-500">— the final map score (after multipliers) on your i-th best map</span></div>
+                        <div><span class="text-white font-mono">D = {{ CFG_D }}</span> <span class="text-gray-500">— decay constant; smaller value means slower decay (more records contribute)</span></div>
+                    </div>
+                </div>
+
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
                     <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">How it works</div>
                     <div class="text-sm space-y-2">
                         <p>1. All your map scores are <strong class="text-white">sorted from highest to lowest</strong></p>
-                        <p>2. Each score gets a weight: <span class="font-mono text-white">exp(-0.02 * rank)</span> where rank starts at 1</p>
-                        <p>3. Your best map gets weight ~0.98, your 10th best ~0.82, your 50th best ~0.37</p>
+                        <p>2. Each score gets a weight: <span class="font-mono text-white">exp(-{{ CFG_D }} * (i - 1))</span> where i starts at 1</p>
+                        <p>3. Your best map gets weight 1.0, your 10th best ~0.84, your 50th best ~0.38</p>
                         <p>4. The final rating is the weighted average of all scores</p>
+                    </div>
+                </div>
+
+                <div class="bg-blue-500/10 border border-blue-500/20 rounded-xl p-4 mb-3">
+                    <div class="flex items-start gap-3">
+                        <svg class="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" /></svg>
+                        <div class="text-sm">
+                            <div class="font-bold text-blue-300 mb-1">Which records actually matter?</div>
+                            <div class="text-xs text-gray-300">With <span class="font-mono text-white">D = {{ CFG_D }}</span>, your <strong class="text-white">top 100 records carry ~{{ top100Share.toFixed(1) }}%</strong> of the total weight in your rating, and your <strong class="text-white">top 200 carry ~{{ top200Share.toFixed(1) }}%</strong>. So pushing your best maps a little harder will move your number much more than adding a hundred more average runs.</div>
+                            <div class="text-[10px] text-gray-500 mt-1">(Computed dynamically from D — if the decay constant changes, this number changes too.)</div>
+                        </div>
                     </div>
                 </div>
 
@@ -419,7 +469,7 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                         <div v-for="(score, i) in exampleScores" :key="i" class="bg-gray-800 rounded px-2 py-1 text-center">
                             <div class="text-gray-500">#{{ i + 1 }}</div>
                             <div class="font-mono" :class="i < 3 ? 'text-green-400' : i < 6 ? 'text-yellow-400' : 'text-gray-400'">{{ score }}</div>
-                            <div class="text-gray-600 text-[9px]">w={{ Math.exp(-CFG_D * (i + 1)).toFixed(3) }}</div>
+                            <div class="text-gray-600 text-[9px]">w={{ Math.exp(-CFG_D * i).toFixed(3) }}</div>
                         </div>
                     </div>
                     <div class="text-sm">
@@ -456,6 +506,18 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                         <div class="text-xs text-gray-500">All maps</div>
                     </div>
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
+                        <div class="text-sm font-bold text-yellow-400">Strafe</div>
+                        <div class="text-xs text-gray-500">Maps without weapons (MG/SG/Gauntlet/Hook/RG allowed)</div>
+                    </div>
+                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
+                        <div class="text-sm font-bold text-cyan-400">Slick</div>
+                        <div class="text-xs text-gray-500">Maps with slick surfaces</div>
+                    </div>
+                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
+                        <div class="text-sm font-bold text-purple-400">Tele</div>
+                        <div class="text-xs text-gray-500">Maps with teleporters</div>
+                    </div>
+                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
                         <div class="text-sm font-bold text-orange-400">Rocket</div>
                         <div class="text-xs text-gray-500">Maps with RL</div>
                     </div>
@@ -468,24 +530,12 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                         <div class="text-xs text-gray-500">Maps with GL</div>
                     </div>
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
-                        <div class="text-sm font-bold text-cyan-400">Slick</div>
-                        <div class="text-xs text-gray-500">Maps with slick surfaces</div>
-                    </div>
-                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
-                        <div class="text-sm font-bold text-purple-400">Teleport</div>
-                        <div class="text-xs text-gray-500">Maps with teleporters</div>
+                        <div class="text-sm font-bold text-pink-400">LG</div>
+                        <div class="text-xs text-gray-500">Maps with Lightning Gun</div>
                     </div>
                     <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
                         <div class="text-sm font-bold text-red-400">BFG</div>
                         <div class="text-xs text-gray-500">Maps with BFG</div>
-                    </div>
-                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
-                        <div class="text-sm font-bold text-yellow-400">Strafe</div>
-                        <div class="text-xs text-gray-500">Maps without weapons (MG/SG/Gauntlet/Hook/RG allowed)</div>
-                    </div>
-                    <div class="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
-                        <div class="text-sm font-bold text-pink-400">LG</div>
-                        <div class="text-xs text-gray-500">Maps with Lightning Gun</div>
                     </div>
                 </div>
                 <div class="mt-3 text-xs text-gray-500">
@@ -521,6 +571,9 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                             <div class="text-xs text-gray-400">Once per day, all rankings across all maps, physics, and categories are recalculated from scratch. This ensures consistency and catches any edge cases the incremental updates might miss.</div>
                         </div>
                     </div>
+                </div>
+                <div class="mt-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 text-xs text-yellow-300">
+                    <strong>Why both?</strong> The incremental update is an optimization — it touches only the map a new record landed on, not every map that record might secondarily affect (e.g. category-wide medians used in the map multiplier shift slightly when any map's player count changes). Over a day these small approximations can drift from the exact value. The nightly full recalculation re-derives everything from scratch and brings the rankings back to the ground truth.
                 </div>
             </section>
 
@@ -566,16 +619,26 @@ const exampleFewRating = calcPlayerRating(exampleFewScores);
                         <div class="text-xs text-gray-400">
                             <div>Category median: <span class="text-white">13 players</span>, k = 6.5</div>
                             <div>Map has <span class="text-white">25 players</span></div>
-                            <div>multiplier = (25^2) / (6.5^2 + 25^2) = <span class="text-blue-400 font-mono font-bold">{{ exampleMultiplier.toFixed(4) }}</span></div>
-                            <div class="mt-1">final_score = {{ exampleBaseScore.toFixed(1) }} * {{ exampleMultiplier.toFixed(4) }} = <span class="text-green-400 font-mono font-bold">{{ exampleFinalScore.toFixed(1) }}</span></div>
+                            <div>map_multiplier = (25^2) / (6.5^2 + 25^2) = <span class="text-blue-400 font-mono font-bold">{{ exampleMultiplier.toFixed(4) }}</span></div>
+                            <div class="mt-1">scaled = {{ exampleBaseScore.toFixed(1) }} * {{ exampleMultiplier.toFixed(4) }} = <span class="text-blue-400 font-mono font-bold">{{ exampleFinalScore.toFixed(1) }}</span></div>
                         </div>
                     </div>
 
-                    <!-- Step 5 -->
+                    <!-- Step 5: Rank multiplier (NEW) -->
                     <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
-                        <div class="text-sm font-bold text-red-400 mb-2">Step 5: Combine into player rating</div>
+                        <div class="text-sm font-bold text-pink-400 mb-2">Step 5: Apply rank multiplier</div>
                         <div class="text-xs text-gray-400">
-                            <div>This score ({{ exampleFinalScore.toFixed(1) }}) joins all your other map scores.</div>
+                            <div>Your rank on the map: <span class="text-white">#3 of 25 players</span></div>
+                            <div>rank_mult = ((25*{{ RANK_V }} - 3) / (25*{{ RANK_V }} - 1))<sup>{{ RANK_N }}</sup> = <span class="text-pink-400 font-mono font-bold">{{ calcRankMultiplier(25, 3).toFixed(4) }}</span></div>
+                            <div class="mt-1">final_score = {{ exampleFinalScore.toFixed(1) }} * {{ calcRankMultiplier(25, 3).toFixed(4) }} = <span class="text-green-400 font-mono font-bold">{{ (exampleFinalScore * calcRankMultiplier(25, 3)).toFixed(1) }}</span></div>
+                        </div>
+                    </div>
+
+                    <!-- Step 6: Player rating (renumbered) -->
+                    <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
+                        <div class="text-sm font-bold text-red-400 mb-2">Step 6: Combine into player rating</div>
+                        <div class="text-xs text-gray-400">
+                            <div>This score ({{ (exampleFinalScore * calcRankMultiplier(25, 3)).toFixed(1) }}) joins all your other map scores from the given category.</div>
                             <div>They are sorted, exponentially weighted, and averaged into your final rating.</div>
                             <div>If you have fewer than 10 records, a penalty is applied.</div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -329,6 +329,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('/api/maps/{mapId}/tags/{tagId}', [App\Http\Controllers\TagController::class, 'removeFromMap'])->name('tags.removeFromMap');
     Route::post('/api/maplists/{id}/tags', [App\Http\Controllers\TagController::class, 'addToMaplist'])->name('tags.addToMaplist');
     Route::delete('/api/maplists/{maplistId}/tags/{tagId}', [App\Http\Controllers\TagController::class, 'removeFromMaplist'])->name('tags.removeFromMaplist');
+
+    // Saved map filter routes (per-user, private)
+    Route::get('/api/saved-map-filters', [App\Http\Controllers\SavedMapFilterController::class, 'index'])->name('savedMapFilters.index');
+    Route::post('/api/saved-map-filters', [App\Http\Controllers\SavedMapFilterController::class, 'store'])->name('savedMapFilters.store');
+    Route::delete('/api/saved-map-filters/{savedMapFilter}', [App\Http\Controllers\SavedMapFilterController::class, 'destroy'])->name('savedMapFilters.destroy');
 });
 
 // Public tag routes

--- a/rust-rating-service/src/main.rs
+++ b/rust-rating-service/src/main.rs
@@ -289,7 +289,9 @@ fn calculate_player_rating(map_scores: &mut Vec<f64>, cfg: &RatingConfig) -> f64
     let mut weight_sum = 0.0;
 
     for (rank, &score) in map_scores.iter().enumerate() {
-        let weight = (-cfg.cfg_d * (rank as f64 + 1.0)).exp();
+        // weight = exp(-D * (i - 1)) with i = rank + 1 (1-indexed) → exp(-D * rank)
+        // so the best record gets weight 1.0
+        let weight = (-cfg.cfg_d * rank as f64).exp();
         weighted_sum += score * weight;
         weight_sum += weight;
     }


### PR DESCRIPTION
## Summary
- Map detail tooltip now exposes the full per-map score breakdown (base × rank_mult × map_mult)
- Profile rating breakdown rounding bumped to 2 decimals so the displayed math reconciles
- Profile records list gains a Best Score sort; ALL/RUN/CTF mode row condensed inline
- Profile header rank badge gets a "Rank" label; existing logic and tooltip unchanged
- Player Select shows selected players as chips with X to deselect (works for has/has-no/WR fields)
- New saved map filters feature: private per-user, DB-backed (`saved_map_filters` table), 50-row cap, Save/Load UI in the filter sidebar
- Weight formula shifted from `exp(-D * i)` to `exp(-D * (i-1))` everywhere (PHP, SQL, Rust, JS) so the top record's weight is 1.0; rating values numerically unchanged because the constant factor cancels in `Σ(s·w)/Σ(w)`
- `/ranking/how-it-works` rewrite per batawi notes: overview gets rank-mult tile, map eligibility clarifies "per physics", formula box font sizes unified, Parameters blocks unified, D/i/score_i explained in Player Rating, dynamic top-N weight share, categories reordered to match `/ranking`, daily full-recalc reasoning, rank-mult step added to Full Walkthrough, green callout that bad records cannot lower the rating

## Test plan
- [ ] Hover a score on `/maps/<map>` and confirm tooltip shows Reltime / Base score / Rank mult / Map mult / Score with values that multiply correctly
- [ ] Open profile rating breakdown (admin) and confirm `base × rank_mult × map_mult ≈ score` within ~0.01
- [ ] On your profile records list, click Sort by → Best Score and verify ordering changes; click ALL/RUN/CTF and confirm they're on one row above CTF 1–7
- [ ] Confirm header badge reads `RANK VQ3 #X | CPM #Y`; hover tooltip still shows the per-category grid
- [ ] On `/maps/filters`, pick a player in any of the player-records filters; verify a chip with flag+name shows below the input, X removes it
- [ ] On `/maps`, configure filters, click Save filter, name it; reload page; click Load → click name and verify filters reapply and URL updates
- [ ] Run `php artisan migrate` on prod to create `saved_map_filters`
- [ ] After Rust rebuild (`./build-rust.sh` in deploy), spot-check a few existing ratings: numbers should not change
- [ ] Visit `/ranking/how-it-works` and walk through it end-to-end with batawi's notes; confirm category order matches `/ranking`, top-N percentage shows ~86.5% / ~98.2%, walkthrough has 6 steps
