### PR TITLE
Add /launcher/latest.json mirror for desktop launcher auto-updates

### DIFF
--- a/app/Http/Controllers/LauncherController.php
+++ b/app/Http/Controllers/LauncherController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class LauncherController extends Controller
+{
+    /**
+     * Mirror of the launcher's signed update manifest. The launcher's
+     * tauri-plugin-updater tries this endpoint first because GitHub is
+     * intermittently blocked / slow for users in CN and parts of RU;
+     * falling back to the GH Releases URL is the second endpoint in the
+     * launcher's config.
+     *
+     * We cache the upstream response for 5 minutes — releases happen
+     * rarely (manual tag push) and a freshly cut release stays fresh
+     * within minutes either way. Caching also shields us from GH rate
+     * limits if the launcher install base grows.
+     *
+     * Returns the upstream manifest verbatim. Do NOT rewrite signatures,
+     * platforms map, etc. — the launcher verifies the signature with the
+     * embedded pubkey, so any rewrite would invalidate it.
+     */
+    public function latestManifest(): JsonResponse
+    {
+        $manifest = Cache::remember('launcher:latest-manifest', now()->addMinutes(5), function () {
+            $response = Http::timeout(10)
+                ->retry(2, 500)
+                ->get('https://github.com/Defrag-racing/defrag-racing-launcher/releases/latest/download/latest.json');
+
+            if (! $response->successful()) {
+                Log::warning('launcher manifest fetch failed', [
+                    'status' => $response->status(),
+                    'body'   => $response->body(),
+                ]);
+                return null;
+            }
+
+            return $response->json();
+        });
+
+        // Upstream unreachable. Returning 503 (rather than caching the
+        // failure) lets the launcher fall through to its GH endpoint
+        // immediately on the next check.
+        if ($manifest === null) {
+            return response()->json(
+                ['error' => 'upstream manifest unavailable'],
+                503
+            );
+        }
+
+        return response()->json($manifest);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\NotificationsController;
 use App\Http\Controllers\RankingController;
 use App\Http\Controllers\EndpointController;
+use App\Http\Controllers\LauncherController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ChangelogController;
 use App\Http\Controllers\PagesController;
@@ -50,6 +51,13 @@ Route::post('/search', [SearchController::class, 'search'])->name('search');
 Route::get('/servers', [ServersController::class, 'index'])->name('servers');
 Route::get('/api/servers/live', [ServersController::class, 'apiServers'])->name('servers.api');
 Route::get('/servers/json', [EndpointController::class, 'index'])->name('servers.json');
+
+// Launcher auto-update manifest — primary endpoint for the desktop
+// launcher's tauri-plugin-updater (GH Releases is its fallback). Proxies
+// the latest signed `latest.json` from GH with a 5-minute cache so we
+// don't pound their CDN on every launcher startup. The mirror exists
+// for CN/RU users who have trouble reaching GitHub directly.
+Route::get('/launcher/latest.json', [LauncherController::class, 'latestManifest'])->name('launcher.manifest');
 
 Route::get('/maps', [MapsController::class, 'index'])->name('maps');
 Route::get('/maps/filters', [MapsController::class, 'filters'])->name('maps.filters');


### PR DESCRIPTION
## Summary
- New `LauncherController::latestManifest()` proxies the upstream signed `latest.json` from `github.com/Defrag-racing/defrag-racing-launcher/releases/latest/download/latest.json`.
- 5-min `Cache::remember` shields us from GH rate limits and keeps response time fast on repeat hits.
- Manifest returned verbatim - signatures stay valid because the launcher verifies them client-side against its embedded pubkey. No rewriting of platforms / URLs / sigs.
- Upstream failure returns 503 with no negative caching, so the launcher's secondary endpoint (GH Releases) takes over immediately on the next check.

## Why
The launcher's `tauri-plugin-updater` config has two endpoints - defrag.racing primary, GitHub Releases fallback. Primary exists because GH is intermittently blocked or slow for users in CN and parts of RU. Without this route, every launcher startup falls through to the secondary endpoint, which works but defeats having defrag.racing as primary at all.