### PR TITLE
Country dropdown & add-server flow; Demome filter on re-uploads

### DIFF
--- a/app/Filament/Resources/ServerResource.php
+++ b/app/Filament/Resources/ServerResource.php
@@ -50,9 +50,13 @@ class ServerResource extends Resource
                 TextInput::make('port')
                     ->required()
                     ->numeric(),
-                TextInput::make('location')
+                Select::make('location')
+                    ->label('Country (ISO-2)')
                     ->required()
-                    ->maxLength(255),
+                    ->options(\App\Support\Countries::options())
+                    ->searchable()
+                    ->native(false)
+                    ->helperText('Drives the flag icon shown next to the server.'),
                 Select::make('type')
                     ->label('Server Type')
                     ->required()

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -47,6 +47,7 @@ class ServerHostingController extends Controller
                 ? $credential->only(['id', 'sftp_username', 'host', 'port', 'remote_path', 'status', 'servers'])
                 : null,
             'pendingPassword' => $pendingPassword,
+            'countries'       => \App\Support\Countries::options(),
         ]);
     }
 
@@ -118,7 +119,7 @@ class ServerHostingController extends Controller
             'servers.*.ip'            => ['required', 'string', 'max:255'],
             'servers.*.port'          => ['required', 'integer', 'between:1,65535'],
             'servers.*.rcon'          => ['required', 'string', 'max:255'],
-            'servers.*.location'      => ['nullable', 'string', 'size:2', 'alpha'],
+            'servers.*.location'      => ['nullable', 'string', 'size:2', 'alpha', \Illuminate\Validation\Rule::in(\App\Support\Countries::CODES)],
         ]);
 
         $user = $request->user();
@@ -148,5 +149,67 @@ class ServerHostingController extends Controller
         ]);
 
         return back()->with('success', 'Application submitted. Admins will review it shortly.');
+    }
+
+    /**
+     * Append a new server entry to an already-approved user's credential.
+     * Does NOT touch SFTP provisioning — the user reuses their existing
+     * account on the storage VPS. Only the per-server metadata
+     * (gametype/ip/port/rcon/location) grows. rs_code is left null and
+     * admins fill it in from Filament after light review.
+     */
+    public function addServer(Request $request)
+    {
+        $request->validate([
+            'gametype' => ['required', 'string', 'in:mixed,cpm,vq3,teamruns,fastcaps,freestyle'],
+            'ip'       => ['required', 'string', 'max:255'],
+            'port'     => ['required', 'integer', 'between:1,65535'],
+            'rcon'     => ['required', 'string', 'max:255'],
+            'location' => ['nullable', 'string', 'size:2', 'alpha', \Illuminate\Validation\Rule::in(\App\Support\Countries::CODES)],
+        ]);
+
+        $user = $request->user();
+
+        $credential = SftpCredential::where('user_id', $user->id)
+            ->active()
+            ->latest()
+            ->first();
+
+        if (!$credential) {
+            return back()->with('danger', 'No active credential — you must be an approved server owner to add servers.');
+        }
+
+        $rateKey = 'sftp-add-server:' . $user->id;
+        if (RateLimiter::tooManyAttempts($rateKey, 10)) {
+            $retry = RateLimiter::availableIn($rateKey);
+            return back()->with('danger', "Too many additions. Try again in {$retry} seconds.");
+        }
+        RateLimiter::hit($rateKey, 3600);
+
+        $servers = $credential->servers ?? [];
+
+        $ip   = trim($request->input('ip'));
+        $port = (int) $request->input('port');
+
+        foreach ($servers as $existing) {
+            if (($existing['ip'] ?? null) === $ip && (int) ($existing['port'] ?? 0) === $port) {
+                return back()->withErrors([
+                    'ip' => "You already have a server registered at {$ip}:{$port}.",
+                ]);
+            }
+        }
+
+        $servers[] = [
+            'gametype' => $request->input('gametype'),
+            'ip'       => $ip,
+            'port'     => $port,
+            'rcon'     => $request->input('rcon'),
+            'location' => $request->input('location'),
+            'rs_code'  => null,
+        ];
+
+        $credential->update(['servers' => $servers]);
+
+        return back()->with('success', 'Server added. Admin will assign an RS code shortly.');
     }
 }

