### PR TITLE
Close the duplicate-render hole between bot and defrag.racing

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -620,7 +620,16 @@ class DemomeController extends Controller
             ->first();
 
         if ($existing) {
-            return response()->json([
+            // If this demo already has a completed render on YouTube, surface
+            // that here so the bot can short-circuit and just reply with the
+            // existing URL instead of re-rendering / re-uploading.
+            $completedVideo = RenderedVideo::where('demo_id', $existing->id)
+                ->where('status', 'completed')
+                ->whereNotNull('youtube_video_id')
+                ->orderBy('id', 'desc')
+                ->first();
+
+            $payload = [
                 'success' => true,
                 'duplicate' => true,
                 'demo_id' => $existing->id,
@@ -630,7 +639,18 @@ class DemomeController extends Controller
                 'time_ms' => $existing->time_ms,
                 'gametype' => $existing->gametype,
                 'record_id' => $existing->record_id,
-            ]);
+            ];
+
+            if ($completedVideo) {
+                $payload['existing_video'] = [
+                    'id'               => $completedVideo->id,
+                    'youtube_video_id' => $completedVideo->youtube_video_id,
+                    'youtube_url'      => $completedVideo->youtube_url,
+                    'source'           => $completedVideo->source,
+                ];
+            }
+
+            return response()->json($payload);
         }
 
         // Create UploadedDemo record
@@ -874,16 +894,37 @@ class DemomeController extends Controller
                 ->first();
         }
 
-        // Build a temporary RenderedVideo-like object for metadata generation
-        $metaItem = new \stdClass();
-        $metaItem->map_name = $demo->map_name;
-        $metaItem->player_name = $demo->player_name;
-        $metaItem->physics = $demo->physics;
-        $metaItem->time_ms = $demo->time_ms;
-        $metaItem->gametype = $demo->gametype;
-        $metaItem->record_id = $demo->record_id;
-        $metaItem->demo_id = $demo->id;
-        $metaItem->demo_filename = $demo->processed_filename ?? $demo->original_filename;
+        // Build a RenderedVideo-like instance for metadata generation. We use
+        // an unsaved RenderedVideo (not stdClass) because VideoMetadataService
+        // has a strict RenderedVideo type hint and crashes the request with a
+        // 500 if you hand it anything else — which is exactly how the bot's
+        // dedup short-circuit silently fell through on 2026-05-19 and caused
+        // duplicate renders/uploads.
+        $metaItem = new RenderedVideo([
+            'map_name'      => $demo->map_name,
+            'player_name'   => $demo->player_name,
+            'physics'       => $demo->physics,
+            'time_ms'       => $demo->time_ms,
+            'gametype'      => $demo->gametype,
+            'record_id'     => $demo->record_id,
+            'demo_id'       => $demo->id,
+            'demo_filename' => $demo->processed_filename ?? $demo->original_filename,
+        ]);
+
+        // Defense in depth: even if VideoMetadataService blows up for some
+        // edge case (missing demo metadata, content filter quirk, etc.), we
+        // must still return the existing_video block — that is what the bot
+        // relies on for dedup. Title/description/tags are nice-to-have.
+        $safeMeta = function (callable $fn, $default) {
+            try {
+                return $fn();
+            } catch (\Throwable $e) {
+                \Log::warning('lookupByHash: metadata generation failed', [
+                    'error' => $e->getMessage(),
+                ]);
+                return $default;
+            }
+        };
 
         $response = [
             'success' => true,
@@ -896,9 +937,9 @@ class DemomeController extends Controller
             'record_id' => $demo->record_id,
             'demo_filename' => $demo->processed_filename ?? $demo->original_filename,
             'download_url' => "https://defrag.racing/demos/{$demo->id}/download",
-            'video_title' => \App\Services\VideoMetadataService::generateTitle($metaItem),
-            'video_description' => \App\Services\VideoMetadataService::generateDescription($metaItem),
-            'video_tags' => \App\Services\VideoMetadataService::generateTags($metaItem),
+            'video_title' => $safeMeta(fn () => \App\Services\VideoMetadataService::generateTitle($metaItem), null),
+            'video_description' => $safeMeta(fn () => \App\Services\VideoMetadataService::generateDescription($metaItem), null),
+            'video_tags' => $safeMeta(fn () => \App\Services\VideoMetadataService::generateTags($metaItem), []),
         ];
 
         if ($existingVideo) {


### PR DESCRIPTION
## Summary
Production was creating duplicate `rendered_videos` rows and duplicate YouTube uploads when the bot ingested a demo whose hash was already live (seen today on `sdc33` by `-MdC-Loule`, rendered + uploaded twice in one day as `4smZ29BoQAM` then `Ik0exy-DcU0`). This PR closes the hole at the first contact point - `upload_demo` - so any path that ingests a demo (normal Discord scrape, single-message reprocess marker, restart-from rewind) reuses the existing YouTube URL instead of re-rendering.

## What changed
- `uploadDemo`'s duplicate branch now joins to `rendered_videos` and, when the demo already has a `completed` render with a `youtube_video_id`, ships an `existing_video` block in the response alongside the metadata. Bot can now short-circuit on the very first API call.
- `lookupByHash` is hardened: it used to hand a `\stdClass` to `VideoMetadataService::generateTitle()`, which has a strict `RenderedVideo` type hint - that crashed the endpoint with a 500 today, which is what caused the reprocess-marker dedup path to fall through (a 500 read as "no existing video" → bot rendered fresh). Now `lookupByHash` builds an unsaved `RenderedVideo` for the metadata service and wraps each `VideoMetadataService` call so the load-bearing `existing_video` block is never lost to an unrelated metadata edge case.

## Why this is the right place to fix it
Hash dedup already existed on the Laravel side - `uploadedDemo` rows were deduped, and `startDiscordRender` reused placeholders that were still `rendering`/`uploading`. But neither of those branches checked whether the demo already had a `completed` render with a YouTube URL. So once an upload + completion succeeded, any subsequent ingestion of the same demo file flowed straight past the dedup checks into a fresh render. The bot's `render_file` would dutifully run oDFe, ffmpeg, and a YouTube upload to produce a duplicate.

The bot-side companion change (separate `demome-bot` commits, see below) reads `existing_video.youtube_url` from the `upload_demo` response and, if present, replies to the Discord requester with that URL, mirrors the message into the local sqlite so the next scrape doesn't see it as new, deletes the downloaded demo file, and returns from `render_file` before touching the renderer or YouTube. Same dedup contract for every ingest path.

## Notes
- No DB schema change.
- `is_outlier` semantics unchanged (still always written `false` since the outlier-normalization removal earlier in this branch).
- After this lands the production duplicate from earlier today (RenderedVideo `340306`, YouTube `Ik0exy-DcU0`) is still orphaned in the table - that needs manual cleanup (delete row + delete YouTube video) since this PR only prevents future occurrences. A separate follow-up could sweep for `(demo_id, status=completed)` pairs that have more than one row and merge them.
- Bot needs the matching `demome-bot` commits - `Short-circuit render_file when defrag.racing already has YouTube for the demo` (a90a3b9) and `Distinguish lookup_by_hash transport failure from a clean miss` (521afe1) - pulled and the python process restarted for end-to-end dedup.
