### PR TITLE
Fix 500 on map pages with Demos Top: stdClass reps lack mdd_id

### DIFF
--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -1754,7 +1754,16 @@ class MapsController extends Controller
     {
         if (!$records || $records->isEmpty()) return;
 
-        $mddIds = $records->getCollection()->pluck('mdd_id')->unique()->toArray();
+        // Unified-leaderboard mode pushes plain stdClass DT reps (no mdd_id property)
+        // alongside Eloquent Record models. PHP 8.3 throws on undefined-property
+        // access, so coerce to null instead and skip score attachment for reps
+        // that have no mdd_id.
+        $mddIds = $records->getCollection()
+            ->map(fn ($r) => $r->mdd_id ?? null)
+            ->filter()
+            ->unique()
+            ->values()
+            ->toArray();
         if (empty($mddIds)) return;
 
         $scores = PlayerMapScore::where('mapname', $mapname)
@@ -1765,7 +1774,8 @@ class MapsController extends Controller
             ->keyBy('mdd_id');
 
         $records->getCollection()->transform(function ($record) use ($scores) {
-            $score = $scores->get($record->mdd_id);
+            $mddId = $record->mdd_id ?? null;
+            $score = $mddId ? $scores->get($mddId) : null;
             $record->map_score = $score ? round($score->map_score, 2) : null;
             $record->reltime = $score ? round($score->reltime, 4) : null;
             $record->multiplier = $score ? round($score->multiplier, 4) : null;


### PR DESCRIPTION
## Summary

- PHP 8.3 throws on undefined-property access, and `buildUnifiedLeaderboard()` mixes plain stdClass Demos Top reps (no `mdd_id` field) into the paginator alongside Eloquent Record/OldtopRecord models.
- The previous commit's `attachMapScores()` pass read `$record->mdd_id` directly, so the page crashed the moment Demos Top was on (regression introduced by the score-column fix that moved the attach to run on the unified paginator).
- Coerce missing `mdd_id` to null via `??` and skip the score lookup for reps that don't have one. Main records and oldtop still get scored; DT reps get `map_score=null`, which the frontend already handles via `v-if="record.map_score"`.

## Test plan

- [ ] Open a map with Demos Top enabled — page loads instead of 500
- [ ] Main MDD records still show their score column populated
- [ ] DT-rep rows show no score (expected — they're not MDD-table entries)
