### PR TITLE
SFTP-credential auto-mirror into servers + Demome queue video metadata

### DIFF
--- a/app/Filament/Pages/BundlesManager.php
+++ b/app/Filament/Pages/BundlesManager.php
@@ -416,6 +416,9 @@ class BundlesManager extends Page
             fclose($stream);
         }
 
+        // Drop the Livewire temp file immediately rather than waiting 24h
+        // for the cleanup job to sweep it.
+        $this->pickerUploadFile->delete();
         $this->pickerUploadFile = null;
         unset($this->pickerListing);
 

--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -85,6 +85,9 @@ class DemomeController extends Controller
                     'source' => $item->source,
                     'record_id' => $item->record_id,
                     'map_page_url' => 'https://defrag.racing/maps/' . $item->map_name,
+                    'video_title' => \App\Services\VideoMetadataService::generateTitle($item),
+                    'video_description' => \App\Services\VideoMetadataService::generateDescription($item),
+                    'video_tags' => \App\Services\VideoMetadataService::generateTags($item),
                 ];
             });
 

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -39,7 +39,8 @@ class Server extends Model
         'besttime_name',
         'besttime_url',
         'besttime_time',
-        'plain_name'
+        'plain_name',
+        'sftp_credential_id',
     ];
 
     public function mapdata () {
@@ -48,5 +49,10 @@ class Server extends Model
 
     public function onlinePlayers () {
         return $this->hasMany(OnlinePlayer::class)->orderByRaw('CASE WHEN time = 0 THEN 1 ELSE 0 END, time ASC');
+    }
+
+    public function sftpCredential()
+    {
+        return $this->belongsTo(SftpCredential::class);
     }
 }

