### PR TITLE
Launcher API throttle: split per endpoint (read 6000/min, upload 300/min)

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -43,9 +43,12 @@ class RouteServiceProvider extends ServiceProvider
         //  - launcher-upload: upload-demo. This actually does work
         //    (multipart receive, file move, ProcessDemoJob dispatch),
         //    plus the file payload is order(s) of magnitude larger
-        //    than a lookup. 60/min = 1/sec is enough for live recording
-        //    and twice that for a backlog drain; anything faster would
-        //    saturate ProcessDemoJob workers anyway.
+        //    than a lookup. We have 7 ProcessDemoJob workers at ~1-2s
+        //    per job = ~210-420 jobs/min sustained capacity. 300/min
+        //    (5/sec) per token sits comfortably under that for a
+        //    single user and absorbs bursts (1000-demo first-run
+        //    rescan finishes in ~3 minutes). Pending jobs queue up
+        //    in the DB during a burst and drain at worker rate.
         //
         // Falls back to user id or IP when somehow no token is present
         // (shouldn't happen on the launcher routes, belt & braces).
@@ -61,7 +64,7 @@ class RouteServiceProvider extends ServiceProvider
         });
 
         RateLimiter::for('launcher-upload', function (Request $request) use ($launcherKey) {
-            return Limit::perMinute(60)->by($launcherKey($request, 'launcher-upload'));
+            return Limit::perMinute(300)->by($launcherKey($request, 'launcher-upload'));
         });
 
         // Back-compat alias for any leftover route still pointing at the

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -28,16 +28,47 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
 
