### PR TITLE
Pre-warm render-queue-preview pool counts so admin doesn't pay the cold-cache rebuild

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -67,6 +67,21 @@ class Kernel extends ConsoleKernel
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();
 
+        // Pre-warm RenderQueueService::getPoolCounts() so the /defraghq/render-queue-preview
+        // and /defraghq/demome-control pages never hit a cold cache. The query is
+        // ~8 large JOIN + NOT EXISTS aggregates against rendered_videos / records /
+        // uploaded_demos that easily stretch past Cloudflare's 100s timeout on
+        // first visit after the 30-min TTL expires. Force a fresh rebuild every
+        // 20 minutes so the cache is continuously valid and an admin visit
+        // never has to wait on the rebuild itself.
+        $schedule->call(function () {
+            \Illuminate\Support\Facades\Cache::forget('demome:pool_counts');
+            for ($tier = 1; $tier <= 8; $tier++) {
+                \Illuminate\Support\Facades\Cache::forget("tier_pool_count_{$tier}");
+            }
+            \App\Services\RenderQueueService::getPoolCounts();
+        })->name('warm-pool-counts')->withoutOverlapping()->everyTwentyMinutes();
+
         // NOTE: Triweekly auto-publish scheduler removed. Bulk publishing is now manual-only
         // via the per-tier buttons in Filament DemomeControl page. The Python bot's every-4h
         // deficit check (auto_publish_deficit) still keeps a steady 12 videos/day trickle.

--- a/app/Filament/Pages/DemomeControl.php
+++ b/app/Filament/Pages/DemomeControl.php
@@ -80,26 +80,48 @@ class DemomeControl extends Page
                     ),
                 ];
             }),
-            'queue_by_priority' => [
-                'wr' => RenderedVideo::where('status', 'pending')->where('priority', 1)->count(),
-                'verified' => RenderedVideo::where('status', 'pending')->where('priority', 2)->count(),
-                'normal' => RenderedVideo::where('status', 'pending')->where('priority', 3)->count(),
-            ],
-            'unlisted_count' => RenderedVideo::where('status', 'completed')
-                ->where('source', 'auto')
-                ->where('publish_approved', false)
-                ->whereNull('published_at')
-                ->whereNotNull('youtube_video_id')
-                ->count(),
-            'unlisted_tier_counts' => $this->getUnlistedTierCounts(),
-            'unlisted_videos' => $this->getUnlistedVideosPaginated(),
-            'unlisted_total_pages' => $this->getUnlistedTotalPages(),
-            'publishing_count' => RenderedVideo::where('status', 'completed')
-                ->where('publish_approved', true)
-                ->whereNull('published_at')
-                ->count(),
+            // Filament re-renders the whole page on every wire:click action,
+            // and the rendered_videos table is several hundred thousand rows
+            // on prod — every uncached COUNT/SELECT here piled up to a
+            // multi-minute Livewire round-trip + Cloudflare 504s on 2026-05-19.
+            // Cache the global aggregates with a short TTL and invalidate from
+            // the handful of action methods that actually mutate this data.
+            'queue_by_priority' => Cache::remember('demome:control_queue_by_priority', 60, function () {
+                return [
+                    'wr' => RenderedVideo::where('status', 'pending')->where('priority', 1)->count(),
+                    'verified' => RenderedVideo::where('status', 'pending')->where('priority', 2)->count(),
+                    'normal' => RenderedVideo::where('status', 'pending')->where('priority', 3)->count(),
+                ];
+            }),
+            'unlisted_count' => Cache::remember('demome:control_unlisted_count', 60, function () {
+                return RenderedVideo::where('status', 'completed')
+                    ->where('source', 'auto')
+                    ->where('publish_approved', false)
+                    ->whereNull('published_at')
+                    ->whereNotNull('youtube_video_id')
+                    ->count();
+            }),
+            'unlisted_tier_counts' => Cache::remember('demome:control_unlisted_tier_counts', 60, fn () => $this->getUnlistedTierCounts()),
+            // Cache the page list per (tier, page) so changing tier or paging
+            // doesn't pay the full filter+sort cost every click.
+            'unlisted_videos' => Cache::remember(
+                "demome:control_unlisted_videos:{$this->unlistedTier}:{$this->unlistedPage}:{$this->unlistedPerPage}",
+                30,
+                fn () => $this->getUnlistedVideosPaginated()
+            ),
+            'unlisted_total_pages' => Cache::remember(
+                "demome:control_unlisted_total_pages:{$this->unlistedTier}:{$this->unlistedPerPage}",
+                60,
+                fn () => $this->getUnlistedTotalPages()
+            ),
+            'publishing_count' => Cache::remember('demome:control_publishing_count', 60, function () {
+                return RenderedVideo::where('status', 'completed')
+                    ->where('publish_approved', true)
+                    ->whereNull('published_at')
+                    ->count();
+            }),
             'manual_bulk_history' => $this->getManualBulkHistory(),
-            'bulk_tier_buttons' => $this->getBulkTierButtonData(),
+            'bulk_tier_buttons' => Cache::remember('demome:control_bulk_tier_buttons', 60, fn () => $this->getBulkTierButtonData()),
             'backlog' => $this->getBacklogStats(),
             'discordRestartMarker' => SiteSetting::get('demome:discord_restart_from_message_id') ?: null,
             'discordReprocessMarker' => SiteSetting::get('demome:discord_reprocess_single_message_id') ?: null,
@@ -267,6 +289,27 @@ class DemomeControl extends Page
         });
     }
 