--- a/app/Observers/SftpCredentialObserver.php
+++ b/app/Observers/SftpCredentialObserver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Server;
+use App\Models\SftpCredential;
+
+class SftpCredentialObserver
+{
+    /**
+     * Mirror the credential's declared servers into the `servers` table so
+     * ScrapeServers picks them up alongside legacy manually-added rows.
+     *
+     * Dedupes by (ip, port): if a Server already exists at that address it's
+     * linked and its rconpassword refreshed; otherwise a new Server row is
+     * created with placeholders that the scraper will overwrite on first run.
+     * Rows that disappear from the JSON are left in place — admin handles
+     * removal manually from the Filament panel.
+     */
+    public function saved(SftpCredential $credential): void
+    {
+        if ($credential->status !== 'active') return;
+
+        $declared = $credential->servers ?? [];
+        if (empty($declared)) return;
+
+        $owner = $credential->user;
+        $ownerName = $owner?->plain_name ?: ($owner?->name ?: 'unknown');
+        $ownerCountry = $owner?->country && $owner->country !== 'XX' ? $owner->country : '_404';
+
+        foreach ($declared as $entry) {
+            if (empty($entry['ip']) || empty($entry['port'])) continue;
+
+            $existing = Server::where('ip', $entry['ip'])
+                ->where('port', (int) $entry['port'])
+                ->first();
+
+            if ($existing) {
+                // Don't clobber scraper-managed fields on existing rows;
+                // just link to the credential and refresh the rcon password.
+                $existing->fill([
+                    'sftp_credential_id' => $credential->id,
+                    'rconpassword'       => $entry['rcon'] ?? $existing->rconpassword,
+                ])->save();
+                continue;
+            }
+
+            Server::create([
+                'ip'                 => $entry['ip'],
+                'port'               => (int) $entry['port'],
+                'sftp_credential_id' => $credential->id,
+                'rconpassword'       => $entry['rcon'] ?? null,
+                'name'               => 'Pending scrape',
+                'plain_name'         => 'Pending scrape',
+                'location'           => $ownerCountry,
+                'type'               => $entry['gametype'] ?? 'mixed',
+                'admin_name'         => $ownerName,
+                'map'                => '',
+                'defrag'             => '',
+                'besttime_country'   => '_404',
+                'besttime_name'      => null,
+                'besttime_url'       => '',
+                'besttime_time'      => 0,
+                'visible'            => true,
+                'online'             => false,
+            ]);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 
+use App\Models\SftpCredential;
+use App\Observers\SftpCredentialObserver;
 use Filament\Support\Assets\Css;
 use Filament\Support\Facades\FilamentAsset;
 
@@ -25,5 +27,7 @@ class AppServiceProvider extends ServiceProvider
         FilamentAsset::register([
             Css::make('q3-stylesheet', __DIR__ . '/../../resources/css/items.css'),
         ]);
+
+        SftpCredential::observe(SftpCredentialObserver::class);
     }
 }

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,165 @@
+<?php
+
+return [
+
+    /*
+    |---------------------------------------------------------------------------
+    | Class Namespace
+    |---------------------------------------------------------------------------
+    |
+    | This value sets the root class namespace for Livewire component classes in
+    | your application. This value will change where component auto-discovery
+    | finds components. It's also referenced by the file creation commands.
+    |
+    */
+
+    'class_namespace' => 'App\\Livewire',
+
+    /*
+    |---------------------------------------------------------------------------
+    | View Path
+    |---------------------------------------------------------------------------
+    |
+    | This value is used to specify where Livewire component Blade templates are
+    | stored when running file creation commands like `artisan make:livewire`.
+    | It is also used if you choose to omit a component's render() method.
+    |
+    */
+
+    'view_path' => resource_path('views/livewire'),
+
+    /*
+    |---------------------------------------------------------------------------
+    | Layout
+    |---------------------------------------------------------------------------
+    | The view that will be used as the layout when rendering a single component
+    | as an entire page via `Route::get('/post/create', CreatePost::class);`.
+    | In this case, the view returned by CreatePost will render into $slot.
+    |
+    */
+
+    'layout' => 'components.layouts.app',
+
+    /*
+    |---------------------------------------------------------------------------
+    | Lazy Loading Placeholder
+    |---------------------------------------------------------------------------
+    | Livewire allows you to lazy load components that would otherwise slow down
+    | the initial page load. Every component can have a custom placeholder or
+    | you can define the default placeholder view for all components below.
+    |
+    */
+
+    'lazy_placeholder' => null,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Temporary File Uploads
+    |---------------------------------------------------------------------------
+    |
+    | Livewire handles file uploads by storing uploads in a temporary directory
+    | before the file is stored permanently. All file uploads are directed to
+    | a global endpoint for temporary storage. You may configure this below:
+    |
+    */
+
+    'temporary_file_upload' => [
+        // Force local temp disk so Filament FileUpload (which uses Livewire
+        // temp upload) doesn't try to push pre-signed direct-to-S3 uploads
+        // from the browser. Backblaze CORS isn't set up for that pattern.
+        // Demo upload is unaffected — it uses a separate FormData POST
+        // through Laravel, not Livewire.
+        'disk' => 'local',     // Example: 'local', 's3'              | Default: 'default'
+        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  | Default: ['required', 'file', 'max:12288'] (12MB)
+        'directory' => null,   // Example: 'tmp'                      | Default: 'livewire-tmp'
+        'middleware' => null,  // Example: 'throttle:5,1'             | Default: 'throttle:60,1'
+        'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs...
+            'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',
+            'mov', 'avi', 'wmv', 'mp3', 'm4a',
+            'jpg', 'jpeg', 'mpga', 'webp', 'wma',
+        ],
+        'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
+        'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | Render On Redirect
+    |---------------------------------------------------------------------------
+    |
+    | This value determines if Livewire will run a component's `render()` method
+    | after a redirect has been triggered using something like `redirect(...)`
+    | Setting this to true will render the view once more before redirecting
+    |
+    */
+
+    'render_on_redirect' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Eloquent Model Binding
+    |---------------------------------------------------------------------------
+    |
+    | Previous versions of Livewire supported binding directly to eloquent model
+    | properties using wire:model by default. However, this behavior has been
+    | deemed too "magical" and has therefore been put under a feature flag.
+    |
+    */
+
+    'legacy_model_binding' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Auto-inject Frontend Assets
+    |---------------------------------------------------------------------------
+    |
+    | By default, Livewire automatically injects its JavaScript and CSS into the
+    | <head> and <body> of pages containing Livewire components. By disabling
+    | this behavior, you need to use @livewireStyles and @livewireScripts.
+    |
+    */
+
+    'inject_assets' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Navigate (SPA mode)
+    |---------------------------------------------------------------------------
+    |
+    | By adding `wire:navigate` to links in your Livewire application, Livewire
+    | will prevent the default link handling and instead request those pages
+    | via AJAX, creating an SPA-like effect. Configure this behavior here.
+    |
+    */
+
+    'navigate' => [
+        'show_progress_bar' => true,
+        'progress_bar_color' => '#2299dd',
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | HTML Morph Markers
+    |---------------------------------------------------------------------------
+    |
+    | Livewire intelligently "morphs" existing HTML into the newly rendered HTML
+    | after each update. To make this process more reliable, Livewire injects
+    | "markers" into the rendered Blade surrounding @if, @class & @foreach.
+    |
+    */
+
+    'inject_morph_markers' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Pagination Theme
+    |---------------------------------------------------------------------------
+    |
+    | When enabling Livewire's pagination feature by using the `WithPagination`
+    | trait, Livewire will use Tailwind templates to render pagination views
+    | on the page. If you want Bootstrap CSS, you can specify: "bootstrap"
+    |
+    */
+
+    'pagination_theme' => 'tailwind',
+];

--- a/database/migrations/2026_05_13_000001_add_sftp_credential_id_to_servers_table.php
+++ b/database/migrations/2026_05_13_000001_add_sftp_credential_id_to_servers_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            // Set when a Server row is owned by an approved SftpCredential.
+            // NULL = legacy manually-added entry. Lets the Filament panel
+            // distinguish source and lets the observer find existing rows
+            // to update instead of duplicating on (ip, port) collision.
+            $table->foreignId('sftp_credential_id')
+                ->nullable()
+                ->after('rconpassword')
+                ->constrained('sftp_credentials')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('sftp_credential_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Observer on `SftpCredential::saved` mirrors each server declared in the credential JSON into the legacy `servers` table, so ScrapeServers picks them up alongside manually-added rows — admin no longer needs to touch defraghq/servers, server owners drive everything via `/server-hosting`.
- Dedupe by (ip, port): existing row gets linked (sets `sftp_credential_id`, refreshes `rconpassword`) without clobbering scraper-managed fields (`name`, `map`, `online`, `besttime_*`). New row gets placeholder fields (admin_name from owner profile, location from owner country) so NOT NULL constraints pass; scraper overwrites on first run.
- Migration adds nullable `sftp_credential_id` FK with `nullOnDelete` so revoking a credential leaves the Server row + its `online_players` history intact.
- Scraper priority unchanged: rcon → getdfstatus → getstatus → q3df.org fallback. SFTP-managed servers get rconpassword from JSON, so they take the same path as legacy rows.
- Demome queue endpoint now returns `video_title` / `video_description` / `video_tags` via `VideoMetadataService` so consumers don't have to format them client-side.

## Test plan

- [ ] Approve a new server-hosting application → Server row auto-created with `sftp_credential_id` set, scraper picks it up next minute
- [ ] Edit credential's JSON to add a server at an ip:port that already has a legacy Server row → row gets linked, no duplicate, scraped fields preserved
- [ ] `php artisan scrape:servers` runs without changes; auto-synced rows show up in /servers page like any other
- [ ] Hit Demome queue endpoint and check that `video_title`, `video_description`, `video_tags` are populated