--- a/app/Support/Countries.php
+++ b/app/Support/Countries.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+class Countries
+{
+    /**
+     * ISO-2 codes for which we ship a flag PNG in /public/images/flags.
+     * Source of truth — keep this list aligned with the flag assets so
+     * the dropdown can't offer a code whose flag image would 404.
+     */
+    public const CODES = [
+        'AD','AE','AF','AG','AL','AM','AR','AT','AU','AZ',
+        'BA','BB','BD','BE','BF','BG','BH','BI','BJ','BN',
+        'BO','BR','BS','BT','BW','BY','BZ','CA','CD','CF',
+        'CG','CH','CI','CL','CM','CN','CO','CR','CU','CV',
+        'CY','CZ','DE','DJ','DK','DM','DO','DZ','EC','EE',
+        'EG','ER','ES','ET','EU','FI','FJ','FM','FR','GA',
+        'GB','GD','GE','GH','GM','GN','GQ','GR','GT','GW',
+        'GY','HK','HN','HR','HT','HU','ID','IE','IL','IN',
+        'IQ','IR','IS','IT','JM','JO','JP','KE','KG','KH',
+        'KI','KM','KN','KP','KR','KW','KY','KZ','LA','LB',
+        'LC','LI','LK','LR','LS','LT','LU','LV','LY','MA',
+        'MC','MD','ME','MG','MH','MK','ML','MM','MN','MR',
+        'MT','MU','MV','MW','MX','MY','MZ','NA','NE','NG',
+        'NI','NL','NO','NP','NR','NZ','OM','PA','PE','PG',
+        'PH','PK','PL','PR','PS','PT','PW','PY','QA','RO',
+        'RS','RU','RW','SA','SB','SC','SD','SE','SG','SI',
+        'SK','SL','SM','SN','SO','SR','SS','ST','SV','SY',
+        'SZ','TD','TG','TH','TJ','TL','TM','TN','TO','TR',
+        'TT','TV','TW','TZ','UA','UG','US','UY','UZ','VA',
+        'VC','VE','VN','VU','WS','XK','YE','ZA','ZM','ZW',
+    ];
+
+    /**
+     * Code => display-name map for use as Filament / select options.
+     * Names come from PHP intl (locale_get_display_region); cached per
+     * request because the lookup is cheap but the call site (form
+     * render) hits it 200x.
+     */
+    public static function options(): array
+    {
+        return Cache::store('array')->rememberForever('countries.options', function () {
+            $out = [];
+            foreach (self::CODES as $code) {
+                $name = function_exists('locale_get_display_region')
+                    ? locale_get_display_region('-' . $code, 'en')
+                    : $code;
+                $out[$code] = $name && $name !== $code ? "{$code} — {$name}" : $code;
+            }
+            asort($out, SORT_NATURAL);
+            return $out;
+        });
+    }
+
+    public static function isValid(?string $code): bool
+    {
+        return $code !== null && in_array(strtoupper($code), self::CODES, true);
+    }
+}

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -14,7 +14,14 @@ const props = defineProps({
     application: Object,
     credential: Object,
     pendingPassword: { type: String, default: null },
+    countries: { type: Object, default: () => ({}) },
 });
+
+// Backend ships countries as { "CZ": "CZ — Czechia", ... } already sorted.
+// Convert to an array of {code,label} for v-for stability.
+const countryOptions = computed(() =>
+    Object.entries(props.countries).map(([code, label]) => ({ code, label }))
+);
 
 const page = usePage();
 const successMsg = computed(() => page.props.success);
@@ -159,6 +166,40 @@ const submittedServerInfoString = computed(() => {
 });
 
 const gametypeLabel = (value) => GAMETYPES.find(g => g.value === value)?.label ?? value;
