### PR TITLE
Storage Browser + Bundles Manager admin pages

### DIFF
--- a/app/Filament/Pages/BundlesManager.php
+++ b/app/Filament/Pages/BundlesManager.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Pages\Concerns\ValidatesStoragePath;
+use App\Models\Bundle;
+use App\Models\BundleCategory;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Attributes\Computed;
+use Livewire\WithFileUploads;
+
+class BundlesManager extends Page
+{
+    use ValidatesStoragePath;
+    use WithFileUploads;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationLabel = 'Bundles Manager';
+    protected static ?string $navigationGroup = 'Bundles';
+    protected static ?int $navigationSort = 1;
+    protected static ?string $title = 'Bundles Manager';
+    protected static string $view = 'filament.pages.bundles-manager';
+
+    protected const DISK = 'dl_storage';
+    protected const PUBLIC_URL_BASE = 'https://dl.defrag.racing/downloads/';
+
+    public ?int $selectedCategoryId = null;
+
+    public bool $bundleFormOpen = false;
+    public ?int $editingBundleId = null;
+    public array $bundleForm = ['name' => '', 'description' => '', 'url' => ''];
+
+    public bool $categoryFormOpen = false;
+    public ?int $editingCategoryId = null;
+    public array $categoryForm = ['name' => ''];
+
+    public bool $pickerOpen = false;
+    public string $pickerPath = '';
+    public $pickerUploadFile = null;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public function mount(): void
+    {
+        $first = BundleCategory::orderBy('name')->first();
+        $this->selectedCategoryId = $first?->id;
+    }
+
+    protected function disk(): Filesystem
+    {
+        return Storage::disk(self::DISK);
+    }
+
+    #[Computed]
+    public function categories()
+    {
+        return BundleCategory::withCount('bundles')->orderBy('name')->get();
+    }
+
+    #[Computed]
+    public function selectedCategory()
+    {
+        if (! $this->selectedCategoryId) {
+            return null;
+        }
+
+        return BundleCategory::with('bundles')->find($this->selectedCategoryId);
+    }
+
+    public function selectCategory(int $id): void
+    {
+        $this->selectedCategoryId = $id;
+    }
+
+    // ---------- Category form ----------
+
+    public function openCategoryForm(?int $id = null): void
+    {
+        $this->editingCategoryId = $id;
+        $this->categoryForm = ['name' => $id ? (BundleCategory::find($id)?->name ?? '') : ''];
+        $this->categoryFormOpen = true;
+    }
+
+    public function closeCategoryForm(): void
+    {
+        $this->categoryFormOpen = false;
+        $this->editingCategoryId = null;
+    }
+
+    public function saveCategory(): void
+    {
+        $name = trim((string) ($this->categoryForm['name'] ?? ''));
+
+        if ($name === '') {
+            Notification::make()->title('Name is required')->danger()->send();
+
+            return;
+        }
+
+        if ($this->editingCategoryId) {
+            BundleCategory::where('id', $this->editingCategoryId)->update(['name' => $name]);
+        } else {
+            $cat = BundleCategory::create(['name' => $name]);
+            $this->selectedCategoryId = $cat->id;
+        }
+
+        unset($this->categories);
+        $this->closeCategoryForm();
+
+        Notification::make()->title('Category saved')->success()->send();
+    }
+
+    public function deleteCategory(int $id): void
+    {
+        $cat = BundleCategory::withCount('bundles')->find($id);
+
+        if (! $cat) {
+            return;
+        }
+
+        if ($cat->bundles_count > 0) {
+            Notification::make()
+                ->title('Cannot delete')
+                ->body("Category has {$cat->bundles_count} bundle(s). Move or delete them first.")
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $cat->delete();
+
+        if ($this->selectedCategoryId === $id) {
+            $this->selectedCategoryId = BundleCategory::orderBy('name')->value('id');
+        }
+
+        unset($this->categories);
+
+        Notification::make()->title('Category deleted')->success()->send();
+    }
+
+    // ---------- Bundle form ----------
+
+    public function openBundleForm(?int $id = null): void
+    {
+        $this->editingBundleId = $id;
+
+        if ($id) {
+            $b = Bundle::find($id);
+
+            $this->bundleForm = [
+                'name' => $b->name ?? '',
+                'description' => $b->description ?? '',
+                'url' => $b->url ?? '',
+            ];
+        } else {
+            $this->bundleForm = ['name' => '', 'description' => '', 'url' => ''];
+        }
+
+        $this->bundleFormOpen = true;
+        $this->pickerOpen = false;
+    }
+
+    public function closeBundleForm(): void
+    {
+        $this->bundleFormOpen = false;
+        $this->editingBundleId = null;
+    }
+
+    public function saveBundle(): void
+    {
+        $name = trim((string) ($this->bundleForm['name'] ?? ''));
+        $description = trim((string) ($this->bundleForm['description'] ?? ''));
+        $url = trim((string) ($this->bundleForm['url'] ?? ''));
+
+        if ($name === '' || $description === '' || $url === '') {
+            Notification::make()->title('Name, description and URL are required')->danger()->send();
+
+            return;
+        }
+
+        if (! $this->selectedCategoryId) {
+            Notification::make()->title('Select a category first')->danger()->send();
+
+            return;
+        }
+
+        $data = [
+            'name' => $name,
+            'description' => $description,
+            'url' => $url,
+            'category_id' => $this->selectedCategoryId,
+        ];
+
+        if ($this->editingBundleId) {
+            Bundle::where('id', $this->editingBundleId)->update($data);
+        } else {
+            Bundle::create($data);
+        }
+
+        unset($this->categories, $this->selectedCategory);
+        $this->closeBundleForm();
+
+        Notification::make()->title('Bundle saved')->success()->send();
+    }
+
+    public function deleteBundle(int $id): void
+    {
+        Bundle::where('id', $id)->delete();
+        unset($this->categories, $this->selectedCategory);
+
+        Notification::make()->title('Bundle deleted')->success()->send();
+    }
+
+    // ---------- Storage picker ----------
+
+    public function openPicker(): void
+    {
+        $this->pickerPath = '';
+        $this->pickerOpen = true;
+    }
+
+    public function closePicker(): void
+    {
+        $this->pickerOpen = false;
+        $this->pickerUploadFile = null;
+    }
+
+    #[Computed]
+    public function pickerListing(): array
+    {
+        if (! $this->pickerOpen) {
+            return ['dirs' => [], 'files' => []];
+        }
+
+        try {
+            $disk = $this->disk();
+            $path = $this->pickerPath;
+
+            $dirs = collect($disk->directories($path))
+                ->map(fn ($p) => ['name' => basename($p), 'path' => $p])
+                ->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)
+                ->values()
+                ->all();
+
+            $files = collect($disk->files($path))
+                ->map(function ($p) use ($disk) {
+                    $size = null;
+
+                    try {
+                        $size = $disk->size($p);
+                    } catch (\Throwable) {
+                    }
+
+                    return ['name' => basename($p), 'path' => $p, 'size' => $size];
+                })
+                ->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)
+                ->values()
+                ->all();
+
+            return ['dirs' => $dirs, 'files' => $files];
+        } catch (\Throwable $e) {
+            Notification::make()->title('Cannot list directory')->body($e->getMessage())->danger()->send();
+
+            return ['dirs' => [], 'files' => []];
+        }
+    }
+
+    #[Computed]
+    public function pickerBreadcrumbs(): array
+    {
+        if ($this->pickerPath === '') {
+            return [];
+        }
+
+        $segments = explode('/', $this->pickerPath);
+        $crumbs = [];
+        $accum = '';
+
+        foreach ($segments as $segment) {
+            $accum = $accum === '' ? $segment : $accum . '/' . $segment;
+            $crumbs[] = ['name' => $segment, 'path' => $accum];
+        }
+
+        return $crumbs;
+    }
+
+    public function pickerEnterDir(string $name): void
+    {
+        $this->validateName($name);
+        $this->pickerPath = $this->joinPath($this->pickerPath, $name);
+    }
+
+    public function pickerGoTo(string $path): void
+    {
+        $path = trim($path, '/');
+        $this->validatePath($path);
+        $this->pickerPath = $path;
+    }
+
+    public function pickerGoUp(): void
+    {
+        if ($this->pickerPath === '') {
+            return;
+        }
+
+        $parts = explode('/', $this->pickerPath);
+        array_pop($parts);
+        $this->pickerPath = implode('/', $parts);
+    }
+
+    public function pickerGoRoot(): void
+    {
+        $this->pickerPath = '';
+    }
+
+    public function pickerSelectFile(string $relativePath): void
+    {
+        $this->validatePath($relativePath);
+
+        $this->bundleForm['url'] = self::PUBLIC_URL_BASE . $relativePath;
+        $this->pickerOpen = false;
+
+        Notification::make()->title('File selected')->body($relativePath)->success()->send();
+    }
+
+    public function pickerCreateFolder(string $name): void
+    {
+        $this->validateName($name);
+
+        $disk = $this->disk();
+        $path = $this->joinPath($this->pickerPath, $name);
+
+        if ($disk->exists($path)) {
+            Notification::make()->title('Already exists')->danger()->send();
+
+            return;
+        }
+
+        $disk->makeDirectory($path);
+        unset($this->pickerListing);
+
+        Notification::make()->title('Folder created')->success()->send();
+    }
+
+    public function pickerUploadHere(): void
+    {
+        if (! $this->pickerUploadFile) {
+            Notification::make()->title('No file selected')->danger()->send();
+
+            return;
+        }
+
+        $name = $this->pickerUploadFile->getClientOriginalName();
+        $this->validateName($name);
+
+        $disk = $this->disk();
+        $targetPath = $this->joinPath($this->pickerPath, $name);
+
+        $stream = fopen($this->pickerUploadFile->getRealPath(), 'rb');
+
+        if (! is_resource($stream)) {
+            Notification::make()->title('Cannot read upload')->danger()->send();
+
+            return;
+        }
+
+        $disk->writeStream($targetPath, $stream);
+
+        if (is_resource($stream)) {
+            fclose($stream);
+        }
+
+        $this->pickerUploadFile = null;
+        unset($this->pickerListing);
+
+        Notification::make()->title('Uploaded')->body($name)->success()->send();
+    }
+
+    public function formatBytes(?int $bytes): string
+    {
+        if ($bytes === null) {
+            return '?';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $i = 0;
+        $value = (float) $bytes;
+
+        while ($value >= 1024 && $i < count($units) - 1) {
+            $value /= 1024;
+            $i++;
+        }
+
+        return round($value, $i === 0 ? 0 : 1) . ' ' . $units[$i];
+    }
+}

