### PR TITLE
Drop throttle:api on launcher routes so per-route limits actually apply

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -38,8 +38,17 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 //
 // `log.api` writes every call to api_call_log for the same audit trail
 // the post-incident /api lockdown added, applied here proactively.
+//
+// `withoutMiddleware('throttle:api')` is critical: the api middleware
+// group applies `throttle:api` (60/min per user) to every route under
+// /api, which would otherwise dominate over the per-route launcher
+// throttles below. Demome routes already drop it for the same reason
+// (their headless renderer would burn through 60/min in seconds).
+// Without this line the launcher-read 6000/min limit was a no-op and
+// rescans got 429ed at the 60-call mark.
 Route::prefix('launcher')
     ->middleware(['auth:sanctum', 'log.api'])
+    ->withoutMiddleware('throttle:api')
     ->group(function () {
         Route::middleware(['abilities:launcher:upload', 'throttle:launcher-upload'])->group(function () {
             Route::post('/upload-demo', [\App\Http\Controllers\Api\LauncherController::class, 'uploadDemo']);


### PR DESCRIPTION
The previous split into launcher-read (6000/min) + launcher-upload (300/min) was effectively a no-op. Launcher routes live under the `api` middleware group which applies `throttle:api` (60/min per user) on top of any per-route throttle. Multiple throttle limiters combine via min(), so the 60/min global won every time and rescans got 429ed at exactly 60 lookups in - regardless of the 6000/launcher-read setting.

Fix mirrors what the demome routes already do:
`->withoutMiddleware('throttle:api')` on the launcher group, so the per-route launcher-read / launcher-upload buckets are the only throttles in play. Auth is still enforced via auth:sanctum and log.api still writes the audit trail.

Reported by a real first-run rescan: queue UI hit 500 / 499 backed up and got a "Rate-limited, resuming in 51s" banner, even though the user had only made one server call past the cache-hit fast path - the global throttle:api had already burned through its 60/min budget on earlier sessions or unrelated /api traffic.