### PR TITLE
Keep priority=-1 in items[] for old-bot compatibility

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -52,18 +52,20 @@ class DemomeController extends Controller
             ->get()
             ->map($mapItem);
 
-        // Normal queue: served only when not paused, and explicitly
-        // EXCLUDES priority=-1 to avoid double-shipping force-render items
-        // (the bot reads them from force_render section only).
-        $items = $paused
-            ? collect()
-            : RenderedVideo::where('status', 'pending')
-                ->where('priority', '>=', 0)
-                ->orderBy('priority', 'asc')
-                ->orderBy('created_at', 'asc')
-                ->limit(5)
-                ->get()
-                ->map($mapItem);
+        // Normal queue: when paused, falls back to the old behavior of
+        // serving ONLY priority=-1 items via items[] too. This is
+        // intentional redundancy with force_render[] above — an old
+        // bot binary that doesn't know about force_render[] still sees
+        // force-render rows here and processes them. Newer bots dedupe
+        // by id so the row isn't rendered twice.
+        $items = ($paused
+            ? RenderedVideo::where('status', 'pending')->where('priority', -1)
+            : RenderedVideo::where('status', 'pending'))
+            ->orderBy('priority', 'asc')
+            ->orderBy('created_at', 'asc')
+            ->limit(5)
+            ->get()
+            ->map($mapItem);
 
         // Find stale items stuck in 'rendering' status (crashed uploads)
         // Exclude items that already have a youtube_url (were completed but status got stuck)


### PR DESCRIPTION
The previous commit (87cc999) moved force-render rows out of items[] when paused, on the assumption every demome bot reads the new force_render[] section. A bot binary on the demome PC that hasn't been pulled+restarted since 55ac512 still only reads items[], so force renders became invisible to it during pause — exactly the regression that broke production.

Restore the original items[] behavior (when paused, only priority=-1 rows are served; when not paused, all priorities) so old bots keep working. force_render[] remains as the explicit redundant path for new bots, which dedupe by id (demome-bot 9a53419) so the same row isn't picked up twice.