--- a/app/Filament/Pages/BundlesManager.php
+++ b/app/Filament/Pages/BundlesManager.php
@@ -60,7 +60,7 @@ class BundlesManager extends Page
     #[Computed]
     public function categories()
     {
-        return BundleCategory::withCount('bundles')->orderBy('name')->get();
+        return BundleCategory::withCount('bundles')->orderBy('position')->orderBy('name')->get();
     }
 
     #[Computed]
@@ -114,6 +114,45 @@ class BundlesManager extends Page
         $this->closeCategoryForm();
 
         Notification::make()->title('Category saved')->success()->send();
+    }
+
+    public function reorderCategories(array $orderedIds): void
+    {
+        $orderedIds = array_values(array_filter(array_map('intval', $orderedIds)));
+        $valid = BundleCategory::whereIn('id', $orderedIds)->pluck('id')->all();
+
+        foreach ($orderedIds as $position => $id) {
+            if (! in_array($id, $valid, true)) {
+                continue;
+            }
+
+            BundleCategory::where('id', $id)->update(['position' => $position]);
+        }
+
+        unset($this->categories);
+    }
+
+    public function reorderBundles(array $orderedIds): void
+    {
+        if (! $this->selectedCategoryId) {
+            return;
+        }
+
+        $orderedIds = array_values(array_filter(array_map('intval', $orderedIds)));
+        $valid = Bundle::where('category_id', $this->selectedCategoryId)
+            ->whereIn('id', $orderedIds)
+            ->pluck('id')
+            ->all();
+
+        foreach ($orderedIds as $position => $id) {
+            if (! in_array($id, $valid, true)) {
+                continue;
+            }
+
+            Bundle::where('id', $id)->update(['position' => $position]);
+        }
+
+        unset($this->selectedCategory);
     }
 
     public function deleteCategory(int $id): void

--- a/app/Filament/Pages/Concerns/ValidatesStoragePath.php
+++ b/app/Filament/Pages/Concerns/ValidatesStoragePath.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Pages\Concerns;
+
+trait ValidatesStoragePath
+{
+    protected function validateName(string $name): void
+    {
+        if ($name === '' || $name === '.' || $name === '..') {
+            abort(400, 'Invalid name');
+        }
+
+        if (str_contains($name, '/') || str_contains($name, "\0")) {
+            abort(400, 'Invalid name');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9._\-][A-Za-z0-9._\- ]*$/', $name)) {
+            abort(400, 'Name contains forbidden characters');
+        }
+    }
+
+    protected function validatePath(string $path): void
+    {
+        $path = trim($path, '/');
+
+        if ($path === '') {
+            return;
+        }
+
+        foreach (explode('/', $path) as $segment) {
+            $this->validateName($segment);
+        }
+    }
+
+    protected function joinPath(string $base, string $name): string
+    {
+        $base = trim($base, '/');
+
+        return $base === '' ? $name : $base . '/' . $name;
+    }
+}

