### PR TITLE
Per-server location on hosting credentials + DNS-resolving scraper

### DIFF
--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -14,6 +14,14 @@ class DefragServer
     private $previousData;
 
     public function __construct ($ip, $port) {
+        // socket_connect/socket_sendto on AF_INET need a numeric IPv4 — they
+        // don't resolve hostnames themselves, so credentials that declare a
+        // server by FQDN (e.g. "deimos.baseq.fr") silently never connect.
+        // Resolve once up front; on failure gethostbyname returns the input
+        // unchanged, which lets the socket call fail loudly as it would.
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+            $ip = gethostbyname($ip);
+        }
         $this->ip = $ip;
         $this->port = $port;
         $this->socket = socket_create(AF_INET, SOCK_DGRAM, 0);

--- a/app/Filament/Resources/SftpCredentialResource.php
+++ b/app/Filament/Resources/SftpCredentialResource.php
@@ -108,7 +108,14 @@ class SftpCredentialResource extends Resource
                                     ->columnSpan(2),
                                 \Filament\Forms\Components\TextInput::make('rcon')
                                     ->required()
-                                    ->columnSpan(3),
+                                    ->columnSpan(2),
+                                \Filament\Forms\Components\TextInput::make('location')
+                                    ->label('Country (ISO-2)')
+                                    ->placeholder('US')
+                                    ->maxLength(2)
+                                    ->extraInputAttributes(['style' => 'text-transform:uppercase'])
+                                    ->dehydrateStateUsing(fn ($state) => $state ? strtoupper($state) : null)
+                                    ->columnSpan(1),
                                 \Filament\Forms\Components\TextInput::make('rs_code')
                                     ->label('RS code')
                                     ->placeholder('e.g. 4711')

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -118,6 +118,7 @@ class ServerHostingController extends Controller
             'servers.*.ip'            => ['required', 'string', 'max:255'],
             'servers.*.port'          => ['required', 'integer', 'between:1,65535'],
             'servers.*.rcon'          => ['required', 'string', 'max:255'],
+            'servers.*.location'      => ['nullable', 'string', 'size:2', 'alpha'],
         ]);
 
         $user = $request->user();

--- a/app/Observers/SftpCredentialObserver.php
+++ b/app/Observers/SftpCredentialObserver.php
@@ -35,12 +35,19 @@ class SftpCredentialObserver
                 ->where('port', (int) $entry['port'])
                 ->first();
 
+            // Per-server location (set by owner in /server-hosting form or
+            // by admin in Filament). Falls back to owner profile country
+            // when blank — at least gives a flag instead of "_404".
+            $entryLocation = !empty($entry['location']) ? strtoupper($entry['location']) : $ownerCountry;
+
             if ($existing) {
                 // Don't clobber scraper-managed fields on existing rows;
-                // just link to the credential and refresh the rcon password.
+                // just link to the credential, refresh the rcon password,
+                // and propagate location updates (admin/owner can change it).
                 $existing->fill([
                     'sftp_credential_id' => $credential->id,
                     'rconpassword'       => $entry['rcon'] ?? $existing->rconpassword,
+                    'location'           => $entryLocation,
                 ])->save();
                 continue;
             }
@@ -52,7 +59,7 @@ class SftpCredentialObserver
                 'rconpassword'       => $entry['rcon'] ?? null,
                 'name'               => 'Pending scrape',
                 'plain_name'         => 'Pending scrape',