-        // Launcher API bucket — per token so multiple devices with the same
-        // account don't share the quota. Falls back to user id when the
-        // request somehow arrives without a token (shouldn't happen, belt &
-        // braces).
-        RateLimiter::for('launcher', function (Request $request) {
-            $key = $request->user()?->currentAccessToken()?->id
+        // Launcher API buckets, keyed per token so two devices on the same
+        // account don't share quota. We split by work intensity:
+        //
+        //  - launcher-read: lookup-by-hash, servers, notifications.
+        //    These are single indexed selects + serializer; the cost is
+        //    HTTP overhead, not DB load. The launcher fires one
+        //    lookup-by-hash per cache-miss demo during a rescan, so a
+        //    10k-demo backlog from a long-time player on first run can
+        //    blow past anything tight. 6000/min = 100/sec covers even
+        //    a "no CPU limit" disk-bound rescan without hitting 429,
+        //    and well under any abuse threshold (it's one indexed read).
+        //
+        //  - launcher-upload: upload-demo. This actually does work
+        //    (multipart receive, file move, ProcessDemoJob dispatch),
+        //    plus the file payload is order(s) of magnitude larger
+        //    than a lookup. 60/min = 1/sec is enough for live recording
+        //    and twice that for a backlog drain; anything faster would
+        //    saturate ProcessDemoJob workers anyway.
+        //
+        // Falls back to user id or IP when somehow no token is present
+        // (shouldn't happen on the launcher routes, belt & braces).
+        $launcherKey = function (Request $request, string $prefix) {
+            $id = $request->user()?->currentAccessToken()?->id
                 ?? $request->user()?->id
                 ?? $request->ip();
+            return $prefix . ':' . $id;
+        };
 
-            return Limit::perMinute(120)->by('launcher:' . $key);
+        RateLimiter::for('launcher-read', function (Request $request) use ($launcherKey) {
+            return Limit::perMinute(6000)->by($launcherKey($request, 'launcher-read'));
+        });
+
+        RateLimiter::for('launcher-upload', function (Request $request) use ($launcherKey) {
+            return Limit::perMinute(60)->by($launcherKey($request, 'launcher-upload'));
+        });
+
+        // Back-compat alias for any leftover route still pointing at the
+        // old single bucket. Same limit as launcher-read so nothing
+        // legacy gets stuck on the old 120/min.
+        RateLimiter::for('launcher', function (Request $request) use ($launcherKey) {
+            return Limit::perMinute(6000)->by($launcherKey($request, 'launcher'));
         });
 
         $this->routes(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,20 +20,37 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 // Desktop launcher API. Sanctum personal access tokens issued at
 // /user/launcher-tokens with abilities ["launcher:upload","launcher:read"].
-// Split into two inner groups so a future read-only token (e.g. for an
-// observer / overlay client) can be scoped without granting upload. The
-// `log.api` middleware writes every call to api_call_log — same audit
-// trail the post-incident lockdown added to the public-facing /api
-// routes, applied here proactively so we never repeat that mistake.
+// Split by both ability AND throttle bucket so cheap reads can't get
+// pushed into 429 by the same per-token limit that gates expensive
+// uploads:
+//
+//  - launcher-read (1200/min): lookup-by-hash, servers, notifications.
+//    A rescan fires one lookup-by-hash per demo so on first run a
+//    long-time player with thousands of cached demos hits it hard.
+//    20/sec headroom keeps that working even on a "no CPU limit" setting.
+//
+//  - launcher-upload (60/min): upload-demo only. Multipart upload is
+//    heavy, ProcessDemoJob takes seconds, 1/sec is plenty for live
+//    recording and matches what worker throughput supports anyway.
+//
+// `log.api` writes every call to api_call_log for the same audit trail
+// the post-incident /api lockdown added, applied here proactively.
 Route::prefix('launcher')
-    ->middleware(['auth:sanctum', 'throttle:launcher', 'log.api'])
+    ->middleware(['auth:sanctum', 'log.api'])
     ->group(function () {
-        Route::middleware('abilities:launcher:upload')->group(function () {
-            Route::post('/lookup-by-hash', [\App\Http\Controllers\Api\LauncherController::class, 'lookupByHash']);
+        Route::middleware(['abilities:launcher:upload', 'throttle:launcher-upload'])->group(function () {
             Route::post('/upload-demo', [\App\Http\Controllers\Api\LauncherController::class, 'uploadDemo']);
         });
 
-        Route::middleware('abilities:launcher:read')->group(function () {
+        // lookup-by-hash is a write-ability route (it's POST and lives
+        // alongside upload-demo conceptually) but uses the read bucket
+        // because it's a single indexed SELECT - same cost shape as
+        // /servers and /notifications.
+        Route::middleware(['abilities:launcher:upload', 'throttle:launcher-read'])->group(function () {
+            Route::post('/lookup-by-hash', [\App\Http\Controllers\Api\LauncherController::class, 'lookupByHash']);
+        });
+
+        Route::middleware(['abilities:launcher:read', 'throttle:launcher-read'])->group(function () {
             Route::get('/servers', [\App\Http\Controllers\Api\LauncherController::class, 'servers']);
             Route::get('/notifications', [\App\Http\Controllers\Api\LauncherController::class, 'notifications']);
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,9 +29,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 //    long-time player with thousands of cached demos hits it hard.
 //    20/sec headroom keeps that working even on a "no CPU limit" setting.
 //
-//  - launcher-upload (60/min): upload-demo only. Multipart upload is
-//    heavy, ProcessDemoJob takes seconds, 1/sec is plenty for live
-//    recording and matches what worker throughput supports anyway.
+//  - launcher-upload (300/min): upload-demo only. Multipart upload
+//    + ProcessDemoJob dispatch. 7 workers at ~1-2s/job give us
+//    ~210-420 jobs/min sustained, so 5/sec per token absorbs first-
+//    run rescan bursts (1000 demos in ~3 min) while leaving headroom
+//    when several uploaders run at once. Pending jobs queue and
+//    drain at worker rate.
 //
 // `log.api` writes every call to api_call_log for the same audit trail
 // the post-incident /api lockdown added, applied here proactively.


### PR DESCRIPTION
## Summary

- Split the single `launcher` rate-limit bucket (120/min) into two: `launcher-read` (6000/min) for cheap indexed reads and `launcher-upload` (300/min) for actual file ingest.
- `routes/api.php` applies throttles per-route group rather than at the outer prefix.
- Old `launcher` bucket kept as a forward-compat alias at the same 6000/min.

## Why

The desktop launcher fires one `POST /api/launcher/lookup-by-hash` per cache-miss demo during a rescan. A long-time player on first run can have thousands of demos. At 120/min they hit 429 within seconds and the launcher silently dropped those demos into Error rows; the actual upload endpoint barely moved at all by comparison. Upload limit is anchored to ProcessDemoJob worker capacity (7 workers × ~1-2s/job ≈ 210-420 jobs/min sustained). New limits match work shape:

| Endpoint | Cost shape | New bucket | Limit |
|---|---|---|---|
| `POST /lookup-by-hash` | indexed SELECT | launcher-read | 6000/min |
| `GET /servers` | cached select + serializer | launcher-read | 6000/min |
| `GET /notifications` | indexed SELECT per user | launcher-read | 6000/min |
| `POST /upload-demo` | multipart + ProcessDemoJob | launcher-upload | 300/min |