+    /**
+     * Drop every cache key the view layer relies on for rendered_videos
+     * aggregates. Call this from any action that mutates publish_approved,
+     * status, or other columns that feed the counts on screen — without it
+     * the new state is invisible until the per-key TTL elapses, which makes
+     * the panel look broken even though the change went through.
+     */
+    private function flushDemomeViewCache(): void
+    {
+        Cache::forget('demome:control_stats');
+        Cache::forget('demome:control_queue_by_priority');
+        Cache::forget('demome:control_unlisted_count');
+        Cache::forget('demome:control_unlisted_tier_counts');
+        Cache::forget('demome:control_publishing_count');
+        Cache::forget('demome:control_bulk_tier_buttons');
+        // unlisted_videos / unlisted_total_pages are keyed by tier+page; we
+        // can't enumerate cheaply, so we let them expire on their short TTL
+        // (30s/60s). The list view is the least state-sensitive piece — a
+        // 30s lag on tier/page transitions is acceptable.
+    }
+
     public function togglePause(): void
     {
         $currentState = SiteSetting::getBool('demome:paused', false);
@@ -295,6 +338,8 @@ class DemomeControl extends Page
     {
         \Artisan::call('demome:populate-queue', ['--force' => true]);
 
+        $this->flushDemomeViewCache();
+
         Notification::make()
             ->title('Queue Populated')
             ->body(\Artisan::output())
@@ -310,6 +355,8 @@ class DemomeControl extends Page
         }
 
         $video->update(['publish_approved' => true]);
+
+        $this->flushDemomeViewCache();
 
         Notification::make()
             ->title('Video Queued for Publishing')
@@ -342,6 +389,8 @@ class DemomeControl extends Page
         $breakdown = collect($tierCounts)->map(fn($c, $l) => "{$c}x {$l}")->join(', ');
 
         $this->recordManualBulk("Mix 12 ({$breakdown})", $batch->count());
+
+        $this->flushDemomeViewCache();
 
         Notification::make()
             ->title("Publish Queued: {$batch->count()} videos")
@@ -388,8 +437,8 @@ class DemomeControl extends Page
 
         $this->recordManualBulk($label, $count);
 
-        // Invalidate the unlisted stats cache so the UI immediately reflects the change.
-        \Illuminate\Support\Facades\Cache::forget('demome:control_stats');
+        // Invalidate every view cache key so the UI immediately reflects the change.
+        $this->flushDemomeViewCache();
 
         Notification::make()
             ->title("Bulk Publish Queued: {$count} videos")

--- a/app/Filament/Pages/RenderQueuePreview.php
+++ b/app/Filament/Pages/RenderQueuePreview.php
@@ -88,6 +88,11 @@ class RenderQueuePreview extends Page
             'demo_filename' => $demo->original_filename,
         ]);
 
+        // Drop the cached aggregates so the new pending count + tier counts
+        // show up on the next render instead of waiting for the TTL.
+        Cache::forget('demome:render_queue_preview_stats');
+        Cache::forget('demome:pool_counts');
+
         Notification::make()->title("Queued: {$demo->map_name}")->success()->send();
 
         // Refresh preview
@@ -109,14 +114,19 @@ class RenderQueuePreview extends Page
 
     public function getCurrentQueueStats(): array
     {
-        return [
-            'pending' => RenderedVideo::where('status', 'pending')->count(),
-            'rendering' => RenderedVideo::where('status', 'rendering')->count(),
-            'completed_today' => RenderedVideo::where('status', 'completed')
-                ->where('updated_at', '>=', now()->startOfDay())->count(),
-            'published_today' => RenderedVideo::where('status', 'completed')
-                ->whereNotNull('published_at')
-                ->where('published_at', '>=', now()->startOfDay())->count(),
-        ];
+        // Called from the blade on every render — without caching, every
+        // wire:click (loadPreview, queueDemo) ran 4 fresh COUNTs against
+        // ~340k rendered_videos and could stack into a CDN-timeout.
+        return Cache::remember('demome:render_queue_preview_stats', 60, function () {
+            return [
+                'pending' => RenderedVideo::where('status', 'pending')->count(),
+                'rendering' => RenderedVideo::where('status', 'rendering')->count(),
+                'completed_today' => RenderedVideo::where('status', 'completed')
+                    ->where('updated_at', '>=', now()->startOfDay())->count(),
+                'published_today' => RenderedVideo::where('status', 'completed')
+                    ->whereNotNull('published_at')
+                    ->where('published_at', '>=', now()->startOfDay())->count(),
+            ];
+        });
     }
 }


### PR DESCRIPTION
## Summary
`/defraghq/render-queue-preview` was 504'ing on first visit after the pool-counts cache expired. Same shape of problem as the DemomeControl fix in `1d44f01`, on a different Filament page.

## Two layers fixed
1. `getCurrentQueueStats()` is called from the blade on every render and ran 4 uncached COUNTs against the ~340k-row `rendered_videos` table. Every `wire:click` (loadPreview, queueDemo) paid the cost. Now wrapped in `Cache::remember` (60s TTL), invalidated from `queueDemo()` so the new pending count surfaces immediately.
2. `RenderQueueService::getPoolCounts()` was already cached at 30-min TTL, but the cold rebuild fires 8 large JOIN + NOT EXISTS aggregates over `rendered_videos` / `records` / `uploaded_demos` sequentially. On prod data that routinely overruns Cloudflare's 100s gateway timeout, so the first visitor after TTL expiry sees a 504 and the rebuild never even completes from their browser. New scheduler entry runs every 20 minutes, explicitly forgets the cache keys, and rebuilds them in the background - admin requests are always a cache hit.

## Notes
- Schedule fires every 20 min on a 30 min TTL = cache continuously valid; the explicit `Cache::forget` before the rebuild prevents the closure from no-opping on a still-warm cache.
- Same `demome:pool_counts` cache is also consumed by `DemomeControl::getBacklogStats()`, so this fix benefits both admin pages.