### PR TITLE
Switch rank multiplier to Batawi's stretched exponential + clean up disabled outlier code

### DIFF
--- a/app/Filament/Pages/RatingSettings.php
+++ b/app/Filament/Pages/RatingSettings.php
@@ -29,8 +29,9 @@ class RatingSettings extends Page
     public string $min_map_players = '';
     public string $min_top1_time = '';
     public string $max_tied_wr_players = '';
-    public string $rank_exponent = '';
-    public string $rank_v = '';
+    public string $rank_k = '';
+    public string $rank_n = '';
+    public string $rank_p = '';
     public string $min_total_records = '';
 
     // Recalc controls
@@ -41,7 +42,7 @@ class RatingSettings extends Page
         'cfg_a', 'cfg_b', 'cfg_m', 'cfg_v', 'cfg_q', 'cfg_d',
         'mult_l', 'mult_n',
         'min_map_players', 'min_top1_time', 'max_tied_wr_players',
-        'rank_exponent', 'rank_v', 'min_total_records',
+        'rank_k', 'rank_n', 'rank_p', 'min_total_records',
     ];
 
     public static function canAccess(): bool
@@ -200,8 +201,9 @@ class RatingSettings extends Page
                 'min_total_records' => 'Min records before penalty applies',
             ],
             'Rank Multiplier' => [
-                'rank_exponent' => 'Steepness exponent (n)',
-                'rank_v' => 'Total players modifier (v)',
+                'rank_k' => 'Floor for worst-ranked record (k)',
+                'rank_n' => 'Overall curve steepness (n)',
+                'rank_p' => 'Position of steep section (p)',
             ],
         ];
     }

--- a/database/migrations/2026_05_19_000002_swap_rank_multiplier_to_stretched_exponential.php
+++ b/database/migrations/2026_05_19_000002_swap_rank_multiplier_to_stretched_exponential.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Replace the old rank multiplier formula
+ *   rank_mult = (((tp * v) - rank) / ((tp * v) - 1)) ^ n
+ * with Batawi's generalized stretched exponential
+ *   t = (rank - 1) / (tp - 1)
+ *   rank_mult = k ^ (t ^ (n + p * (1 - t)))
+ *
+ * Three new params drive the new curve (k = floor for the worst rank,
+ * n = overall steepness, p = position of the steep section). The two
+ * old params (rank_exponent, rank_v) are dropped — they have no meaning
+ * under the new formula.
+ *
+ * Filament admin and the rust service are updated in the same change
+ * so the DB schema, the consumer, and the editor stay consistent.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('rating_settings')->whereIn('key', ['rank_exponent', 'rank_v'])->delete();
+
+        $now = now();
+        $rows = [
+            ['key' => 'rank_k', 'value' => '0.80', 'description' => 'Rank multiplier — value for the worst-ranked record on the map (k in k^(t^(n+p(1-t)))).'],
+            ['key' => 'rank_n', 'value' => '0.95', 'description' => 'Rank multiplier — controls overall curve steepness.'],
+            ['key' => 'rank_p', 'value' => '0.05', 'description' => 'Rank multiplier — controls where the steep section sits along the curve.'],
+        ];
+        foreach ($rows as $row) {
+            DB::table('rating_settings')->updateOrInsert(
+                ['key' => $row['key']],
+                array_merge($row, ['created_at' => $now, 'updated_at' => $now]),
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('rating_settings')->whereIn('key', ['rank_k', 'rank_n', 'rank_p'])->delete();
+
+        $now = now();
+        $rows = [
+            ['key' => 'rank_exponent', 'value' => '0.33', 'description' => 'Rank multiplier exponent (n).'],
+            ['key' => 'rank_v', 'value' => '2.0', 'description' => 'Rank multiplier total_players modifier (v).'],
+        ];
+        foreach ($rows as $row) {
+            DB::table('rating_settings')->updateOrInsert(
+                ['key' => $row['key']],
+                array_merge($row, ['created_at' => $now, 'updated_at' => $now]),
+            );
+        }
+    }
+};

