### PR TITLE
getdfstatus KG7X-format support, score column fix on Demos Top, unified score tooltip

### DIFF
--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -159,9 +159,17 @@ class DefragServer
 
         list($serverData, $playerLines) = $this->parseResponseBody(substr($data, $headerEnd + 1));
 
-        // Parse player lines - two formats:
-        // Extended (oDFe): clientId dfscore ping "name" "spectating_name" "tld" "model" "headmodel" uid "color1"
-        // Legacy (GTK):    dfscore ping "name" "spectating_name"
+        // Reject responses that aren't real statusResponse packets (e.g. "print\nBad command")
+        // so the caller can fall back to getstatus instead of saving empty data.
+        if (empty($serverData['mapname']) || empty($serverData['sv_hostname'])) {
+            return null;
+        }
+
+        // Parse player lines - three formats:
+        // KG7X (new):       dfscore ping clientId "name" spec_clientId "tld" "color1" uid "model" "headmodel"
+        // Extended (oDFe):  clientId dfscore ping "name" "spectating_name" "tld" "model" "headmodel" uid "color1"
+        // Legacy (GTK):     dfscore ping "name" "spectating_name"
+        $kg7xRegex = '/^(-?\d+)\s+(\d+)\s+(\d+)\s+"([^"]*)"\s+(-?\d+)\s+"([^"]*)"\s+"([^"]*)"\s+(\d+)\s+"([^"]*)"\s+"([^"]*)"$/';
         $extendedRegex = '/^(\d+)\s+(-?\d+)\s+(\d+)\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"\s+(\d+)\s+"([^"]*)"$/';
         $legacyRegex = '/^(-?\d+)\s+(\d+)\s+"([^"]*)"\s+"([^"]*)"$/';
 
@@ -172,7 +180,25 @@ class DefragServer
                 continue;
             }
 