+
+// Add-server form (only shown when state === 'active'). Pre-fills IP from
+// the user's most-recent declared server so the common "another port on
+// the same box" case is one click — they only tweak port + gametype.
+const addServerOpen = ref(false);
+
+const existingIps = computed(() => {
+    const list = props.credential?.servers || [];
+    return [...new Set(list.map(s => s.ip).filter(Boolean))];
+});
+
+const addServerForm = useForm({
+    gametype: 'mixed',
+    ip: '',
+    port: 27960,
+    rcon: '',
+    location: '',
+});
+
+const openAddServer = () => {
+    addServerForm.reset();
+    addServerForm.ip = existingIps.value[0] ?? '';
+    addServerOpen.value = true;
+};
+
+const submitAddServer = () => {
+    addServerForm.post(route('server-hosting.add-server'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            addServerOpen.value = false;
+            addServerForm.reset();
+        },
+    });
+};
 </script>
 
 <template>
@@ -309,6 +350,88 @@ const gametypeLabel = (value) => GAMETYPES.find(g => g.value === value)?.label ?
                 <p class="text-xs text-gray-500 mt-2">
                     Put each RS code into <code>sv.conf</code> as <code>rs&lt;PORT&gt;=&lt;rs_code&gt;</code> (set <code>MDD_ENABLED=1</code> too).
                 </p>
+
+                <!-- Add another server (reuses existing SFTP credential) -->
+                <div class="mt-4">
+                    <button v-if="!addServerOpen"
+                            type="button"
+                            @click="openAddServer"
+                            class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 text-sm transition">
+                        <span class="text-base leading-none">+</span> Add another server
+                    </button>
+
+                    <form v-else
+                          @submit.prevent="submitAddServer"
+                          class="rounded-lg border border-emerald-500/20 bg-black/30 p-4 space-y-3">
+                        <div class="flex items-center justify-between">
+                            <h4 class="text-sm font-semibold text-emerald-200">Register another server</h4>
+                            <p class="text-xs text-gray-500">Reuses your existing SFTP credentials — no new password.</p>
+                        </div>
+
+                        <div class="grid grid-cols-12 gap-2 items-start">
+                            <div class="col-span-2">
+                                <label class="block text-xs text-gray-500 mb-1">Gametype</label>
+                                <select v-model="addServerForm.gametype"
+                                        class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
+                                               bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
+                                               bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
+                                    <option v-for="g in GAMETYPES" :key="g.value" :value="g.value"
+                                            class="bg-slate-900 text-gray-200">{{ g.label }}</option>
+                                </select>
+                            </div>
+                            <div class="col-span-3">
+                                <label class="block text-xs text-gray-500 mb-1">IP</label>
+                                <input v-model="addServerForm.ip"
+                                       :list="existingIps.length ? 'existing-ips' : null"
+                                       type="text" placeholder="123.45.67.89"
+                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
+                                <datalist v-if="existingIps.length" id="existing-ips">
+                                    <option v-for="ip in existingIps" :key="ip" :value="ip" />
+                                </datalist>
+                                <p v-if="addServerForm.errors.ip" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.ip }}</p>
+                            </div>
+                            <div class="col-span-2">
+                                <label class="block text-xs text-gray-500 mb-1">Port</label>
+                                <input v-model.number="addServerForm.port"
+                                       type="number" min="1" max="65535" placeholder="27960"
+                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
+                                <p v-if="addServerForm.errors.port" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.port }}</p>
+                            </div>
+                            <div class="col-span-2">
+                                <label class="block text-xs text-gray-500 mb-1">Rcon</label>
+                                <input v-model="addServerForm.rcon"
+                                       type="text" placeholder="rcon"
+                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
+                                <p v-if="addServerForm.errors.rcon" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.rcon }}</p>
+                            </div>
+                            <div class="col-span-3">
+                                <label class="block text-xs text-gray-500 mb-1">Country</label>
+                                <select v-model="addServerForm.location"
+                                        class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
+                                               bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
+                                               bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
+                                    <option value="" class="bg-slate-900 text-gray-400">— flag —</option>
+                                    <option v-for="c in countryOptions" :key="c.code" :value="c.code"
+                                            class="bg-slate-900 text-gray-200">{{ c.label }}</option>
+                                </select>
+                                <p v-if="addServerForm.errors.location" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.location }}</p>
+                            </div>
+                        </div>
+
+                        <div class="flex justify-end gap-2 pt-1">
+                            <button type="button"
+                                    @click="addServerOpen = false"
+                                    class="px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-gray-300 transition">
+                                Cancel
+                            </button>
+                            <button type="submit"
+                                    :disabled="addServerForm.processing"
+                                    class="px-3 py-1.5 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-500/30 text-xs text-emerald-200 transition disabled:opacity-50">
+                                {{ addServerForm.processing ? 'Adding…' : 'Add server' }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
             </div>
 
             <details class="mt-6 group">
@@ -438,12 +561,14 @@ DEMO_SFTP_REMOTEDIR={{ credential.remote_path }}</code></pre>
                                 <p v-if="form.errors[`servers.${i}.rcon`]" class="text-xs text-red-400 mt-1">{{ form.errors[`servers.${i}.rcon`] }}</p>
                             </div>
                             <div class="col-span-2">
-                                <input v-model="s.location"
-                                       type="text"
-                                       maxlength="2"
-                                       placeholder="US"
-                                       @input="s.location = (s.location || '').toUpperCase()"
-                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono uppercase focus:border-blue-500 focus:ring-0 transition" />
+                                <select v-model="s.location"
+                                        class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
+                                               bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
+                                               bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
+                                    <option value="" class="bg-slate-900 text-gray-400">— flag —</option>
+                                    <option v-for="c in countryOptions" :key="c.code" :value="c.code"
+                                            class="bg-slate-900 text-gray-200">{{ c.label }}</option>
+                                </select>
                                 <p v-if="form.errors[`servers.${i}.location`]" class="text-xs text-red-400 mt-1">{{ form.errors[`servers.${i}.location`] }}</p>
                             </div>
                             <div class="col-span-1 flex justify-end">

--- a/routes/web.php
+++ b/routes/web.php
@@ -298,6 +298,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/server-hosting/apply', [\App\Http\Controllers\ServerHostingController::class, 'apply'])->name('server-hosting.apply');
     Route::post('/server-hosting/acknowledge-password', [\App\Http\Controllers\ServerHostingController::class, 'acknowledgePassword'])->name('server-hosting.acknowledge-password');
     Route::post('/server-hosting/reset-password', [\App\Http\Controllers\ServerHostingController::class, 'resetPassword'])->name('server-hosting.reset-password');
+    Route::post('/server-hosting/add-server', [\App\Http\Controllers\ServerHostingController::class, 'addServer'])->name('server-hosting.add-server');
 });
 
 