--- a/resources/js/Pages/RankingHowItWorks.vue
+++ b/resources/js/Pages/RankingHowItWorks.vue
@@ -58,8 +58,9 @@ const s = computed(() => {
         cfg_d: num('cfg_d', 0.02),
         mult_l: num('mult_l', 1.0),
         mult_n: num('mult_n', 2.0),
-        rank_n: num('rank_exponent', 1.5),
-        rank_v: num('rank_v', 2.0),
+        rank_k: num('rank_k', 0.80),
+        rank_n: num('rank_n', 0.95),
+        rank_p: num('rank_p', 0.05),
         min_map_players: num('min_map_players', 5),
         min_top1_time: num('min_top1_time', 500),
         max_tied_wr_players: num('max_tied_wr_players', 3),
@@ -76,11 +77,11 @@ function fmt(value, digits = 4) {
 
 function calcRankMultiplier(totalPlayers, yourRank) {
     const cfg = s.value;
-    if (cfg.rank_n === 0 || cfg.rank_v === 0 || totalPlayers <= 1 || yourRank === 0) return 1.0;
-    const numerator = (totalPlayers * cfg.rank_v) - yourRank;
-    const denominator = (totalPlayers * cfg.rank_v) - 1;
-    if (denominator <= 0) return 1.0;
-    return Math.pow(Math.max(numerator / denominator, 0), cfg.rank_n);
+    if (totalPlayers <= 1 || yourRank === 0) return 1.0;
+    const t = Math.min(Math.max((yourRank - 1) / (totalPlayers - 1), 0), 1);
+    if (t === 0) return 1.0;
+    const exponent = Math.pow(t, cfg.rank_n + cfg.rank_p * (1 - t));
+    return Math.pow(cfg.rank_k, exponent);
 }
 
 function calcMapScore(reltime) {
@@ -499,15 +500,20 @@ const top200Share = computed(() => topNWeightShare(200));
                 </h2>
                 <p class="mb-3">Your rank on each map further scales your score. Higher ranks earn a bigger multiplier:</p>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 font-mono text-center text-sm text-white mb-3 overflow-x-auto">
-                    rank_mult = (((total_players * v) - your_rank) / ((total_players * v) - 1)) ^ n
+                    t = (your_rank - 1) / (total_players - 1)<br>
+                    rank_mult = k ^ (t ^ (n + p * (1 - t)))
+                </div>
+                <div class="text-xs text-gray-500 mb-3">
+                    Generalized stretched exponential with a position-dependent exponent. WR (t = 0) always gets exactly 1.0; the worst rank on the map (t = 1) gets exactly <span class="font-mono">k</span>.
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4 mb-3">
                     <div class="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">Parameters</div>
                     <div class="space-y-1 text-xs">
                         <div><span class="text-white font-mono">total_players</span> <span class="text-gray-500">— number of unique players on the map</span></div>
                         <div><span class="text-white font-mono">your_rank</span> <span class="text-gray-500">— your position on the map leaderboard (1 = WR)</span></div>
-                        <div><span class="text-white font-mono">n = {{ fmt(s.rank_n) }}</span> <span class="text-gray-500">— steepness of the curve</span></div>
-                        <div><span class="text-white font-mono">v = {{ fmt(s.rank_v) }}</span> <span class="text-gray-500">— total_players modifier</span></div>
+                        <div><span class="text-white font-mono">k = {{ fmt(s.rank_k) }}</span> <span class="text-gray-500">— rank_mult value for the worst-ranked record on the map</span></div>
+                        <div><span class="text-white font-mono">n = {{ fmt(s.rank_n) }}</span> <span class="text-gray-500">— overall curve steepness</span></div>
+                        <div><span class="text-white font-mono">p = {{ fmt(s.rank_p) }}</span> <span class="text-gray-500">— position of the steep section along the curve</span></div>
                     </div>
                 </div>
                 <div class="bg-gray-900/60 border border-gray-800 rounded-xl p-4">
@@ -767,7 +773,8 @@ const top200Share = computed(() => topNWeightShare(200));
                         <div class="text-sm font-bold text-pink-400 mb-2">Step 5: Apply rank multiplier</div>
                         <div class="text-xs text-gray-400">
                             <div>Your rank on the map: <span class="text-white">#3 of 25 players</span></div>
-                            <div>rank_mult = ((25*{{ fmt(s.rank_v) }} - 3) / (25*{{ fmt(s.rank_v) }} - 1))<sup>{{ fmt(s.rank_n) }}</sup> = <span class="text-pink-400 font-mono font-bold">{{ calcRankMultiplier(25, 3).toFixed(4) }}</span></div>
+                            <div>t = (3 - 1) / (25 - 1) = <span class="text-white font-mono">{{ (2/24).toFixed(4) }}</span></div>
+                            <div>rank_mult = {{ fmt(s.rank_k) }}<sup>(t ^ ({{ fmt(s.rank_n) }} + {{ fmt(s.rank_p) }} * (1 - t)))</sup> = <span class="text-pink-400 font-mono font-bold">{{ calcRankMultiplier(25, 3).toFixed(4) }}</span></div>
                             <div class="mt-1">final_score = {{ exampleFinalScore.toFixed(1) }} * {{ calcRankMultiplier(25, 3).toFixed(4) }} = <span class="text-green-400 font-mono font-bold">{{ (exampleFinalScore * calcRankMultiplier(25, 3)).toFixed(1) }}</span></div>
                         </div>
                     </div>

--- a/rust-rating-service/src/main.rs
+++ b/rust-rating-service/src/main.rs
@@ -20,8 +20,9 @@ struct RatingConfig {
     cfg_d: f64,
     mult_l: f64,
     mult_n: f64,
+    rank_k: f64,
     rank_n: f64,
-    rank_v: f64,
+    rank_p: f64,
 }
 
 impl RatingConfig {
@@ -53,8 +54,9 @@ impl RatingConfig {
             cfg_d: get_f64("cfg_d", 0.02),
             mult_l: get_f64("mult_l", 1.0),
             mult_n: get_f64("mult_n", 2.0),
-            rank_n: get_f64("rank_exponent", 1.5),
-            rank_v: get_f64("rank_v", 2.0),
+            rank_k: get_f64("rank_k", 0.80),
+            rank_n: get_f64("rank_n", 0.95),
+            rank_p: get_f64("rank_p", 0.05),
         }
     }
 }
@@ -117,19 +119,24 @@ fn calculate_map_score(reltime: f64, cfg: &RatingConfig) -> f64 {
 }
 
 /// Rank-based multiplier: rewards higher ranks on a map.
-/// rank_multiplier = (((total_players * v) - your_rank) / ((total_players * v) - 1)) ^ n
+/// Generalized stretched exponential with a position-dependent exponent:
+///   t = (your_rank - 1) / (total_players - 1)
+///   rank_multiplier = k ^ (t ^ (n + p * (1 - t)))
+/// k is the floor for the worst rank (t = 1), the WR (t = 0) always
+/// gets exactly 1.0. n controls overall steepness, p shifts where the
+/// steep section sits along the curve.
 fn calculate_rank_multiplier(total_players: usize, your_rank: usize, cfg: &RatingConfig) -> f64 {
-    if cfg.rank_n == 0.0 || cfg.rank_v == 0.0 || total_players <= 1 || your_rank == 0 {
+    if total_players <= 1 || your_rank == 0 {
         return 1.0;
     }
     let tp = total_players as f64;
     let rank = your_rank as f64;
-    let numerator = (tp * cfg.rank_v) - rank;
-    let denominator = (tp * cfg.rank_v) - 1.0;
-    if denominator <= 0.0 {
+    let t = ((rank - 1.0) / (tp - 1.0)).clamp(0.0, 1.0);
+    if t == 0.0 {
         return 1.0;
     }
-    (numerator / denominator).max(0.0).powf(cfg.rank_n)
+    let exponent = t.powf(cfg.rank_n + cfg.rank_p * (1.0 - t));
+    cfg.rank_k.powf(exponent)
 }
 
 /// Map score multiplier based on number of records/players on given map.
@@ -835,8 +842,8 @@ fn main() -> Result<()> {
 
     // Load rating config from database (rating_settings table)
     let cfg = RatingConfig::from_db(&mut conn);
-    println!("Config: D={}, A={}, B={}, M={}, V={}, Q={}, MULT_L={}, MULT_N={}, RANK_N={}, RANK_V={}, min_players={}, min_time={}, max_tied_wr={}, min_records={}",
-        cfg.cfg_d, cfg.cfg_a, cfg.cfg_b, cfg.cfg_m, cfg.cfg_v, cfg.cfg_q, cfg.mult_l, cfg.mult_n, cfg.rank_n, cfg.rank_v,
+    println!("Config: D={}, A={}, B={}, M={}, V={}, Q={}, MULT_L={}, MULT_N={}, RANK_K={}, RANK_N={}, RANK_P={}, min_players={}, min_time={}, max_tied_wr={}, min_records={}",
+        cfg.cfg_d, cfg.cfg_a, cfg.cfg_b, cfg.cfg_m, cfg.cfg_v, cfg.cfg_q, cfg.mult_l, cfg.mult_n, cfg.rank_k, cfg.rank_n, cfg.rank_p,
         cfg.min_map_total_participators, cfg.min_top1_time, cfg.max_tied_wr_players, cfg.min_total_records);
 
     // Load maps for category filtering

--- a/rust-rating-service/src/main.rs
+++ b/rust-rating-service/src/main.rs
@@ -6,9 +6,6 @@ use rayon::prelude::*;
 
 // Constants - read from environment variables (shared with PHP via .env)
 // Fallback defaults match config/ratings.php
-#[allow(dead_code)]
-const OUTLIER_THRESHOLD: f64 = 0.6; // ratio below this = outlier detected (currently disabled)
-
 
 struct RatingConfig {
     min_map_total_participators: usize,
@@ -112,25 +109,7 @@ struct MapStats {
     times: Vec<i32>,
     mdd_ids: Vec<i32>,
     total_participators: usize,
-    ref_index: usize,
     is_ranked: bool,
-}
-
-/// Find where the "normal" cluster starts by scanning consecutive time ratios.
-/// Returns the index of the first time in the normal cluster.
-/// DISABLED: outlier normalization commented out - rank 1 and 2 get same reward which is wrong
-fn find_normal_cluster_start(_times: &[i32]) -> usize {
-    return 0;
-    // if times.len() < 2 {
-    //     return 0;
-    // }
-    // for i in 0..times.len() - 1 {
-    //     let ratio = times[i] as f64 / times[i + 1] as f64;
-    //     if ratio >= OUTLIER_THRESHOLD {
-    //         return i;
-    //     }
-    // }
-    // times.len() - 1
 }
 
 fn calculate_map_score(reltime: f64, cfg: &RatingConfig) -> f64 {
@@ -226,33 +205,14 @@ fn process_map_records(records: &[Record], stats: &MapStats, category_median: f6
     }
 
     let times = &stats.times;
-    let ref_index = stats.ref_index;
-    let ref_time = times[ref_index].max(cfg.min_top1_time) as f64;
+    let ref_time = times[0].max(cfg.min_top1_time) as f64;
 
     records.iter().filter_map(|record| {
-        let is_in_outlier_group = if ref_index > 0 {
-            let mut found_outlier = false;
-            for idx in 0..ref_index {
-                if times[idx] == record.time {
-                    found_outlier = true;
-                    break;
-                }
-            }
-            found_outlier
-        } else {
-            false
-        };
-
-        let reltime = if is_in_outlier_group {
-            if ref_index + 1 < times.len() {
-                let next_time = times[ref_index + 1].max(cfg.min_top1_time) as f64;
-                ref_time / next_time
-            } else {
-                1.0
-            }
-        } else if record.time as f64 <= ref_time {
-            if ref_index + 1 < times.len() {
-                ref_time / times[ref_index + 1].max(cfg.min_top1_time) as f64
+        // The WR holder is benchmarked against the 2nd-place time rather than
+        // their own, so reltime stays meaningful at the top of the leaderboard.
+        let reltime = if record.time as f64 <= ref_time {
+            if times.len() > 1 {
+                ref_time / times[1].max(cfg.min_top1_time) as f64
             } else {
                 1.0
             }
@@ -261,10 +221,8 @@ fn process_map_records(records: &[Record], stats: &MapStats, category_median: f6
         };
 
         let base_score = calculate_map_score(reltime, cfg);
-        // Apply map multiplier based on number of records/players on given map
         let multiplier = calculate_map_multiplier(stats.total_participators, category_median, cfg);
 
-        // Apply rank multiplier: find player's rank on this map (1-indexed)
         let your_rank = times.iter().position(|&t| t == record.time).map(|p| p + 1).unwrap_or(stats.total_participators);
         let rank_mult = calculate_rank_multiplier(stats.total_participators, your_rank, cfg);
 
@@ -276,7 +234,7 @@ fn process_map_records(records: &[Record], stats: &MapStats, category_median: f6
             map_score,
             multiplier,
             rank_multiplier: rank_mult,
-            is_outlier: is_in_outlier_group,
+            is_outlier: false,
         })
     }).collect()
 }
@@ -331,22 +289,20 @@ fn build_map_stats(records: &[Record], cfg: &RatingConfig) -> HashMap<String, Ma
         let top1_time = times[0];
         if total_participators < cfg.min_map_total_participators || top1_time < cfg.min_top1_time {
             map_stats.insert(mapname, MapStats {
-                times, mdd_ids, total_participators, ref_index: 0, is_ranked: false,
+                times, mdd_ids, total_participators, is_ranked: false,
             });
             continue;
         }
 
         if is_free_wr_map(&times, &mdd_ids, cfg) {
             map_stats.insert(mapname, MapStats {
-                times, mdd_ids, total_participators, ref_index: 0, is_ranked: false,
+                times, mdd_ids, total_participators, is_ranked: false,
             });
             continue;
         }
 
-        let ref_index = find_normal_cluster_start(&times);
-
         map_stats.insert(mapname, MapStats {
-            times, mdd_ids, total_participators, ref_index, is_ranked: true,
+            times, mdd_ids, total_participators, is_ranked: true,
         });
     }
 
@@ -425,15 +381,12 @@ fn full_recalc(conn: &mut PooledConn, physics: &str, mode: &str, category: &str,
         .filter(|(_, s)| s.is_ranked)
         .map(|(n, _)| n.clone())
         .collect();
-    let outlier_count = map_stats.iter()
-        .filter(|(_, s)| s.is_ranked && s.ref_index > 0)
-        .count();
     let free_wr_count = map_stats.iter()
         .filter(|(_, s)| !s.is_ranked && s.total_participators >= cfg.min_map_total_participators && s.times.first().map_or(false, |&t| t >= cfg.min_top1_time))
         .count();
 
-    println!("  Ranked maps: {}, outlier-normalized: {}, free WR excluded: {}",
-        ranked_maps.len(), outlier_count, free_wr_count);
+    println!("  Ranked maps: {}, free WR excluded: {}",
+        ranked_maps.len(), free_wr_count);
 
     // Step 3: Process records
     println!("Step 3: Processing records...");
@@ -663,10 +616,6 @@ fn incremental_recalc(conn: &mut PooledConn, physics: &str, mode: &str, map_name
             map_name.replace("'", "''"), physics, mode
         ))?;
         return Ok(());
-    }
-
-    if stats.ref_index > 0 {
-        println!("  Outlier detected: {} outlier player(s), ref_index={}", stats.ref_index, stats.ref_index);
     }
 
     // Step 3: Calculate category median for map multiplier


### PR DESCRIPTION
## Summary
Two rankings-pipeline changes in one PR - the user-facing formula swap and a long-overdue cleanup of dead detection code that paved the way for it.

### Rank multiplier formula swap (commit 07c5497)
- Drops `rank_exponent` and `rank_v` from `rating_settings`. Seeds `rank_k=0.80`, `rank_n=0.95`, `rank_p=0.05`.
- Rust service `calculate_rank_multiplier` now computes `t = (rank - 1) / (tp - 1)` then `rank_mult = k ^ (t ^ (n + p * (1 - t)))` - Batawi's generalized stretched exponential with a position-dependent exponent.
- Filament Rating Settings page exposes the three new knobs (k = floor, n = overall steepness, p = position of the steep section) under the existing Rank Multiplier group.
- How It Works page picks up the new formula text + live values automatically (already DB-driven from the previous commit). Section 6 shows the new formula, parameters list, and example bars; section 11 walkthrough updated.

### Outlier-normalization cleanup (commit 2a1817b)
- Removes `find_normal_cluster_start`, `OUTLIER_THRESHOLD`, and the `ref_index` plumbing through `MapStats` and `process_map_records`.
- The detection was already short-circuited (the function returned 0 unconditionally) because the original implementation gave rank 1 and rank 2 the same reward when they fell into the same outlier cluster.
- Batawi confirmed we're not reviving it: no clean way to tell a cheat from a player who just found a route nobody else has, so the heuristic causes more harm than good.
- `is_outlier` column on `player_map_scores` stays (still read by Profile / Records / Maps controllers + Profile.vue OUTLIER badge) but is always written `false` going forward.

## Why this shape
The old `rank_mult = (((tp*v) - rank) / ((tp*v) - 1))^n` bunched the top 10 records at ~0.97–1.00 (rank barely mattered at the top) and dropped the worst rank somewhere between ~0.36 and ~0.80 depending on map size (rank mattered too much at the bottom). The new shape spreads top ranks a bit wider, pins the floor of the worst rank to a constant `k` regardless of map size, and gives three independent knobs instead of two coupled ones - so future tuning can move floor, steepness, and curve position separately.

## Notes
- **Goes live after deploy + one manual `php artisan ratings:calculate`** so the `player_ratings` table reflects the new shape immediately instead of waiting for the nightly cycle.
- DB migration is idempotent on re-run (uses `updateOrInsert` on the three new keys; old keys are deleted by `whereIn` which is a no-op if already gone).
- `down()` of the migration restores the previous keys with their previous live production values (`rank_exponent=0.33`, `rank_v=2.0`) so a rollback returns the system to its current pre-PR state cleanly.