--- a/app/Filament/Pages/StorageBrowser.php
+++ b/app/Filament/Pages/StorageBrowser.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Pages\Concerns\ValidatesStoragePath;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class StorageBrowser extends Page
+{
+    use ValidatesStoragePath;
+
+    protected static ?string $navigationIcon = 'heroicon-o-folder-open';
+    protected static ?string $navigationLabel = 'Storage Browser';
+    protected static ?string $navigationGroup = 'Storage';
+    protected static ?string $title = 'Storage Browser (dl.defrag.racing)';
+    protected static string $view = 'filament.pages.storage-browser';
+
+    protected const DISK = 'dl_storage';
+
+    public string $currentPath = '';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public function mount(): void
+    {
+        $this->currentPath = '';
+    }
+
+    protected function disk(): Filesystem
+    {
+        return Storage::disk(self::DISK);
+    }
+
+    public function getListingProperty(): array
+    {
+        $disk = $this->disk();
+        $path = $this->currentPath;
+
+        try {
+            $directories = collect($disk->directories($path))
+                ->map(fn ($p) => [
+                    'name' => basename($p),
+                    'path' => $p,
+                    'type' => 'dir',
+                ])
+                ->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)
+                ->values()
+                ->all();
+
+            $files = collect($disk->files($path))
+                ->map(function ($p) use ($disk) {
+                    $size = null;
+                    $mtime = null;
+
+                    try {
+                        $size = $disk->size($p);
+                    } catch (\Throwable) {
+                    }
+
+                    try {
+                        $mtime = $disk->lastModified($p);
+                    } catch (\Throwable) {
+                    }
+
+                    return [
+                        'name' => basename($p),
+                        'path' => $p,
+                        'type' => 'file',
+                        'size' => $size,
+                        'mtime' => $mtime,
+                    ];
+                })
+                ->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)
+                ->values()
+                ->all();
+
+            return ['dirs' => $directories, 'files' => $files];
+        } catch (\Throwable $e) {
+            Notification::make()
+                ->title('Cannot list directory')
+                ->body($e->getMessage())
+                ->danger()
+                ->send();
+
+            return ['dirs' => [], 'files' => []];
+        }
+    }
+
+    public function getBreadcrumbsProperty(): array
+    {
+        if ($this->currentPath === '') {
+            return [];
+        }
+
+        $segments = explode('/', $this->currentPath);
+        $crumbs = [];
+        $accum = '';
+
+        foreach ($segments as $segment) {
+            $accum = $accum === '' ? $segment : $accum . '/' . $segment;
+            $crumbs[] = ['name' => $segment, 'path' => $accum];
+        }
+
+        return $crumbs;
+    }
+
+    public function enterDir(string $name): void
+    {
+        $this->validateName($name);
+        $this->currentPath = $this->joinPath($this->currentPath, $name);
+    }
+
+    public function goTo(string $path): void
+    {
+        $path = trim($path, '/');
+        $this->validatePath($path);
+        $this->currentPath = $path;
+    }
+
+    public function goUp(): void
+    {
+        if ($this->currentPath === '') {
+            return;
+        }
+
+        $parts = explode('/', $this->currentPath);
+        array_pop($parts);
+        $this->currentPath = implode('/', $parts);
+    }
+
+    public function goRoot(): void
+    {
+        $this->currentPath = '';
+    }
+
+    public function downloadFile(string $name)
+    {
+        $this->validateName($name);
+        $disk = $this->disk();
+        $path = $this->joinPath($this->currentPath, $name);
+
+        if (! $disk->exists($path)) {
+            Notification::make()->title('File not found')->danger()->send();
+
+            return null;
+        }
+
+        $size = $disk->size($path);
+
+        return new StreamedResponse(function () use ($disk, $path) {
+            $stream = $disk->readStream($path);
+
+            if (is_resource($stream)) {
+                fpassthru($stream);
+                fclose($stream);
+            }
+        }, 200, [
+            'Content-Type' => 'application/octet-stream',
+            'Content-Disposition' => 'attachment; filename="' . addslashes(basename($name)) . '"',
+            'Content-Length' => (string) $size,
+            'X-Accel-Buffering' => 'no',
+        ]);
+    }
+
+    public function mkdirAction(): Action
+    {
+        return Action::make('mkdir')
+            ->label('New folder')
+            ->icon('heroicon-o-folder-plus')
+            ->color('primary')
+            ->form([
+                TextInput::make('name')
+                    ->label('Folder name')
+                    ->required()
+                    ->maxLength(255)
+                    ->regex('/^[A-Za-z0-9._\-][A-Za-z0-9._\- ]*$/')
+                    ->helperText('Letters, digits, dot, underscore, hyphen, space.'),
+            ])
+            ->action(function (array $data) {
+                $name = $data['name'];
+                $this->validateName($name);
+
+                $disk = $this->disk();
+                $path = $this->joinPath($this->currentPath, $name);
+
+                if ($disk->exists($path)) {
+                    Notification::make()->title('Already exists')->danger()->send();
+
+                    return;
+                }
+
+                $disk->makeDirectory($path);
+
+                Notification::make()->title('Folder created')->success()->send();
+            });
+    }
+
+    public function uploadAction(): Action
+    {
+        return Action::make('upload')
+            ->label('Upload files')
+            ->icon('heroicon-o-arrow-up-tray')
+            ->color('primary')
+            ->form([
+                FileUpload::make('files')
+                    ->label('Drop files here')
+                    ->multiple()
+                    ->preserveFilenames()
+                    ->required()
+                    ->disk('local')
+                    ->directory('storage-browser-uploads')
+                    ->maxSize(1024 * 1024)
+                    ->helperText('Max 1 GB per file. Existing files will be overwritten.'),
+            ])
+            ->action(function (array $data) {
+                $disk = $this->disk();
+                $local = Storage::disk('local');
+                $uploaded = 0;
+                $overwritten = 0;
+
+                foreach ((array) $data['files'] as $tempPath) {
+                    $name = basename($tempPath);
+                    $this->validateName($name);
+
+                    $targetPath = $this->joinPath($this->currentPath, $name);
+                    $existed = $disk->exists($targetPath);
+
+                    $stream = $local->readStream($tempPath);
+
+                    if (! is_resource($stream)) {
+                        continue;
+                    }
+
+                    $disk->writeStream($targetPath, $stream);
+
+                    if (is_resource($stream)) {
+                        fclose($stream);
+                    }
+
+                    $local->delete($tempPath);
+
+                    $uploaded++;
+
+                    if ($existed) {
+                        $overwritten++;
+                    }
+                }
+
+                Notification::make()
+                    ->title("Uploaded {$uploaded} file(s)")
+                    ->body($overwritten > 0 ? "{$overwritten} overwritten." : null)
+                    ->success()
+                    ->send();
+            });
+    }
+
+    public function renameAction(): Action
+    {
+        return Action::make('rename')
+            ->icon('heroicon-o-pencil-square')
+            ->modalHeading(fn (array $arguments) => "Rename \"{$arguments['oldName']}\"")
+            ->form(fn (array $arguments) => [
+                TextInput::make('newName')
+                    ->label('New name')
+                    ->default($arguments['oldName'] ?? '')
+                    ->required()
+                    ->maxLength(255)
+                    ->regex('/^[A-Za-z0-9._\-][A-Za-z0-9._\- ]*$/'),
+            ])
+            ->action(function (array $data, array $arguments) {
+                $oldName = $arguments['oldName'];
+                $newName = $data['newName'];
+
+                $this->validateName($oldName);
+                $this->validateName($newName);
+
+                if ($oldName === $newName) {
+                    return;
+                }
+
+                $disk = $this->disk();
+                $oldPath = $this->joinPath($this->currentPath, $oldName);
+                $newPath = $this->joinPath($this->currentPath, $newName);
+
+                if ($disk->exists($newPath)) {
+                    Notification::make()->title('Target already exists')->danger()->send();
+
+                    return;
+                }
+
+                $disk->move($oldPath, $newPath);
+
+                Notification::make()->title('Renamed')->success()->send();
+            });
+    }
+
+    public function deleteAction(): Action
+    {
+        return Action::make('delete')
+            ->icon('heroicon-o-trash')
+            ->color('danger')
+            ->requiresConfirmation()
+            ->modalHeading(fn (array $arguments) => "Delete \"{$arguments['name']}\"?")
+            ->modalDescription('This permanently removes the file/folder from the storage VPS. Cannot be undone.')
+            ->modalSubmitActionLabel('Delete')
+            ->action(function (array $arguments) {
+                $name = $arguments['name'];
+                $type = $arguments['type'];
+
+                $this->validateName($name);
+
+                $disk = $this->disk();
+                $path = $this->joinPath($this->currentPath, $name);
+
+                if ($type === 'dir') {
+                    $disk->deleteDirectory($path);
+                } else {
+                    $disk->delete($path);
+                }
+
+                Notification::make()->title('Deleted')->success()->send();
+            });
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            $this->uploadAction(),
+            $this->mkdirAction(),
+        ];
+    }
+
+    public function formatBytes(?int $bytes): string
+    {
+        if ($bytes === null) {
+            return '?';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $i = 0;
+        $value = (float) $bytes;
+
+        while ($value >= 1024 && $i < count($units) - 1) {
+            $value /= 1024;
+            $i++;
+        }
+
+        return round($value, $i === 0 ? 0 : 1) . ' ' . $units[$i];
+    }
+}

