### PR TITLE
Backfill render history + linkable map name in render notifications

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -201,14 +201,18 @@ class DemomeController extends Controller
 
         $mapName = $renderedVideo->map_name ?: 'unknown map';
         $cleanMap = \App\Services\ContentFilter::filterText($mapName);
+        $mapUrl = $renderedVideo->map_name
+            ? route('maps.map', ['mapname' => $renderedVideo->map_name])
+            : null;
 
         \App\Models\Notification::create([
-            'user_id'   => $renderedVideo->user_id,
-            'type'      => 'render_completed',
-            'before'    => $cleanMap,
-            'headline'  => 'render is ready',
-            'after'     => '', // column is NOT NULL in DB
-            'url'       => $renderedVideo->youtube_url,
+            'user_id'     => $renderedVideo->user_id,
+            'type'        => 'render_completed',
+            'before'      => $cleanMap,
+            'headline'    => 'render is ready',
+            'after'       => '', // column is NOT NULL in DB
+            'subheadline' => $mapUrl, // map page link, rendered as a separate clickable on the map name
+            'url'         => $renderedVideo->youtube_url,
         ]);
     }
 

--- a/database/migrations/2026_05_18_000002_backfill_render_completed_notifications.php
+++ b/database/migrations/2026_05_18_000002_backfill_render_completed_notifications.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Backfill render_completed notifications for every historical
+ * user-requested render that already shipped to YouTube. Inserted rows
+ * are marked read=1 so users see their personal render history under
+ * the Render tab without the bell counter spiking. New renders after
+ * deploy still come in as unread via DemomeController@notifyRenderResult.
+ *
+ * Match criteria mirror the runtime hook in notifyRenderResult:
+ *   - status = 'completed'
+ *   - source != 'auto' (auto renders never notify)
+ *   - user_id NOT NULL (anonymous Discord renders skip)
+ *   - youtube_url NOT NULL (nothing to link to otherwise)
+ * Plus we skip any rendered_video that already has a matching
+ * notification, so re-running the migration is a no-op.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('rendered_videos')
+            ->where('status', 'completed')
+            ->where('source', '!=', 'auto')
+            ->whereNotNull('user_id')
+            ->whereNotNull('youtube_url')
+            ->orderBy('id')
+            ->chunkById(500, function ($videos) {
+                $now = now();
+                $rows = [];
+
+                foreach ($videos as $video) {
+                    $mapName = $video->map_name ?: 'unknown map';
+                    $cleanMap = \App\Services\ContentFilter::filterText($mapName);
+                    $mapUrl = $video->map_name
+                        ? route('maps.map', ['mapname' => $video->map_name])
+                        : null;
+
+                    $existing = DB::table('notifications')
+                        ->where('user_id', $video->user_id)
+                        ->where('type', 'render_completed')
+                        ->where('url', $video->youtube_url);
+
+                    if ($existing->exists()) {
+                        // Older render_completed rows (pre-subheadline) may be
+                        // missing the map link — patch it in opportunistically.
+                        if ($mapUrl) {
+                            (clone $existing)
+                                ->whereNull('subheadline')
+                                ->update([
+                                    'subheadline' => $mapUrl,
+                                    'updated_at'  => $now,
+                                ]);
+                        }
+                        continue;
+                    }
+
+                    $rows[] = [
+                        'user_id'     => $video->user_id,
+                        'type'        => 'render_completed',
+                        'before'      => $cleanMap,
+                        'headline'    => 'render is ready',
+                        'after'       => '',
+                        'subheadline' => $mapUrl,
+                        'url'         => $video->youtube_url,
+                        'read'        => 1,
+                        'created_at'  => $now,
+                        'updated_at'  => $now,
+                    ];
+                }
+
+                if (!empty($rows)) {
+                    DB::table('notifications')->insert($rows);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // No-op: rolling back would risk deleting notifications a user
+        // has already manually marked read post-deploy. If you really
+        // need to undo, do it via a tagged one-off query on the box.
+    }
+};

--- a/resources/js/Pages/NotificationsView.vue
+++ b/resources/js/Pages/NotificationsView.vue
@@ -647,6 +647,12 @@
                                         <span>Announcement: </span>
                                         <Link class="text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
                                     </template>
+                                    <template v-else-if="notification.type === 'render_completed'">
+                                        <Link v-if="notification.subheadline" class="text-emerald-300 hover:text-emerald-200 hover:underline font-bold transition-colors" :href="notification.subheadline" v-html="q3tohtml(notification.before)"></Link>
+                                        <span v-else v-html="q3tohtml(notification.before)"></span>
+                                        <span> </span>
+                                        <Link class="text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
+                                    </template>
                                     <template v-else>
                                         <span v-html="q3tohtml(notification.before)"></span>
                                         <span> </span>


### PR DESCRIPTION
## Summary
- Render-completed notifications now carry the map page URL in `subheadline` alongside the YouTube URL in `url`, so the Notification Center renders the map name as a separate clickable link distinct from the "render is ready" YouTube link.
- Backfill migration walks every completed, user-requested, youtube-published render and inserts a `read=1` notification per historical row - users get their full render history under the Render tab without unread spam.
- Existing `render_completed` rows missing `subheadline` are patched in-place so the test/early notifications also gain the map link.