-            if (preg_match($extendedRegex, $line, $m)) {
+            if (preg_match($kg7xRegex, $line, $m)) {
+                $clientId = (int) $m[3];
+                $color1 = $m[7];
+                $mddId = (int) $m[8];
+                $parsedPlayers[$clientId] = [
+                    'clientId' => $clientId,
+                    'dfscore' => (int) $m[1],
+                    'ping' => (int) $m[2],
+                    'name' => $m[4],
+                    'spectating_id' => (int) $m[5],
+                    'spectating' => '',
+                    'country' => strtolower($m[6]),
+                    'color1' => $color1,
+                    'mddId' => $mddId,
+                    'model' => $m[9] !== '' ? $m[9] : 'sarge',
+                    'headmodel' => $m[10] !== '' ? $m[10] : 'sarge',
+                    'nospec' => ($color1 == 'nospec' || $color1 == 'nospecpm'),
+                ];
+            } elseif (preg_match($extendedRegex, $line, $m)) {
                 $clientId = (int) $m[1];
                 $parsedPlayers[$clientId] = [
                     'clientId' => $clientId,
@@ -180,6 +206,7 @@ class DefragServer
                     'ping' => (int) $m[3],
                     'name' => $m[4],
                     'spectating' => $m[5],
+                    'spectating_id' => null,
                     'country' => strtolower($m[6]),
                     'model' => $m[7],
                     'headmodel' => $m[8],
@@ -195,6 +222,7 @@ class DefragServer
                     'ping' => (int) $m[2],
                     'name' => $m[3],
                     'spectating' => $m[4],
+                    'spectating_id' => null,
                     'country' => '_404',
                     'model' => 'sarge',
                     'headmodel' => 'sarge',
@@ -205,7 +233,7 @@ class DefragServer
             }
         }
 
-        // Build name -> clientId lookup for spectating resolution
+        // Build name -> clientId lookup for spectating resolution (legacy/extended formats)
         $nameToClientId = [];
         foreach ($parsedPlayers as $p) {
             $nameToClientId[$p['name']] = $p['clientId'];
@@ -227,9 +255,13 @@ class DefragServer
         // scores.players with player_num, time, follow_num for getPlayerScore()
         $scorePlayers = [];
         foreach ($parsedPlayers as $clientId => $p) {
-            $followNum = -1;
-            if (!empty($p['spectating']) && isset($nameToClientId[$p['spectating']])) {
-                $followNum = $nameToClientId[$p['spectating']];
+            if (isset($p['spectating_id']) && $p['spectating_id'] !== null) {
+                $followNum = $p['spectating_id'];
+            } else {
+                $followNum = -1;
+                if (!empty($p['spectating']) && isset($nameToClientId[$p['spectating']])) {
+                    $followNum = $nameToClientId[$p['spectating']];
+                }
             }
 
             $scorePlayers[] = [

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -572,10 +572,6 @@ class MapsController extends Controller
             return $record;
         });
 
-        // Attach map scores (map_score, reltime) from player_map_scores
-        $this->attachMapScores($cpmRecords, $map->name, 'cpm', $gametype);
-        $this->attachMapScores($vq3Records, $map->name, 'vq3', $gametype);
-
         $userDefaultOldtop = $request->user()?->default_show_oldtop ? 'true' : 'false';
         $showOldtop = $request->has('showOldtop') ? $request->input('showOldtop') : $userDefaultOldtop;
 
@@ -639,6 +635,14 @@ class MapsController extends Controller
             $cpmOfflineRecords = null;
             $vq3OfflineRecords = null;
         }
+
+        // Attach map scores (map_score, reltime, base_score, rank_multiplier) from
+        // player_map_scores. Done AFTER the unified-leaderboard swap so the
+        // replaced paginator gets scores too — otherwise demos top / oldtop
+        // toggles wiped scores from the main MDD records they pushed into the
+        // unified collection.
+        $this->attachMapScores($cpmRecords, $map->name, 'cpm', $gametype);
+        $this->attachMapScores($vq3Records, $map->name, 'vq3', $gametype);
 
         // Redirect clamps must respect every source that shares the page
         // parameter — main records, oldtop, and Demos Top (grouped offline).

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1203,6 +1203,17 @@ class ProfileController extends Controller {
             $record->map_score = $score ? round($score->map_score, 2) : null;
             $record->reltime = $score ? round($score->reltime, 4) : null;
             $record->multiplier = $score ? round($score->multiplier, 4) : null;
+            $record->rank_multiplier = $score ? round($score->rank_multiplier ?? 1, 4) : null;
+            if ($score) {
+                $mapMult = $score->multiplier ?? 1;
+                $rankMult = $score->rank_multiplier ?? 1;
+                $divisor = $mapMult * $rankMult;
+                $record->base_score = $divisor > 0
+                    ? round($score->map_score / $divisor, 2)
+                    : round($score->map_score, 2);
+            } else {
+                $record->base_score = null;
+            }
             $record->is_outlier = $score ? $score->is_outlier : false;
             $record->score_rank = $scoreRanks[$record->mapname] ?? null;
             $record->score_rank_total = $totalMaps;

--- a/app/Http/Controllers/RecordsController.php
+++ b/app/Http/Controllers/RecordsController.php
@@ -119,6 +119,17 @@ class RecordsController extends Controller
             $record->map_score = $score ? round($score->map_score, 2) : null;
             $record->reltime = $score ? round($score->reltime, 4) : null;
             $record->multiplier = $score ? round($score->multiplier, 4) : null;
+            $record->rank_multiplier = $score ? round($score->rank_multiplier ?? 1, 4) : null;
+            if ($score) {
+                $mapMult = $score->multiplier ?? 1;
+                $rankMult = $score->rank_multiplier ?? 1;
+                $divisor = $mapMult * $rankMult;
+                $record->base_score = $divisor > 0
+                    ? round($score->map_score / $divisor, 2)
+                    : round($score->map_score, 2);
+            } else {
+                $record->base_score = null;
+            }
             $record->is_outlier = $score ? $score->is_outlier : false;
         });
 

--- a/resources/js/Components/Record.vue
+++ b/resources/js/Components/Record.vue
@@ -130,7 +130,7 @@
                     <div class="hidden sm:block w-8 sm:w-10 text-center flex-shrink-0">
                         <div v-if="record.map_score"
                             class="text-xs sm:text-sm font-black tabular-nums leading-none text-yellow-400/80 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] cursor-help" style="padding-left: 5px"
-                            @mouseenter="$emit('scoreHover', { score: record.map_score, reltime: record.reltime, multiplier: record.multiplier, el: $event.target })"
+                            @mouseenter="$emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
                             @mouseleave="$emit('scoreHover', null)">{{ Math.round(record.map_score) }}</div>
                     </div>
                     <div :class="[dateColWidth, 'flex-shrink-0 text-right opacity-90 group-hover:opacity-100 transition-opacity']" v-if="windowWidth >= 400">

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -2571,7 +2571,7 @@
                                         <div class="w-8 sm:w-10 flex-shrink-0 text-center">
                                             <div v-if="record.map_score"
                                                 class="text-[10px] sm:text-xs font-black tabular-nums leading-none text-yellow-400/80 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] cursor-help" style="padding-left: 5px"
-                                                @mouseenter="scoreTooltip = { score: record.map_score, reltime: record.reltime, multiplier: record.multiplier, el: $event.target }"
+                                                @mouseenter="scoreTooltip = { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target }"
                                                 @mouseleave="scoreTooltip = null">
                                                 {{ Math.round(record.map_score) }}
                                             </div>
@@ -2700,7 +2700,7 @@
                                         <div class="w-8 sm:w-10 flex-shrink-0 text-center">
                                             <div v-if="record.map_score"
                                                 class="text-[10px] sm:text-xs font-black tabular-nums leading-none text-yellow-400/80 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] cursor-help" style="padding-left: 5px"
-                                                @mouseenter="scoreTooltip = { score: record.map_score, reltime: record.reltime, multiplier: record.multiplier, el: $event.target }"
+                                                @mouseenter="scoreTooltip = { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target }"
                                                 @mouseleave="scoreTooltip = null">
                                                 {{ Math.round(record.map_score) }}
                                             </div>
@@ -3406,9 +3406,11 @@
     <Teleport to="body">
         <div v-if="scoreTooltip" :style="scoreTooltipStyle"
             class="px-3 py-2 rounded-lg bg-gray-900 border border-white/15 text-[10px] text-gray-300 whitespace-nowrap shadow-2xl pointer-events-none">
-            <div>Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
             <div>Reltime: <span class="text-blue-400">{{ scoreTooltip.reltime }}</span></div>
-            <div v-if="scoreTooltip.multiplier != null">Multiplier: <span class="text-green-400">{{ scoreTooltip.multiplier }}</span></div>
+            <div v-if="scoreTooltip.base_score != null">Base score: <span class="text-gray-100">{{ scoreTooltip.base_score }}</span></div>
+            <div v-if="scoreTooltip.rank_multiplier != null">Rank mult: <span class="text-purple-400">× {{ scoreTooltip.rank_multiplier }}</span></div>
+            <div v-if="scoreTooltip.multiplier != null">Map mult: <span class="text-green-400">× {{ scoreTooltip.multiplier }}</span></div>
+            <div class="border-t border-white/10 mt-1 pt-1">Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
         </div>
     </Teleport>
 </template>

--- a/resources/js/Pages/RecordsView.vue
+++ b/resources/js/Pages/RecordsView.vue
@@ -283,9 +283,11 @@
     <Teleport to="body">
         <div v-if="scoreTooltip" :style="scoreTooltipStyle"
             class="px-3 py-2 rounded-lg bg-gray-900 border border-white/15 text-[10px] text-gray-300 whitespace-nowrap shadow-2xl pointer-events-none">
-            <div>Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
             <div>Reltime: <span class="text-blue-400">{{ scoreTooltip.reltime }}</span></div>
-            <div v-if="scoreTooltip.multiplier != null">Multiplier: <span class="text-green-400">{{ scoreTooltip.multiplier }}</span></div>
+            <div v-if="scoreTooltip.base_score != null">Base score: <span class="text-gray-100">{{ scoreTooltip.base_score }}</span></div>
+            <div v-if="scoreTooltip.rank_multiplier != null">Rank mult: <span class="text-purple-400">× {{ scoreTooltip.rank_multiplier }}</span></div>
+            <div v-if="scoreTooltip.multiplier != null">Map mult: <span class="text-green-400">× {{ scoreTooltip.multiplier }}</span></div>
+            <div class="border-t border-white/10 mt-1 pt-1">Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
         </div>
     </Teleport>
 </template>


### PR DESCRIPTION
## Summary

- **getdfstatus parser**: support KG7X's redesigned player-line shape (`dfscore ping clientId "name" spec_id "tld" "color1" uid "model" "head"`). His servers are already serving it, so the scraper needs to read both his shape and our pending PR https://github.com/Defrag-racing/oDFe/pull/64 shape side-by-side. Third regex added, existing two kept for back-compat, sanity check rejects non-statusResponse replies so we fall back to `getstatus` instead of writing empty data.
- **Score column fix**: with Demos Top or Oldtop toggled on, main MDD records lost their score because `attachMapScores()` ran on the original paginator and then `buildUnifiedLeaderboard()` replaced it. Moved the attach to after the swap.
- **Unified score tooltip**: Map detail showed the full breakdown (Reltime / Base / Rank mult / Map mult / Score) but Profile and `/records` only showed Score + Reltime + Multiplier. Backfilled `base_score` and `rank_multiplier` in `RecordsController` and `ProfileController` and replaced the two simpler tooltips so the breakdown is identical everywhere.

## Test plan

- [ ] Open a map with Demos Top enabled — main MDD records show score column populated
- [ ] Hover any score on Map detail — full breakdown tooltip
- [ ] Hover any score in Profile records tab — same breakdown
- [ ] Hover any score in `/records` — same breakdown
- [ ] Records without a rating (`map_score == null`) — score column blank, no console errors
- [ ] `php artisan scrape:servers` against KG7X server (83.243.73.220:27965) — players parsed with model/headmodel + spec_id correctly