### PR DESCRIPTION
## Summary
- ISO-2 country becomes a searchable dropdown in both the public server-hosting form and the Filament admin; backed by a single `Countries` helper sourced from the flag PNGs we actually ship (200 codes, names via PHP intl), validated server-side so unsupported codes can't be submitted
- Approved server owners can register additional servers directly from `/server-hosting` — appends to `credential.servers` with `rs_code` left null for admin to fill in from Filament, reuses the existing SFTP account (no new password, no provisioning call). IP datalist pre-fills from existing servers so "another port on the same box" is one click. Rate-limited 10/h per user; duplicate ip+port rejected
- Closes the upload_pending filter gap on Demome: the queue endpoint now ships `video_title`/`video_description`/`video_tags` through `VideoMetadataService`, so the bot's re-upload path (`retry_upload_pending`) goes through the blacklist instead of regenerating titles locally from raw map/player names — paired with [demome-bot 9025f8d](https://github.com/Defrag-racing/demome-bot/commit/9025f8d)

## Test plan
- [ ] Filament: edit a server, Country field is searchable dropdown, save works
- [ ] `/server-hosting` apply form: location dropdown lists all flags, free text rejected
- [ ] Approved user: "+ Add another server" visible below servers table; IP datalist suggests existing IPs; submit appends row with "awaiting admin" RS code
- [ ] Submit same IP+port twice → validation error, no duplicate row
- [ ] Hammer the add-server endpoint → 11th attempt within an hour hits rate limit
- [ ] Add a test word to `blacklisted_words.txt`, mark a video `upload_pending`, let bot retry → YouTube title is censored
