### PR TITLE
Refactor system notification rendering - icons, prefixes, click fixes

### DIFF
--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -635,8 +635,17 @@
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-blue-400 shrink-0">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155" />
                                         </svg>
-                                        <span class="text-gray-500">{{ currentSystemNotification.type?.startsWith('clan_') ? 'Clan:' : currentSystemNotification.type?.startsWith('tournament_') || currentSystemNotification.type?.startsWith('round_') ? 'Tournament:' : currentSystemNotification.type?.startsWith('render_') ? 'Render:' : 'Announcement:' }}</span>
-                                        <span class="font-bold text-blue-400 truncate" v-html="q3tohtml(currentSystemNotification.headline || '')"></span>
+                                        <span class="text-gray-500 shrink-0">{{ currentSystemNotification.type?.startsWith('clan_') ? 'Clan:' : currentSystemNotification.type?.startsWith('tournament_') || currentSystemNotification.type?.startsWith('round_') ? 'Tournament:' : currentSystemNotification.type?.startsWith('render_') ? 'Render:' : 'Announcement:' }}</span>
+                                        <template v-if="currentSystemNotification.type === 'render_completed'">
+                                            <span class="font-bold text-emerald-300 truncate" v-html="q3tohtml(currentSystemNotification.before || '')"></span>
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4 shrink-0 text-red-500">
+                                                <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+                                            </svg>
+                                            <span class="font-bold text-blue-400 truncate">ready</span>
+                                        </template>
+                                        <template v-else>
+                                            <span class="font-bold text-blue-400 truncate" v-html="q3tohtml(currentSystemNotification.headline || '')"></span>
+                                        </template>
                                     </div>
                                     <div class="shrink-0 flex items-center justify-center min-w-[20px] h-5 px-1.5 bg-blue-500 text-white text-xs font-bold rounded">
                                         {{ systemNotifications.length }}

--- a/resources/js/Pages/NotificationsView.vue
+++ b/resources/js/Pages/NotificationsView.vue
@@ -170,6 +170,17 @@
         };
     });
 
+    // Inline label prefix shown before before/headline/after in the
+    // Notification Center. Mirrors the categorization used in the
+    // header bell pill so users see "Clan:", "Tournament:" etc.
+    const getNotificationPrefix = (type) => {
+        if (!type) return null;
+        if (type.startsWith('clan_')) return 'Clan:';
+        if (type.startsWith('tournament_') || type.startsWith('round_')) return 'Tournament:';
+        if (type === 'alias_suggestion') return 'Alias:';
+        return null;
+    };
+
     // Get icon and color for notification type
     const getNotificationTypeInfo = (type) => {
         const types = {
@@ -644,23 +655,39 @@
                                 <!-- Content -->
                                 <div class="flex-1 min-w-0 text-sm text-gray-300">
                                     <template v-if="notification.type === 'announcement'">
-                                        <span>Announcement: </span>
-                                        <Link class="text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
+                                        <span class="text-gray-400">Announcement:</span>
+                                        <Link @click.stop class="ml-1.5 text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
                                     </template>
                                     <template v-else-if="notification.type === 'render_completed'">
-                                        <Link v-if="notification.subheadline" class="text-emerald-300 hover:text-emerald-200 hover:underline font-bold transition-colors" :href="notification.subheadline" v-html="q3tohtml(notification.before)"></Link>
-                                        <span v-else v-html="q3tohtml(notification.before)"></span>
-                                        <span> </span>
-                                        <Link class="text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
+                                        <span class="text-gray-400">Render:</span>
+                                        <Link v-if="notification.subheadline" @click.stop class="ml-1.5 inline-flex items-center gap-1 align-middle text-emerald-300 hover:text-emerald-200 hover:underline font-bold transition-colors" :href="notification.subheadline">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 shrink-0">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z" />
+                                            </svg>
+                                            <span v-html="q3tohtml(notification.before)"></span>
+                                        </Link>
+                                        <span v-else class="ml-1.5" v-html="q3tohtml(notification.before)"></span>
+                                        <span class="mx-1.5 text-gray-500">-</span>
+                                        <a @click.stop class="inline-flex items-center gap-1 align-middle text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" target="_blank" rel="noopener noreferrer">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4 shrink-0 text-red-500">
+                                                <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+                                            </svg>
+                                            <span v-html="q3tohtml(notification.headline)"></span>
+                                        </a>
                                     </template>
                                     <template v-else>
-                                        <span v-html="q3tohtml(notification.before)"></span>
-                                        <span> </span>
-                                        <Link class="text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
-                                        <span> </span>
-                                        <span v-html="q3tohtml(notification.after)"></span>
-                                        <span v-if="notification.type === 'alias_suggestion'">. </span>
-                                        <Link v-if="notification.type === 'alias_suggestion'" class="text-blue-400 hover:text-blue-300 hover:underline transition-colors" :href="notification.url">Click here to approve or reject</Link>
+                                        <span v-if="getNotificationPrefix(notification.type)" class="text-gray-400 mr-1.5">{{ getNotificationPrefix(notification.type) }}</span>
+                                        <span v-if="notification.before" class="text-gray-400" v-html="q3tohtml(notification.before)"></span>
+                                        <Link @click.stop class="mx-1.5 text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
+                                        <span v-if="notification.after" class="text-gray-400" v-html="q3tohtml(notification.after)"></span>
+                                        <template v-if="notification.type === 'alias_suggestion'">
+                                            <Link @click.stop class="ml-1.5 inline-flex items-center gap-1 align-middle text-yellow-400 hover:text-yellow-300 hover:underline transition-colors" :href="notification.url">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 shrink-0">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                                                </svg>
+                                                Approve / reject
+                                            </Link>
+                                        </template>
                                     </template>
                                 </div>
 


### PR DESCRIPTION
## Summary
- Render-completed rows now show map icon + emerald map link and YouTube brand icon + blue YouTube link, separated by a visible dash. Whitespace-only spacer spans replaced with explicit margin classes so adjacent Links don't glue together.
- All other types (announcement, clan_*, tournament_*, round_*, alias_suggestion) get a consistent typed label prefix in muted gray; before/after text is gray so the headline link stands out.
- alias_suggestion's call-to-action becomes a yellow button-style chip with a check icon.
- Inner Links use `@click.stop` so clicking them navigates instead of bubbling up to the row's toggle-read handler.
- YouTube link switches from Inertia `<Link>` to plain `<a target="_blank">` - Inertia routing can't reach external origins and was silently swallowing the click.
- Header bell pill gets the same render_completed treatment: map name + YouTube icon + "ready", so users see which map the render belongs to.