### PR TITLE
Per-server admin notes on SFTP credentials

### DIFF
--- a/app/Filament/Resources/SftpCredentialResource.php
+++ b/app/Filament/Resources/SftpCredentialResource.php
@@ -109,17 +109,21 @@ class SftpCredentialResource extends Resource
                                 \Filament\Forms\Components\TextInput::make('rcon')
                                     ->required()
                                     ->columnSpan(2),
-                                \Filament\Forms\Components\TextInput::make('location')
-                                    ->label('Country (ISO-2)')
-                                    ->placeholder('US')
-                                    ->maxLength(2)
-                                    ->extraInputAttributes(['style' => 'text-transform:uppercase'])
-                                    ->dehydrateStateUsing(fn ($state) => $state ? strtoupper($state) : null)
-                                    ->columnSpan(1),
+                                \Filament\Forms\Components\Select::make('location')
+                                    ->label('Country')
+                                    ->options(\App\Support\Countries::options())
+                                    ->searchable()
+                                    ->native(false)
+                                    ->columnSpan(2),
                                 \Filament\Forms\Components\TextInput::make('rs_code')
                                     ->label('RS code')
                                     ->placeholder('e.g. 4711')
-                                    ->columnSpan(2),
+                                    ->columnSpan(1),
+                                \Filament\Forms\Components\Textarea::make('admin_note')
+                                    ->label('Admin note')
+                                    ->placeholder('Engine, special config, things to remember — not shown to the user')
+                                    ->rows(2)
+                                    ->columnSpan(12),
                             ])
                             ->columns(12)
                             ->addable() // admin can add rows post-approval if user adds servers

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -41,11 +41,19 @@ class ServerHostingController extends Controller
             $pendingPassword = $credential->password_pending;
         }
 
+        $credentialPayload = null;
+        if ($credential) {
+            $credentialPayload = $credential->only(['id', 'sftp_username', 'host', 'port', 'remote_path', 'status', 'servers']);
+            // admin_note is admin-only metadata; never leak it to the user.
+            $credentialPayload['servers'] = array_map(
+                fn ($s) => collect($s)->except('admin_note')->all(),
+                $credentialPayload['servers'] ?? []
+            );
+        }
+
         return Inertia::render('ServerHosting', [
             'application'     => $application,
-            'credential'      => $credential
-                ? $credential->only(['id', 'sftp_username', 'host', 'port', 'remote_path', 'status', 'servers'])
-                : null,
+            'credential'      => $credentialPayload,
             'pendingPassword' => $pendingPassword,
             'countries'       => \App\Support\Countries::options(),
         ]);


### PR DESCRIPTION
## Summary
- Each server entry on `SftpCredential.servers` can now carry an `admin_note` (engine version, special config, anything worth remembering); editable from the Filament "Manage servers" modal as a textarea spanning the row, stripped from the `/server-hosting` Inertia payload so the user never sees it. The `addServer` endpoint can't accept the field either — validation doesn't list it, and the JSON column means no migration is needed
- The `location` field inside the same Filament modal was still a free-text `TextInput`; upgraded to the shared `Countries::options()` searchable dropdown so all three places that touch country codes (admin server resource, admin credential modal, public apply form) now match