--- a/app/Filament/Resources/BundleCategoryResource.php
+++ b/app/Filament/Resources/BundleCategoryResource.php
@@ -21,6 +21,8 @@ class BundleCategoryResource extends Resource
 
     protected static ?string $navigationGroup = 'Bundles';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     public static function canAccess(): bool
     {
         return auth()->user()?->isAdmin() ?? false;

--- a/app/Filament/Resources/BundleResource.php
+++ b/app/Filament/Resources/BundleResource.php
@@ -21,6 +21,8 @@ class BundleResource extends Resource
 
     protected static ?string $navigationGroup = 'Bundles';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     public static function canAccess(): bool
     {
         return auth()->user()?->isAdmin() ?? false;

--- a/app/Models/Bundle.php
+++ b/app/Models/Bundle.php
@@ -9,17 +9,17 @@ class Bundle extends Model
 {
     use HasFactory;
 
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'name',
         'description',
         'url',
         'file',
-        'category_id'
+        'category_id',
+        'position',
     ];
+
+    public function category()
+    {
+        return $this->belongsTo(BundleCategory::class, 'category_id');
+    }
 }

--- a/app/Models/BundleCategory.php
+++ b/app/Models/BundleCategory.php
@@ -9,16 +9,13 @@ class BundleCategory extends Model
 {
     use HasFactory;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
-        'name'
+        'name',
+        'position',
     ];
 
-    public function bundles () {
-        return $this->hasMany(Bundle::class, 'category_id');
+    public function bundles()
+    {
+        return $this->hasMany(Bundle::class, 'category_id')->orderBy('position');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "laravel/socialite": "^5.23",
         "laravel/tinker": "^2.8",
         "league/flysystem-aws-s3-v3": "^3.0",
+        "league/flysystem-sftp-v3": "*",
         "mokhosh/filament-kanban": "^2.3",
         "opcodesio/log-viewer": "^3.1",
         "php-http/curl-client": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5408fca8f40380d657d384eed4f3d4b8",
+    "content-hash": "7bf92b7ca0ca8c0cfc853a90dd87ff70",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4423,6 +4423,55 @@
                 "source": "https://github.com/thephpleague/flysystem-local/tree/3.29.0"
             },
             "time": "2024-08-09T21:24:39+00:00"
+        },
+        {
+            "name": "league/flysystem-sftp-v3",
+            "version": "3.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-sftp-v3.git",
+                "reference": "34ff5ef0f841add92e2b902c1005f72135b03646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-sftp-v3/zipball/34ff5ef0f841add92e2b902c1005f72135b03646",
+                "reference": "34ff5ef0f841add92e2b902c1005f72135b03646",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "^3.0.14",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2",
+                "phpseclib/phpseclib": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\PhpseclibV3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "SFTP filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "sftp"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-sftp-v3/tree/3.33.0"
+            },
+            "time": "2026-03-20T13:22:31+00:00"
         },
         {
             "name": "league/mime-type-detection",

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -61,6 +61,23 @@ return [
             'throw' => true,
         ],
 
+        'dl_storage' => env('STORAGE_VPS_DL_DRIVER', 'sftp') === 'local'
+            ? [
+                'driver' => 'local',
+                'root'   => storage_path('app/dl-storage-local'),
+                'throw'  => true,
+            ]
+            : [
+                'driver'     => 'sftp',
+                'host'       => env('STORAGE_VPS_DL_HOST'),
+                'port'       => (int) env('STORAGE_VPS_DL_PORT', 2258),
+                'username'   => env('STORAGE_VPS_DL_USER', 'dlbrowser'),
+                'privateKey' => env('STORAGE_VPS_DL_KEY_PATH'),
+                'root'       => env('STORAGE_VPS_DL_ROOT', '/www/downloads'),
+                'timeout'    => 30,
+                'throw'      => true,
+            ],
+
     ],
 
     /*

--- a/config/services.php
+++ b/config/services.php
@@ -67,4 +67,12 @@ return [
         'key_path' => env('STORAGE_VPS_KEY_PATH'),
     ],
 
+    'storage_vps_dl' => [
+        'host'     => env('STORAGE_VPS_DL_HOST'),
+        'port'     => (int) env('STORAGE_VPS_DL_PORT', 2258),
+        'user'     => env('STORAGE_VPS_DL_USER', 'dlbrowser'),
+        'key_path' => env('STORAGE_VPS_DL_KEY_PATH'),
+        'root'     => env('STORAGE_VPS_DL_ROOT', '/www/downloads'),
+    ],
+
 ];

--- a/database/migrations/2026_05_14_000001_add_position_to_bundles_and_categories.php
+++ b/database/migrations/2026_05_14_000001_add_position_to_bundles_and_categories.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bundle_categories', function (Blueprint $table) {
+            $table->unsignedInteger('position')->default(0)->after('name');
+        });
+
+        Schema::table('bundles', function (Blueprint $table) {
+            $table->unsignedInteger('position')->default(0)->after('category_id');
+        });
+
+        // Backfill existing rows so they keep current visual order (id ASC)
+        $cats = DB::table('bundle_categories')->orderBy('id')->pluck('id');
+        foreach ($cats as $i => $id) {
+            DB::table('bundle_categories')->where('id', $id)->update(['position' => $i]);
+        }
+
+        $catIds = DB::table('bundles')->select('category_id')->distinct()->pluck('category_id');
+        foreach ($catIds as $catId) {
+            $bundles = DB::table('bundles')->where('category_id', $catId)->orderBy('id')->pluck('id');
+            foreach ($bundles as $i => $id) {
+                DB::table('bundles')->where('id', $id)->update(['position' => $i]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('bundle_categories', function (Blueprint $table) {
+            $table->dropColumn('position');
+        });
+
+        Schema::table('bundles', function (Blueprint $table) {
+            $table->dropColumn('position');
+        });
+    }
+};

--- a/resources/views/filament/pages/bundles-manager.blade.php
+++ b/resources/views/filament/pages/bundles-manager.blade.php
@@ -34,12 +34,27 @@
                     onmouseout="this.style.backgroundColor='rgba(234,88,12,0.15)'"
                     title="New category">+</button>
             </div>
-            <div>
+            <div
+                x-data
+                x-init="
+                    new Sortable($el, {
+                        handle: '.cat-drag-handle',
+                        animation: 150,
+                        ghostClass: 'sortable-ghost-cat',
+                        onEnd: () => {
+                            const ids = Array.from($el.querySelectorAll('[data-cat-id]')).map(el => el.dataset.catId);
+                            $wire.call('reorderCategories', ids);
+                        }
+                    });
+                "
+            >
                 @forelse ($categories as $cat)
                     @php $isActive = $selectedCat && $selectedCat->id === $cat->id; @endphp
-                    <div style="display:flex;align-items:center;border-left:3px solid {{ $isActive ? '#ea580c' : 'transparent' }};background:{{ $isActive ? 'rgba(234,88,12,0.10)' : 'transparent' }};transition:background-color 120ms;"
+                    <div data-cat-id="{{ $cat->id }}"
+                        style="display:flex;align-items:center;border-left:3px solid {{ $isActive ? '#ea580c' : 'transparent' }};background:{{ $isActive ? 'rgba(234,88,12,0.10)' : 'transparent' }};transition:background-color 120ms;"
                         onmouseover="if(!{{ $isActive ? 'true' : 'false' }})this.style.backgroundColor='rgba(255,255,255,0.04)'"
                         onmouseout="if(!{{ $isActive ? 'true' : 'false' }})this.style.backgroundColor='transparent'">
+                        <span class="cat-drag-handle" style="cursor:grab;padding:0 6px 0 8px;color:#52525b;user-select:none;font-size:14px;line-height:1;" title="Drag to reorder">⋮⋮</span>
                         <button type="button"
                             wire:click="selectCategory({{ $cat->id }})"
                             style="background:transparent;border:none;cursor:pointer;flex:1;text-align:left;padding:10px 14px;color:{{ $isActive ? '#fb923c' : '#e4e4e7' }};font-size:13px;font-weight:{{ $isActive ? '700' : '500' }};display:flex;align-items:center;justify-content:space-between;gap:8px;min-width:0;">
@@ -102,16 +117,33 @@
                 <table style="width:100%;border-collapse:collapse;font-size:13px;">
                     <thead>
                         <tr style="background:#18181b;">
+                            <th style="width:24px;"></th>
                             <th style="text-align:left;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Name</th>
                             <th style="text-align:left;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">URL</th>
                             <th style="text-align:right;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;width:140px;">Actions</th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody
+                        x-data
+                        x-init="
+                            new Sortable($el, {
+                                handle: '.bundle-drag-handle',
+                                animation: 150,
+                                ghostClass: 'sortable-ghost-bundle',
+                                onEnd: () => {
+                                    const ids = Array.from($el.querySelectorAll('tr[data-bundle-id]')).map(el => el.dataset.bundleId);
+                                    $wire.call('reorderBundles', ids);
+                                }
+                            });
+                        "
+                    >
                         @forelse($selectedCat->bundles as $bundle)
-                            <tr style="border-top:1px solid #27272a;transition:background-color 120ms;"
+                            <tr data-bundle-id="{{ $bundle->id }}" style="border-top:1px solid #27272a;transition:background-color 120ms;"
                                 onmouseover="this.style.backgroundColor='rgba(234,88,12,0.08)'"
                                 onmouseout="this.style.backgroundColor='transparent'">
+                                <td style="padding:10px 14px;width:24px;">
+                                    <span class="bundle-drag-handle" style="cursor:grab;color:#52525b;user-select:none;font-size:14px;" title="Drag to reorder">⋮⋮</span>
+                                </td>
                                 <td style="padding:10px 14px;">
                                     <div style="color:#fafafa;font-weight:600;font-size:14px;">{{ $bundle->name }}</div>
                                     @if($bundle->description)
@@ -149,7 +181,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="3" style="padding:32px 14px;text-align:center;color:#71717a;border-top:1px solid #27272a;">
+                                <td colspan="4" style="padding:32px 14px;text-align:center;color:#71717a;border-top:1px solid #27272a;">
                                     No bundles in this category. Click <strong style="color:#fb923c;">+ New Bundle</strong> to add one.
                                 </td>
                             </tr>

--- a/resources/views/filament/pages/bundles-manager.blade.php
+++ b/resources/views/filament/pages/bundles-manager.blade.php
@@ -1,0 +1,327 @@
+<x-filament-panels::page>
+    @php
+        $categories = $this->categories;
+        $selectedCat = $this->selectedCategory;
+
+        $primaryBtn = 'background:#ea580c;color:#fff;border:none;padding:8px 14px;font-size:12px;font-weight:700;border-radius:6px;cursor:pointer;text-transform:uppercase;letter-spacing:0.5px;transition:background-color 120ms;';
+        $primaryBtnHover = "this.style.backgroundColor='#f97316'";
+        $primaryBtnOut = "this.style.backgroundColor='#ea580c'";
+
+        $secondaryBtn = 'background:transparent;color:#a1a1aa;border:1px solid #3f3f46;padding:8px 14px;font-size:12px;font-weight:600;border-radius:6px;cursor:pointer;transition:all 120ms;';
+        $secondaryBtnHover = "this.style.backgroundColor='#27272a';this.style.color='#fafafa'";
+        $secondaryBtnOut = "this.style.backgroundColor='transparent';this.style.color='#a1a1aa'";
+
+        $iconBtnBase = 'background:transparent;border:none;cursor:pointer;padding:6px 8px;border-radius:6px;color:#9ca3af;transition:all 120ms;';
+        $iconBtnHover = "this.style.backgroundColor='rgba(255,255,255,0.08)';this.style.color='#fff'";
+        $iconBtnOut = "this.style.backgroundColor='transparent';this.style.color='#9ca3af'";
+
+        $deleteBtnBase = 'background:transparent;border:none;cursor:pointer;padding:6px 8px;border-radius:6px;color:#ef4444;transition:all 120ms;';
+        $deleteBtnHover = "this.style.backgroundColor='rgba(239,68,68,0.15)';this.style.color='#fca5a5'";
+        $deleteBtnOut = "this.style.backgroundColor='transparent';this.style.color='#ef4444'";
+
+        $inputStyle = 'background:#0a0a0f;color:#fafafa;border:1px solid #3f3f46;border-radius:6px;padding:8px 12px;font-size:14px;width:100%;box-sizing:border-box;';
+    @endphp
+
+    <div style="display:grid;grid-template-columns:280px 1fr;gap:14px;">
+        {{-- ============= LEFT SIDEBAR: CATEGORIES ============= --}}
+        <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;overflow:hidden;align-self:start;">
+            <div style="padding:12px 14px;border-bottom:1px solid #27272a;display:flex;align-items:center;justify-content:space-between;">
+                <h3 style="color:#fb923c;font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:1px;margin:0;">Categories</h3>
+                <button type="button"
+                    wire:click="openCategoryForm"
+                    style="background:rgba(234,88,12,0.15);color:#fb923c;border:none;cursor:pointer;padding:4px 8px;border-radius:6px;font-size:18px;line-height:1;font-weight:700;"
+                    onmouseover="this.style.backgroundColor='rgba(234,88,12,0.3)'"
+                    onmouseout="this.style.backgroundColor='rgba(234,88,12,0.15)'"
+                    title="New category">+</button>
+            </div>
+            <div>
+                @forelse ($categories as $cat)
+                    @php $isActive = $selectedCat && $selectedCat->id === $cat->id; @endphp
+                    <div style="display:flex;align-items:center;border-left:3px solid {{ $isActive ? '#ea580c' : 'transparent' }};background:{{ $isActive ? 'rgba(234,88,12,0.10)' : 'transparent' }};transition:background-color 120ms;"
+                        onmouseover="if(!{{ $isActive ? 'true' : 'false' }})this.style.backgroundColor='rgba(255,255,255,0.04)'"
+                        onmouseout="if(!{{ $isActive ? 'true' : 'false' }})this.style.backgroundColor='transparent'">
+                        <button type="button"
+                            wire:click="selectCategory({{ $cat->id }})"
+                            style="background:transparent;border:none;cursor:pointer;flex:1;text-align:left;padding:10px 14px;color:{{ $isActive ? '#fb923c' : '#e4e4e7' }};font-size:13px;font-weight:{{ $isActive ? '700' : '500' }};display:flex;align-items:center;justify-content:space-between;gap:8px;min-width:0;">
+                            <span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ $cat->name }}</span>
+                            <span style="background:{{ $isActive ? 'rgba(234,88,12,0.25)' : 'rgba(255,255,255,0.06)' }};color:{{ $isActive ? '#fb923c' : '#71717a' }};font-size:10px;font-weight:700;padding:2px 6px;border-radius:8px;flex-shrink:0;">{{ $cat->bundles_count }}</span>
+                        </button>
+                        <div style="display:flex;gap:2px;padding:0 8px;">
+                            <button type="button"
+                                wire:click="openCategoryForm({{ $cat->id }})"
+                                style="{{ $iconBtnBase }}padding:4px 6px;"
+                                onmouseover="{{ $iconBtnHover }}"
+                                onmouseout="{{ $iconBtnOut }}"
+                                title="Edit category">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:12px;height:12px;">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                                </svg>
+                            </button>
+                            <button type="button"
+                                wire:click="deleteCategory({{ $cat->id }})"
+                                wire:confirm="Delete category '{{ $cat->name }}'?"
+                                style="{{ $deleteBtnBase }}padding:4px 6px;"
+                                onmouseover="{{ $deleteBtnHover }}"
+                                onmouseout="{{ $deleteBtnOut }}"
+                                title="Delete category">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:12px;height:12px;">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                @empty
+                    <div style="padding:20px 14px;text-align:center;color:#71717a;font-size:12px;">
+                        No categories yet.<br>Click <strong style="color:#fb923c;">+</strong> to create one.
+                    </div>
+                @endforelse
+            </div>
+        </div>
+
+        {{-- ============= RIGHT MAIN: BUNDLES ============= --}}
+        <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;overflow:hidden;">
+            <div style="padding:12px 14px;border-bottom:1px solid #27272a;display:flex;align-items:center;justify-content:space-between;gap:12px;">
+                <div>
+                    <h2 style="color:#fafafa;font-size:16px;font-weight:800;margin:0;">{{ $selectedCat?->name ?? 'No category selected' }}</h2>
+                    @if($selectedCat)
+                        <p style="color:#71717a;font-size:11px;margin:2px 0 0 0;">{{ $selectedCat->bundles->count() }} bundle(s)</p>
+                    @endif
+                </div>
+                @if($selectedCat)
+                    <button type="button"
+                        wire:click="openBundleForm"
+                        style="{{ $primaryBtn }}"
+                        onmouseover="{{ $primaryBtnHover }}"
+                        onmouseout="{{ $primaryBtnOut }}">
+                        + New Bundle
+                    </button>
+                @endif
+            </div>
+
+            @if($selectedCat)
+                <table style="width:100%;border-collapse:collapse;font-size:13px;">
+                    <thead>
+                        <tr style="background:#18181b;">
+                            <th style="text-align:left;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Name</th>
+                            <th style="text-align:left;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">URL</th>
+                            <th style="text-align:right;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;width:140px;">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($selectedCat->bundles as $bundle)
+                            <tr style="border-top:1px solid #27272a;transition:background-color 120ms;"
+                                onmouseover="this.style.backgroundColor='rgba(234,88,12,0.08)'"
+                                onmouseout="this.style.backgroundColor='transparent'">
+                                <td style="padding:10px 14px;">
+                                    <div style="color:#fafafa;font-weight:600;font-size:14px;">{{ $bundle->name }}</div>
+                                    @if($bundle->description)
+                                        <div style="color:#71717a;font-size:11px;margin-top:2px;line-height:1.4;max-width:400px;">{{ Str::limit($bundle->description, 100) }}</div>
+                                    @endif
+                                </td>
+                                <td style="padding:10px 14px;color:#22d3ee;font-size:11px;font-family:monospace;word-break:break-all;max-width:300px;">
+                                    {{ $bundle->url ?: ($bundle->file ? '/storage/' . $bundle->file : '—') }}
+                                </td>
+                                <td style="padding:10px 14px;">
+                                    <div style="display:flex;justify-content:flex-end;gap:4px;">
+                                        <button type="button"
+                                            wire:click="openBundleForm({{ $bundle->id }})"
+                                            style="{{ $iconBtnBase }}"
+                                            onmouseover="{{ $iconBtnHover }}"
+                                            onmouseout="{{ $iconBtnOut }}"
+                                            title="Edit">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                                            </svg>
+                                        </button>
+                                        <button type="button"
+                                            wire:click="deleteBundle({{ $bundle->id }})"
+                                            wire:confirm="Delete bundle '{{ $bundle->name }}'?"
+                                            style="{{ $deleteBtnBase }}"
+                                            onmouseover="{{ $deleteBtnHover }}"
+                                            onmouseout="{{ $deleteBtnOut }}"
+                                            title="Delete">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" style="padding:32px 14px;text-align:center;color:#71717a;border-top:1px solid #27272a;">
+                                    No bundles in this category. Click <strong style="color:#fb923c;">+ New Bundle</strong> to add one.
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            @else
+                <div style="padding:48px;text-align:center;color:#71717a;">
+                    Select a category from the sidebar, or create one.
+                </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- ============= CATEGORY FORM MODAL ============= --}}
+    @if($categoryFormOpen)
+        <div wire:click.self="closeCategoryForm" style="position:fixed;inset:0;background:rgba(0,0,0,0.7);z-index:50;display:flex;align-items:center;justify-content:center;padding:20px;">
+            <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;padding:20px;width:100%;max-width:420px;">
+                <h2 style="color:#fb923c;font-size:14px;font-weight:800;text-transform:uppercase;letter-spacing:1px;margin:0 0 16px 0;">
+                    {{ $editingCategoryId ? 'Edit category' : 'New category' }}
+                </h2>
+                <div style="margin-bottom:16px;">
+                    <label style="display:block;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;margin-bottom:6px;">Name</label>
+                    <input type="text" wire:model="categoryForm.name" wire:keydown.enter="saveCategory" autofocus style="{{ $inputStyle }}" />
+                </div>
+                <div style="display:flex;justify-content:flex-end;gap:8px;">
+                    <button type="button" wire:click="closeCategoryForm" style="{{ $secondaryBtn }}" onmouseover="{{ $secondaryBtnHover }}" onmouseout="{{ $secondaryBtnOut }}">Cancel</button>
+                    <button type="button" wire:click="saveCategory" style="{{ $primaryBtn }}" onmouseover="{{ $primaryBtnHover }}" onmouseout="{{ $primaryBtnOut }}">Save</button>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- ============= BUNDLE FORM MODAL ============= --}}
+    @if($bundleFormOpen)
+        <div wire:click.self="closeBundleForm" style="position:fixed;inset:0;background:rgba(0,0,0,0.7);z-index:50;display:flex;align-items:center;justify-content:center;padding:20px;">
+            <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;padding:20px;width:100%;max-width:640px;max-height:90vh;overflow-y:auto;">
+                <h2 style="color:#fb923c;font-size:14px;font-weight:800;text-transform:uppercase;letter-spacing:1px;margin:0 0 16px 0;">
+                    {{ $editingBundleId ? 'Edit bundle' : 'New bundle' }} <span style="color:#71717a;font-weight:500;text-transform:none;letter-spacing:0;">in {{ $selectedCat?->name }}</span>
+                </h2>
+
+                <div style="margin-bottom:14px;">
+                    <label style="display:block;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;margin-bottom:6px;">Name</label>
+                    <input type="text" wire:model="bundleForm.name" style="{{ $inputStyle }}" />
+                </div>
+
+                <div style="margin-bottom:14px;">
+                    <label style="display:block;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;margin-bottom:6px;">Description</label>
+                    <textarea wire:model="bundleForm.description" rows="3" style="{{ $inputStyle }}resize:vertical;font-family:inherit;"></textarea>
+                </div>
+
+                <div style="margin-bottom:14px;">
+                    <label style="display:block;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;margin-bottom:6px;">Download URL</label>
+                    <div style="display:flex;gap:8px;">
+                        <input type="text" wire:model="bundleForm.url" placeholder="https://dl.defrag.racing/downloads/..." style="{{ $inputStyle }}font-family:monospace;font-size:12px;" />
+                        <button type="button"
+                            wire:click="openPicker"
+                            style="background:#1f2937;color:#22d3ee;border:1px solid #22d3ee;padding:8px 14px;font-size:12px;font-weight:700;border-radius:6px;cursor:pointer;white-space:nowrap;flex-shrink:0;transition:all 120ms;"
+                            onmouseover="this.style.backgroundColor='rgba(34,211,238,0.15)'"
+                            onmouseout="this.style.backgroundColor='#1f2937'">
+                            Browse storage
+                        </button>
+                    </div>
+                </div>
+
+                <div style="display:flex;justify-content:flex-end;gap:8px;">
+                    <button type="button" wire:click="closeBundleForm" style="{{ $secondaryBtn }}" onmouseover="{{ $secondaryBtnHover }}" onmouseout="{{ $secondaryBtnOut }}">Cancel</button>
+                    <button type="button" wire:click="saveBundle" style="{{ $primaryBtn }}" onmouseover="{{ $primaryBtnHover }}" onmouseout="{{ $primaryBtnOut }}">Save bundle</button>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- ============= STORAGE PICKER MODAL ============= --}}
+    @if($pickerOpen)
+        @php
+            $pl = $this->pickerListing;
+            $pcrumbs = $this->pickerBreadcrumbs;
+        @endphp
+        <div wire:click.self="closePicker" style="position:fixed;inset:0;background:rgba(0,0,0,0.85);z-index:60;display:flex;align-items:center;justify-content:center;padding:20px;">
+            <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;padding:0;width:100%;max-width:900px;max-height:90vh;display:flex;flex-direction:column;overflow:hidden;">
+                <div style="padding:14px 16px;border-bottom:1px solid #27272a;display:flex;align-items:center;justify-content:space-between;">
+                    <h2 style="color:#22d3ee;font-size:14px;font-weight:800;text-transform:uppercase;letter-spacing:1px;margin:0;">Pick file from storage VPS</h2>
+                    <button type="button" wire:click="closePicker" style="background:transparent;border:none;cursor:pointer;color:#a1a1aa;font-size:20px;line-height:1;padding:4px 8px;" onmouseover="this.style.color='#fff'" onmouseout="this.style.color='#a1a1aa'">×</button>
+                </div>
+
+                {{-- Breadcrumb + Upload --}}
+                <div style="padding:10px 16px;border-bottom:1px solid #27272a;display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+                    <div style="display:flex;align-items:center;gap:4px;font-size:13px;flex-wrap:wrap;">
+                        <button type="button" wire:click="pickerGoRoot" style="background:transparent;border:none;cursor:pointer;color:#fb923c;font-weight:700;padding:4px 8px;border-radius:6px;" onmouseover="this.style.backgroundColor='rgba(234,88,12,0.15)'" onmouseout="this.style.backgroundColor='transparent'">/</button>
+                        @foreach($pcrumbs as $i => $crumb)
+                            <span style="color:#52525b;">/</span>
+                            @if($i === count($pcrumbs)-1)
+                                <span style="color:#fafafa;font-weight:700;padding:4px 8px;">{{ $crumb['name'] }}</span>
+                            @else
+                                <button type="button" wire:click="pickerGoTo(@js($crumb['path']))" style="background:transparent;border:none;cursor:pointer;color:#fb923c;font-weight:600;padding:4px 8px;border-radius:6px;" onmouseover="this.style.backgroundColor='rgba(234,88,12,0.15)'" onmouseout="this.style.backgroundColor='transparent'">{{ $crumb['name'] }}</button>
+                            @endif
+                        @endforeach
+                    </div>
+                    <div style="display:flex;gap:8px;align-items:center;">
+                        <label style="background:#1f2937;color:#22d3ee;border:1px solid #22d3ee;padding:6px 12px;font-size:11px;font-weight:700;border-radius:6px;cursor:pointer;text-transform:uppercase;letter-spacing:0.5px;display:inline-block;">
+                            <input type="file" wire:model="pickerUploadFile" style="display:none;" />
+                            {{ $pickerUploadFile ? $pickerUploadFile->getClientOriginalName() : 'Choose file' }}
+                        </label>
+                        @if($pickerUploadFile)
+                            <button type="button" wire:click="pickerUploadHere" style="{{ $primaryBtn }}padding:6px 12px;font-size:11px;" onmouseover="{{ $primaryBtnHover }}" onmouseout="{{ $primaryBtnOut }}">Upload here</button>
+                        @endif
+                    </div>
+                </div>
+
+                {{-- Listing --}}
+                <div style="overflow-y:auto;flex:1;">
+                    <table style="width:100%;border-collapse:collapse;font-size:13px;">
+                        <tbody>
+                            @if($pickerPath !== '')
+                                <tr style="border-top:1px solid #27272a;transition:background-color 120ms;cursor:pointer;"
+                                    onmouseover="this.style.backgroundColor='rgba(234,88,12,0.08)'"
+                                    onmouseout="this.style.backgroundColor='transparent'"
+                                    wire:click="pickerGoUp">
+                                    <td style="padding:8px 16px;width:32px;">
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:18px;height:18px;color:#71717a;">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+                                        </svg>
+                                    </td>
+                                    <td style="padding:8px 16px;color:#fb923c;font-weight:600;">..</td>
+                                    <td></td>
+                                </tr>
+                            @endif
+
+                            @foreach($pl['dirs'] as $dir)
+                                <tr style="border-top:1px solid #27272a;transition:background-color 120ms;cursor:pointer;"
+                                    onmouseover="this.style.backgroundColor='rgba(234,88,12,0.08)'"
+                                    onmouseout="this.style.backgroundColor='transparent'"
+                                    wire:click="pickerEnterDir(@js($dir['name']))">
+                                    <td style="padding:8px 16px;width:32px;">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="width:20px;height:20px;color:#fb923c;">
+                                            <path d="M19.5 21a3 3 0 0 0 3-3v-4.5a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3V18a3 3 0 0 0 3 3h15ZM1.5 10.146V6a3 3 0 0 1 3-3h5.379a2.25 2.25 0 0 1 1.59.659l2.122 2.121c.14.141.331.22.53.22H19.5a3 3 0 0 1 3 3v1.146A4.483 4.483 0 0 0 19.5 9h-15a4.483 4.483 0 0 0-3 1.146Z" />
+                                        </svg>
+                                    </td>
+                                    <td style="padding:8px 16px;color:#fb923c;font-weight:600;">{{ $dir['name'] }}</td>
+                                    <td></td>
+                                </tr>
+                            @endforeach
+
+                            @foreach($pl['files'] as $file)
+                                <tr style="border-top:1px solid #27272a;transition:background-color 120ms;cursor:pointer;"
+                                    onmouseover="this.style.backgroundColor='rgba(34,211,238,0.10)'"
+                                    onmouseout="this.style.backgroundColor='transparent'"
+                                    wire:click="pickerSelectFile(@js($file['path']))">
+                                    <td style="padding:8px 16px;width:32px;">
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:18px;height:18px;color:#22d3ee;">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                                        </svg>
+                                    </td>
+                                    <td style="padding:8px 16px;color:#fafafa;font-weight:500;">{{ $file['name'] }}</td>
+                                    <td style="padding:8px 16px;color:#71717a;font-size:11px;text-align:right;font-variant-numeric:tabular-nums;">{{ $this->formatBytes($file['size']) }}</td>
+                                </tr>
+                            @endforeach
+
+                            @if(empty($pl['dirs']) && empty($pl['files']) && $pickerPath === '')
+                                <tr>
+                                    <td colspan="3" style="padding:32px 16px;text-align:center;color:#71717a;">Empty.</td>
+                                </tr>
+                            @endif
+                        </tbody>
+                    </table>
+                </div>
+
+                <div style="padding:10px 16px;border-top:1px solid #27272a;color:#71717a;font-size:11px;">
+                    Click on a <strong style="color:#22d3ee;">file</strong> to use its URL. Click on a <strong style="color:#fb923c;">folder</strong> to navigate.
+                </div>
+            </div>
+        </div>
+    @endif
+</x-filament-panels::page>

--- a/resources/views/filament/pages/storage-browser.blade.php
+++ b/resources/views/filament/pages/storage-browser.blade.php
@@ -1,0 +1,209 @@
+<x-filament-panels::page>
+    @php
+        $listing = $this->listing;
+        $crumbs = $this->breadcrumbs;
+        $atRoot = $this->currentPath === '';
+        $rowBase = 'background:transparent;transition:background-color 120ms ease;';
+        $rowHover = "this.style.backgroundColor='rgba(234,88,12,0.10)'";
+        $rowOut = "this.style.backgroundColor='transparent'";
+        $iconBtnBase = 'background:transparent;border:none;cursor:pointer;padding:6px 8px;border-radius:6px;color:#9ca3af;transition:all 120ms;';
+        $iconBtnHover = "this.style.backgroundColor='rgba(255,255,255,0.08)';this.style.color='#fff'";
+        $iconBtnOut = "this.style.backgroundColor='transparent';this.style.color='#9ca3af'";
+        $deleteBtnBase = 'background:transparent;border:none;cursor:pointer;padding:6px 8px;border-radius:6px;color:#ef4444;transition:all 120ms;';
+        $deleteBtnHover = "this.style.backgroundColor='rgba(239,68,68,0.15)';this.style.color='#fca5a5'";
+        $deleteBtnOut = "this.style.backgroundColor='transparent';this.style.color='#ef4444'";
+        $crumbBtn = 'background:transparent;border:none;cursor:pointer;padding:4px 8px;border-radius:6px;color:#fb923c;font-weight:600;font-size:13px;transition:background-color 120ms;';
+    @endphp
+
+    {{-- Breadcrumb --}}
+    <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;padding:10px 14px;">
+        <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;font-size:13px;">
+            <button
+                type="button"
+                wire:click="goRoot"
+                style="background:transparent;border:none;cursor:pointer;padding:4px 8px;border-radius:6px;color:#fb923c;font-weight:700;display:flex;align-items:center;gap:4px;transition:background-color 120ms;"
+                onmouseover="this.style.backgroundColor='rgba(234,88,12,0.15)'"
+                onmouseout="this.style.backgroundColor='transparent'"
+                title="Go to root"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+                </svg>
+                <span>/</span>
+            </button>
+
+            @foreach ($crumbs as $i => $crumb)
+                <span style="color:#52525b;">/</span>
+                @if ($i === count($crumbs) - 1)
+                    <span style="color:#fafafa;font-weight:700;padding:4px 8px;">{{ $crumb['name'] }}</span>
+                @else
+                    <button
+                        type="button"
+                        wire:click="goTo(@js($crumb['path']))"
+                        style="{{ $crumbBtn }}"
+                        onmouseover="this.style.backgroundColor='rgba(234,88,12,0.15)'"
+                        onmouseout="this.style.backgroundColor='transparent'"
+                    >{{ $crumb['name'] }}</button>
+                @endif
+            @endforeach
+
+            <span style="margin-left:auto;color:#71717a;font-size:11px;">
+                {{ count($listing['dirs']) }} folder(s) &middot; {{ count($listing['files']) }} file(s)
+            </span>
+        </div>
+    </div>
+
+    {{-- Listing --}}
+    <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;overflow:hidden;margin-top:14px;">
+        <table style="width:100%;border-collapse:collapse;font-size:13px;">
+            <thead>
+                <tr style="background:#18181b;">
+                    <th style="text-align:left;padding:10px 14px;width:32px;"></th>
+                    <th style="text-align:left;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Name</th>
+                    <th style="text-align:right;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;width:120px;">Size</th>
+                    <th style="text-align:right;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;width:170px;">Modified</th>
+                    <th style="text-align:right;padding:10px 14px;color:#a1a1aa;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;width:200px;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (! $atRoot)
+                    <tr style="{{ $rowBase }}border-top:1px solid #27272a;"
+                        onmouseover="{{ $rowHover }}"
+                        onmouseout="{{ $rowOut }}">
+                        <td style="padding:8px 14px;">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:18px;height:18px;color:#71717a;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+                            </svg>
+                        </td>
+                        <td style="padding:8px 14px;">
+                            <button
+                                type="button"
+                                wire:click="goUp"
+                                style="background:transparent;border:none;cursor:pointer;padding:0;color:#fb923c;font-weight:600;font-size:14px;text-decoration:none;"
+                                onmouseover="this.style.textDecoration='underline'"
+                                onmouseout="this.style.textDecoration='none'"
+                            >..</button>
+                        </td>
+                        <td colspan="3"></td>
+                    </tr>
+                @endif
+
+                @forelse ($listing['dirs'] as $dir)
+                    <tr style="{{ $rowBase }}border-top:1px solid #27272a;"
+                        onmouseover="{{ $rowHover }}"
+                        onmouseout="{{ $rowOut }}">
+                        <td style="padding:8px 14px;">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="width:20px;height:20px;color:#fb923c;">
+                                <path d="M19.5 21a3 3 0 0 0 3-3v-4.5a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3V18a3 3 0 0 0 3 3h15ZM1.5 10.146V6a3 3 0 0 1 3-3h5.379a2.25 2.25 0 0 1 1.59.659l2.122 2.121c.14.141.331.22.53.22H19.5a3 3 0 0 1 3 3v1.146A4.483 4.483 0 0 0 19.5 9h-15a4.483 4.483 0 0 0-3 1.146Z" />
+                            </svg>
+                        </td>
+                        <td style="padding:8px 14px;">
+                            <button
+                                type="button"
+                                wire:click="enterDir(@js($dir['name']))"
+                                style="background:transparent;border:none;cursor:pointer;padding:0;color:#fb923c;font-weight:600;font-size:14px;text-align:left;"
+                                onmouseover="this.style.textDecoration='underline'"
+                                onmouseout="this.style.textDecoration='none'"
+                            >{{ $dir['name'] }}</button>
+                        </td>
+                        <td style="padding:8px 14px;text-align:right;color:#52525b;">&mdash;</td>
+                        <td style="padding:8px 14px;text-align:right;color:#52525b;">&mdash;</td>
+                        <td style="padding:8px 14px;">
+                            <div style="display:flex;justify-content:flex-end;gap:4px;">
+                                <button type="button"
+                                    wire:click="mountAction('rename', @js(['oldName' => $dir['name']]))"
+                                    style="{{ $iconBtnBase }}"
+                                    onmouseover="{{ $iconBtnHover }}"
+                                    onmouseout="{{ $iconBtnOut }}"
+                                    title="Rename">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                                    </svg>
+                                </button>
+                                <button type="button"
+                                    wire:click="mountAction('delete', @js(['name' => $dir['name'], 'type' => 'dir']))"
+                                    style="{{ $deleteBtnBase }}"
+                                    onmouseover="{{ $deleteBtnHover }}"
+                                    onmouseout="{{ $deleteBtnOut }}"
+                                    title="Delete">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                    </svg>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    @if (empty($listing['files']))
+                        <tr>
+                            <td colspan="5" style="padding:32px 14px;text-align:center;color:#71717a;border-top:1px solid #27272a;">
+                                Empty folder. Use <strong style="color:#fb923c;">Upload files</strong> or <strong style="color:#fb923c;">New folder</strong> above.
+                            </td>
+                        </tr>
+                    @endif
+                @endforelse
+
+                @foreach ($listing['files'] as $file)
+                    <tr style="{{ $rowBase }}border-top:1px solid #27272a;"
+                        onmouseover="{{ $rowHover }}"
+                        onmouseout="{{ $rowOut }}">
+                        <td style="padding:8px 14px;">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:18px;height:18px;color:#22d3ee;">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                            </svg>
+                        </td>
+                        <td style="padding:8px 14px;">
+                            <span style="color:#fafafa;font-weight:500;font-size:14px;">{{ $file['name'] }}</span>
+                        </td>
+                        <td style="padding:8px 14px;text-align:right;color:#a1a1aa;font-variant-numeric:tabular-nums;font-size:12px;">
+                            {{ $this->formatBytes($file['size']) }}
+                        </td>
+                        <td style="padding:8px 14px;text-align:right;color:#71717a;font-variant-numeric:tabular-nums;font-size:11px;">
+                            @if ($file['mtime'])
+                                {{ \Carbon\Carbon::createFromTimestamp($file['mtime'])->format('Y-m-d H:i') }}
+                            @else
+                                &mdash;
+                            @endif
+                        </td>
+                        <td style="padding:8px 14px;">
+                            <div style="display:flex;justify-content:flex-end;gap:4px;">
+                                <button type="button"
+                                    wire:click="downloadFile(@js($file['name']))"
+                                    style="{{ $iconBtnBase }}"
+                                    onmouseover="{{ $iconBtnHover }}"
+                                    onmouseout="{{ $iconBtnOut }}"
+                                    title="Download">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                                    </svg>
+                                </button>
+                                <button type="button"
+                                    wire:click="mountAction('rename', @js(['oldName' => $file['name']]))"
+                                    style="{{ $iconBtnBase }}"
+                                    onmouseover="{{ $iconBtnHover }}"
+                                    onmouseout="{{ $iconBtnOut }}"
+                                    title="Rename">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                                    </svg>
+                                </button>
+                                <button type="button"
+                                    wire:click="mountAction('delete', @js(['name' => $file['name'], 'type' => 'file']))"
+                                    style="{{ $deleteBtnBase }}"
+                                    onmouseover="{{ $deleteBtnHover }}"
+                                    onmouseout="{{ $deleteBtnOut }}"
+                                    title="Delete">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:16px;height:16px;">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                    </svg>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    <x-filament-actions::modals />
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- New **Storage Browser** Filament page - browse, upload, download, rename, mkdir, delete files on the file storage straight from admin
- New **Bundles Manager** page replacing split Bundle / BundleCategory resources with one tree UI (categories sidebar + bundles main panel)
- Embedded file picker in bundle form auto-fills the URL when you click a file
- Drag-and-drop reorder for both categories and bundles (new `position` column, backfilled by id ASC)
- Old resources hidden from nav but kept registered as rollback hatch