-                'location'           => $ownerCountry,
+                'location'           => $entryLocation,
                 'type'               => $entry['gametype'] ?? 'mixed',
                 'admin_name'         => $ownerName,
                 'map'                => '',

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -119,6 +119,7 @@ const blankServer = () => ({
     ip: '',
     port: 27960,
     rcon: '',
+    location: '',
 });
 
 const form = useForm({
@@ -282,6 +283,7 @@ const gametypeLabel = (value) => GAMETYPES.find(g => g.value === value)?.label ?
                             <tr>
                                 <th class="px-3 py-2 text-left">Gametype</th>
                                 <th class="px-3 py-2 text-left">IP : Port</th>
+                                <th class="px-3 py-2 text-left">Location</th>
                                 <th class="px-3 py-2 text-left">RS code</th>
                             </tr>
                         </thead>
@@ -289,6 +291,13 @@ const gametypeLabel = (value) => GAMETYPES.find(g => g.value === value)?.label ?
                             <tr v-for="(s, i) in credential.servers" :key="i">
                                 <td class="px-3 py-2 font-medium text-emerald-200/80">{{ (s.gametype || '').toUpperCase() }}</td>
                                 <td class="px-3 py-2 font-mono text-gray-300">{{ s.ip }}:{{ s.port }}</td>
+                                <td class="px-3 py-2 font-mono text-gray-300">
+                                    <span v-if="s.location" class="inline-flex items-center gap-1.5">
+                                        <img :src="`/images/flags/${s.location}.png`" class="w-4 h-3 rounded shadow-sm" :alt="s.location" onerror="this.style.display='none'">
+                                        {{ s.location }}
+                                    </span>
+                                    <span v-else class="text-gray-500 italic">not set</span>
+                                </td>
                                 <td class="px-3 py-2 font-mono">
                                     <span v-if="s.rs_code" class="text-emerald-200">{{ s.rs_code }}</span>
                                     <span v-else class="text-gray-500 italic">awaiting admin</span>
@@ -396,7 +405,7 @@ DEMO_SFTP_REMOTEDIR={{ credential.remote_path }}</code></pre>
                     <div class="space-y-2">
                         <div v-for="(s, i) in form.servers" :key="i"
                              class="grid grid-cols-12 gap-2 items-start">
-                            <div class="col-span-3">
+                            <div class="col-span-2">
                                 <select v-model="s.gametype"
                                         class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
                                                bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
@@ -406,7 +415,7 @@ DEMO_SFTP_REMOTEDIR={{ credential.remote_path }}</code></pre>
                                 </select>
                                 <p v-if="form.errors[`servers.${i}.gametype`]" class="text-xs text-red-400 mt-1">{{ form.errors[`servers.${i}.gametype`] }}</p>
                             </div>
-                            <div class="col-span-4">
+                            <div class="col-span-3">
                                 <input v-model="s.ip"
                                        type="text"
                                        placeholder="123.45.67.89"
@@ -427,6 +436,15 @@ DEMO_SFTP_REMOTEDIR={{ credential.remote_path }}</code></pre>
                                        placeholder="rcon"
                                        class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
                                 <p v-if="form.errors[`servers.${i}.rcon`]" class="text-xs text-red-400 mt-1">{{ form.errors[`servers.${i}.rcon`] }}</p>
+                            </div>
+                            <div class="col-span-2">
+                                <input v-model="s.location"
+                                       type="text"
+                                       maxlength="2"
+                                       placeholder="US"
+                                       @input="s.location = (s.location || '').toUpperCase()"
+                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono uppercase focus:border-blue-500 focus:ring-0 transition" />
+                                <p v-if="form.errors[`servers.${i}.location`]" class="text-xs text-red-400 mt-1">{{ form.errors[`servers.${i}.location`] }}</p>
                             </div>
                             <div class="col-span-1 flex justify-end">
                                 <button type="button"


### PR DESCRIPTION
## Summary

- Owners can now pick a per-server country flag in `/server-hosting` (2-letter ISO, uppercased on input).
- Admin can edit the same field in the SftpCredential "Manage Servers" modal.
- Observer propagates `location` into `Server.location` on every credential save — including existing rows, so fixing a wrong flag in Filament reflects on `/servers` immediately.
- Falls back to owner's profile country when blank (old behaviour preserved, existing credentials keep working without edits).
- Scraper now resolves DNS hostnames before opening the AF_INET UDP socket: `socket_connect` / `socket_sendto` don't accept FQDNs themselves, so credentials declaring a server by hostname (e.g. `deimos.baseq.fr`) were silently never reachable. `gethostbyname()` up front fixes it; numeric IPs short-circuit via `filter_var` so behaviour is unchanged for them.

## Test plan

- [ ] Submit a new `/server-hosting` application with `Location=US` set → form posts, application stored with location
- [ ] In Filament SftpCredentials → "Servers" modal: edit a row's `Country (ISO-2)` → save → corresponding Server row's `location` reflects the change
- [ ] Re-save existing credentials (`$cred->save()` in tinker) → no errors, location stays empty/owner-country for rows without `location` in JSON
- [ ] `php artisan scrape:servers 1` on production → `deimos.baseq.fr:*` rows turn `online=true` with hostname populated
- [ ] `/servers` page renders correct flag per auto-synced server