### PR TITLE
Launcher API: records / maps / me / render endpoints + throttle bucket split

### DIFF
--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -189,6 +189,29 @@ class LauncherController extends Controller
     }
 
     /**
+     * Minimal "who am I" for the launcher. Returns the fields the
+     * launcher needs to wire up the top nav's Profile button (mdd_id
+     * for the /profile/{id} link, name + country for the badge) and
+     * nothing else. Used once per app start; cached in the launcher's
+     * config store so the button works offline thereafter.
+     *
+     * Lives under the launcher-read bucket so a misclick on the
+     * Profile button can't be turned into a 429 by the global
+     * throttle:api ceiling.
+     */
+    public function me(Request $request)
+    {
+        $user = $request->user();
+        return response()->json([
+            'id' => $user->id,
+            'mdd_id' => $user->mdd_id,
+            'name' => $user->name,
+            'plain_name' => $user->plain_name ?? null,
+            'country' => $user->country ?? null,
+        ]);
+    }
+
+    /**
      * Paginated recent records for the launcher's Records tab. Single
      * physics per call (the launcher renders two tables side-by-side
      * and queries each independently) so the response stays small and

--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Jobs\ProcessDemoJob;
+use App\Models\Map;
 use App\Models\Notification;
+use App\Models\Record;
 use App\Models\RecordNotification;
 use App\Models\UploadedDemo;
 use App\Services\ServerListService;
@@ -184,5 +186,75 @@ class LauncherController extends Controller
                 'total' => $unreadRecords + $unreadSystem,
             ],
         ]);
+    }
+
+    /**
+     * Paginated recent records for the launcher's Records tab. Single
+     * physics per call (the launcher renders two tables side-by-side
+     * and queries each independently) so the response stays small and
+     * the per-page count is honest.
+     *
+     * Deliberately a minimal projection of what RecordsController
+     * returns to the web Inertia page - no PlayerMapScore enrichment,
+     * no rating multipliers, no offline_records merge. The launcher
+     * lists "newest records, by physics" as a quick browser; users
+     * who want the rich rating context click through to the web map
+     * page anyway.
+     *
+     * Query: ?physics=vq3|cpm  (defaults to vq3)
+     *        &page=1
+     */
+    public function records(Request $request)
+    {
+        $data = $request->validate([
+            'physics' => 'nullable|in:vq3,cpm',
+            'page' => 'nullable|integer|min:1|max:1000',
+        ]);
+
+        $physics = $data['physics'] ?? 'vq3';
+        $page = $data['page'] ?? 1;
+        $perPage = 100;
+
+        $records = Record::query()
+            ->where('physics', $physics)
+            ->with(['user:id,name,plain_name,country,profile_photo_path'])
+            ->orderBy('date_set', 'DESC')
+            ->paginate($perPage, ['id', 'name', 'country', 'mdd_id', 'mapname', 'rank', 'time', 'date_set', 'physics', 'mode'], 'page', $page);
+
+        return response()->json($records);
+    }
+
+    /**
+     * Paginated map list for the launcher's Maps tab. Newest first,
+     * optional name search. The launcher intentionally doesn't expose
+     * the web's MapFilters surface - if the user wants to filter by
+     * weapon / gametype / NSFW / etc. they click through to the
+     * matching map page and get the web's full filter UI.
+     *
+     * Query: ?page=1  &search=optional-substring
+     */
+    public function maps(Request $request)
+    {
+        $data = $request->validate([
+            'page' => 'nullable|integer|min:1|max:1000',
+            'search' => 'nullable|string|max:64',
+        ]);
+
+        $page = $data['page'] ?? 1;
+        $search = $data['search'] ?? null;
+        $perPage = 50;
+
+        $query = Map::query()
+            ->select('id', 'name', 'author', 'thumbnail', 'physics', 'gametype', 'is_nsfw', 'date_added')
+            ->orderBy('date_added', 'DESC')
+            ->orderBy('id', 'DESC');
+
+        if ($search !== null && $search !== '') {
+            $query->where('name', 'LIKE', '%' . $search . '%');
+        }
+
+        return response()->json(
+            $query->paginate($perPage, ['*'], 'page', $page)
+        );
     }
 }

--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -8,9 +8,11 @@ use App\Models\Map;
 use App\Models\Notification;
 use App\Models\Record;
 use App\Models\RecordNotification;
+use App\Models\RenderedVideo;
 use App\Models\UploadedDemo;
 use App\Services\ServerListService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -279,5 +281,173 @@ class LauncherController extends Controller
         return response()->json(
             $query->paginate($perPage, ['*'], 'page', $page)
         );
+    }
+
+    /**
+     * Request a YouTube render for a demo the launcher already
+     * uploaded. Mirrors the web RenderRequestController flow, with two
+     * key differences:
+     *
+     *  - lookup by file_hash OR demo_id (launcher has the hash locally
+     *    from uploaded.json without needing the demo_id round-trip)
+     *  - record_id is optional (launcher renders are demo-driven, not
+     *    record-driven; demome's pipeline handles record_id=null)
+     *
+     * If the demo already has a non-failed RenderedVideo we short-
+     * circuit and return its current status / youtube_url so the
+     * launcher can show "already rendered" without a second queue
+     * entry. Same 20-renders-per-day quota as the web button, shared
+     * cache key so the user can't exceed it by bouncing between web
+     * and launcher.
+     *
+     * Notification on completion comes for free - DemomeController's
+     * markPublished() already fires a `render_completed` Notification
+     * when the YouTube upload succeeds, regardless of source.
+     */
+    public function renderVideo(Request $request)
+    {
+        $data = $request->validate([
+            'demo_id' => 'nullable|integer|exists:uploaded_demos,id',
+            'file_hash' => 'nullable|string|size:32',
+        ]);
+
+        if (empty($data['demo_id']) && empty($data['file_hash'])) {
+            return response()->json([
+                'error' => 'Pass either demo_id or file_hash.',
+            ], 422);
+        }
+
+        $user = $request->user();
+
+        if (! $user->canUploadDemos()) {
+            return response()->json([
+                'error' => 'Your account is restricted from rendering.',
+            ], 403);
+        }
+
+        $demo = isset($data['demo_id'])
+            ? UploadedDemo::find($data['demo_id'])
+            : UploadedDemo::where('file_hash', strtolower($data['file_hash']))->first();
+
+        if (! $demo) {
+            return response()->json([
+                'error' => 'Demo not found. Upload it first via /upload-demo.',
+                'needs_upload' => true,
+            ], 404);
+        }
+
+        // Already in the pipeline (any non-failed state) - hand back
+        // whatever we have so the launcher can show progress instead
+        // of double-queueing.
+        $existing = RenderedVideo::where('demo_id', $demo->id)
+            ->whereIn('status', ['pending', 'rendering', 'uploading', 'completed'])
+            ->orderByDesc('id')
+            ->first();
+
+        if ($existing) {
+            return response()->json([
+                'already_queued' => true,
+                'id' => $existing->id,
+                'status' => $existing->status,
+                'youtube_url' => $existing->youtube_url,
+                'youtube_video_id' => $existing->youtube_video_id,
+            ]);
+        }
+
+        // Same daily quota as the web request flow - shared cache key
+        // so a user can't sidestep the cap by alternating between
+        // /render-request on the web and /render-video here.
+        $cacheKey = "render_requests_user_{$user->id}_" . now()->format('Y-m-d');
+        $todayCount = Cache::get($cacheKey, 0);
+        if ($todayCount >= 20) {
+            return response()->json([
+                'error' => 'Daily render limit reached (20/day).',
+                'remaining' => 0,
+            ], 429);
+        }
+
+        $demoUrl = config('app.url') . "/api/demome/download-demo/{$demo->id}";
+
+        $video = RenderedVideo::create([
+            'map_name' => $demo->map_name,
+            'player_name' => $demo->player_name,
+            'physics' => $demo->physics,
+            'time_ms' => $demo->time_ms,
+            'gametype' => $demo->gametype,
+            'demo_id' => $demo->id,
+            'record_id' => null,
+            'user_id' => $user->id,
+            'source' => 'launcher',
+            'requested_by' => $user->name,
+            'status' => 'pending',
+            'priority' => 0,
+            'demo_url' => $demoUrl,
+            'demo_filename' => $demo->original_filename,
+        ]);
+
+        Cache::put($cacheKey, $todayCount + 1, now()->endOfDay());
+
+        $queuePosition = RenderedVideo::where('status', 'pending')
+            ->where('id', '<', $video->id)
+            ->count() + 1;
+
+        return response()->json([
+            'success' => true,
+            'id' => $video->id,
+            'status' => 'pending',
+            'queue_position' => $queuePosition,
+            'remaining_today' => 20 - ($todayCount + 1),
+        ]);
+    }
+
+    /**
+     * Fast status check for a render the launcher previously queued.
+     * Used by the Library view to refresh the YouTube link without
+     * the user having to wait for the next notifications poll.
+     * Cheaper than fetching all notifications.
+     */
+    public function renderStatus(Request $request)
+    {
+        $data = $request->validate([
+            'demo_id' => 'nullable|integer|exists:uploaded_demos,id',
+            'file_hash' => 'nullable|string|size:32',
+        ]);
+
+        if (empty($data['demo_id']) && empty($data['file_hash'])) {
+            return response()->json([
+                'error' => 'Pass either demo_id or file_hash.',
+            ], 422);
+        }
+
+        $demo = isset($data['demo_id'])
+            ? UploadedDemo::find($data['demo_id'])
+            : UploadedDemo::where('file_hash', strtolower($data['file_hash']))->first();
+
+        if (! $demo) {
+            return response()->json([
+                'has_render' => false,
+                'reason' => 'demo_not_uploaded',
+            ]);
+        }
+
+        $video = RenderedVideo::where('demo_id', $demo->id)
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $video) {
+            return response()->json([
+                'has_render' => false,
+                'demo_id' => $demo->id,
+            ]);
+        }
+
+        return response()->json([
+            'has_render' => true,
+            'demo_id' => $demo->id,
+            'id' => $video->id,
+            'status' => $video->status,
+            'youtube_url' => $video->youtube_url,
+            'youtube_video_id' => $video->youtube_video_id,
+        ]);
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -28,27 +28,33 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
 
-        // Launcher API buckets, keyed per token so two devices on the same
-        // account don't share quota. We split by work intensity:
+        // Launcher API buckets, keyed per token so two devices on the
+        // same account don't share quota. Three buckets, one per
+        // workload shape, so heavy traffic in one can't starve another:
         //
-        //  - launcher-read: lookup-by-hash, servers, notifications.
-        //    These are single indexed selects + serializer; the cost is
-        //    HTTP overhead, not DB load. The launcher fires one
-        //    lookup-by-hash per cache-miss demo during a rescan, so a
-        //    10k-demo backlog from a long-time player on first run can
-        //    blow past anything tight. 6000/min = 100/sec covers even
-        //    a "no CPU limit" disk-bound rescan without hitting 429,
-        //    and well under any abuse threshold (it's one indexed read).
+        //  - launcher-lookup: hash-by-lookup ONLY. Rescans burn this
+        //    bucket - one call per cache-miss demo. A power user on a
+        //    fresh install with thousands of demos and the Faster (no
+        //    limit) CPU setting can fire 50-100 requests/sec for a
+        //    couple of minutes. 6000/min = 100/sec covers that without
+        //    429 and sits well under any abuse threshold (single
+        //    indexed read).
         //
-        //  - launcher-upload: upload-demo. This actually does work
-        //    (multipart receive, file move, ProcessDemoJob dispatch),
-        //    plus the file payload is order(s) of magnitude larger
-        //    than a lookup. We have 7 ProcessDemoJob workers at ~1-2s
+        //  - launcher-browse: servers, notifications, records, maps,
+        //    me. User-initiated UI calls; polling intervals are ~60s,
+        //    a click can't fire faster than a few per second. 600/min
+        //    = 10/sec is huge headroom for that traffic pattern and
+        //    crucially is RESERVED from the lookup budget so a heavy
+        //    rescan can't 429 the server browser / Records / Maps
+        //    while it drains. Previously these shared launcher-read
+        //    with lookup-by-hash and a Faster-button rescan could
+        //    starve them.
+        //
+        //  - launcher-upload: upload-demo. Actual work (multipart
+        //    receive + ProcessDemoJob dispatch); 7 workers at ~1-2s
         //    per job = ~210-420 jobs/min sustained capacity. 300/min
-        //    (5/sec) per token sits comfortably under that for a
-        //    single user and absorbs bursts (1000-demo first-run
-        //    rescan finishes in ~3 minutes). Pending jobs queue up
-        //    in the DB during a burst and drain at worker rate.
+        //    (5/sec) absorbs first-run bursts and queues overflow at
+        //    worker rate via the DB queue table.
         //
         // Falls back to user id or IP when somehow no token is present
         // (shouldn't happen on the launcher routes, belt & braces).
@@ -59,17 +65,25 @@ class RouteServiceProvider extends ServiceProvider
             return $prefix . ':' . $id;
         };
 
-        RateLimiter::for('launcher-read', function (Request $request) use ($launcherKey) {
-            return Limit::perMinute(6000)->by($launcherKey($request, 'launcher-read'));
+        RateLimiter::for('launcher-lookup', function (Request $request) use ($launcherKey) {
+            return Limit::perMinute(6000)->by($launcherKey($request, 'launcher-lookup'));
+        });
+
+        RateLimiter::for('launcher-browse', function (Request $request) use ($launcherKey) {
+            return Limit::perMinute(600)->by($launcherKey($request, 'launcher-browse'));
         });
 
         RateLimiter::for('launcher-upload', function (Request $request) use ($launcherKey) {
             return Limit::perMinute(300)->by($launcherKey($request, 'launcher-upload'));
         });
 
-        // Back-compat alias for any leftover route still pointing at the
-        // old single bucket. Same limit as launcher-read so nothing
-        // legacy gets stuck on the old 120/min.
+        // Back-compat aliases for any leftover route still pointing at
+        // the older single bucket. Same numeric limit as launcher-lookup
+        // so legacy traffic isn't punished, but new routes should use
+        // launcher-lookup / launcher-browse explicitly.
+        RateLimiter::for('launcher-read', function (Request $request) use ($launcherKey) {
+            return Limit::perMinute(6000)->by($launcherKey($request, 'launcher-read'));
+        });
         RateLimiter::for('launcher', function (Request $request) use ($launcherKey) {
             return Limit::perMinute(6000)->by($launcherKey($request, 'launcher'));
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,6 +70,17 @@ Route::prefix('launcher')
             Route::get('/notifications', [\App\Http\Controllers\Api\LauncherController::class, 'notifications']);
             Route::get('/records', [\App\Http\Controllers\Api\LauncherController::class, 'records']);
             Route::get('/maps', [\App\Http\Controllers\Api\LauncherController::class, 'maps']);
+            Route::get('/render-status', [\App\Http\Controllers\Api\LauncherController::class, 'renderStatus']);
+        });
+
+        // Render-video is a write op (queues a job, costs render farm
+        // time) so it requires the upload ability the same way
+        // upload-demo does. Stays in the browse bucket because the
+        // user-facing rate is "a few clicks per minute" - the
+        // 20-per-day quota inside the controller is the real cap, the
+        // bucket is just abuse defence.
+        Route::middleware(['abilities:launcher:upload', 'throttle:launcher-browse'])->group(function () {
+            Route::post('/render-video', [\App\Http\Controllers\Api\LauncherController::class, 'renderVideo']);
         });
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,21 +20,22 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 // Desktop launcher API. Sanctum personal access tokens issued at
 // /user/launcher-tokens with abilities ["launcher:upload","launcher:read"].
-// Split by both ability AND throttle bucket so cheap reads can't get
-// pushed into 429 by the same per-token limit that gates expensive
-// uploads:
+// Three throttle buckets, one per workload shape, so traffic in one
+// section can't starve another:
 //
-//  - launcher-read (1200/min): lookup-by-hash, servers, notifications.
-//    A rescan fires one lookup-by-hash per demo so on first run a
-//    long-time player with thousands of cached demos hits it hard.
-//    20/sec headroom keeps that working even on a "no CPU limit" setting.
+//  - launcher-lookup (6000/min = 100/sec): lookup-by-hash ONLY.
+//    Rescans hammer this; isolated so a Faster-button burst can't
+//    affect browse endpoints.
 //
-//  - launcher-upload (300/min): upload-demo only. Multipart upload
-//    + ProcessDemoJob dispatch. 7 workers at ~1-2s/job give us
-//    ~210-420 jobs/min sustained, so 5/sec per token absorbs first-
-//    run rescan bursts (1000 demos in ~3 min) while leaving headroom
-//    when several uploaders run at once. Pending jobs queue and
-//    drain at worker rate.
+//  - launcher-browse (600/min = 10/sec): servers, notifications,
+//    records, maps, me. User-initiated UI; reserved from the
+//    lookup budget so the launcher UI stays responsive even during
+//    a heavy rescan.
+//
+//  - launcher-upload (300/min = 5/sec): upload-demo only. Multipart
+//    upload + ProcessDemoJob dispatch. 7 workers at ~1-2s/job give
+//    us ~210-420 jobs/min sustained. Pending jobs queue and drain
+//    at worker rate.
 //
 // `log.api` writes every call to api_call_log for the same audit trail
 // the post-incident /api lockdown added, applied here proactively.
@@ -55,14 +56,15 @@ Route::prefix('launcher')
         });
 
         // lookup-by-hash is a write-ability route (it's POST and lives
-        // alongside upload-demo conceptually) but uses the read bucket
-        // because it's a single indexed SELECT - same cost shape as
-        // /servers and /notifications.
-        Route::middleware(['abilities:launcher:upload', 'throttle:launcher-read'])->group(function () {
+        // alongside upload-demo conceptually) but lives in its OWN
+        // throttle bucket (launcher-lookup) so a rescan burst can't
+        // burn through the budget that gates the browse endpoints
+        // below.
+        Route::middleware(['abilities:launcher:upload', 'throttle:launcher-lookup'])->group(function () {
             Route::post('/lookup-by-hash', [\App\Http\Controllers\Api\LauncherController::class, 'lookupByHash']);
         });
 
-        Route::middleware(['abilities:launcher:read', 'throttle:launcher-read'])->group(function () {
+        Route::middleware(['abilities:launcher:read', 'throttle:launcher-browse'])->group(function () {
             Route::get('/me', [\App\Http\Controllers\Api\LauncherController::class, 'me']);
             Route::get('/servers', [\App\Http\Controllers\Api\LauncherController::class, 'servers']);
             Route::get('/notifications', [\App\Http\Controllers\Api\LauncherController::class, 'notifications']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,7 @@ Route::prefix('launcher')
         });
 
         Route::middleware(['abilities:launcher:read', 'throttle:launcher-read'])->group(function () {
+            Route::get('/me', [\App\Http\Controllers\Api\LauncherController::class, 'me']);
             Route::get('/servers', [\App\Http\Controllers\Api\LauncherController::class, 'servers']);
             Route::get('/notifications', [\App\Http\Controllers\Api\LauncherController::class, 'notifications']);
             Route::get('/records', [\App\Http\Controllers\Api\LauncherController::class, 'records']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,8 @@ Route::prefix('launcher')
         Route::middleware(['abilities:launcher:read', 'throttle:launcher-read'])->group(function () {
             Route::get('/servers', [\App\Http\Controllers\Api\LauncherController::class, 'servers']);
             Route::get('/notifications', [\App\Http\Controllers\Api\LauncherController::class, 'notifications']);
+            Route::get('/records', [\App\Http\Controllers\Api\LauncherController::class, 'records']);
+            Route::get('/maps', [\App\Http\Controllers\Api\LauncherController::class, 'maps']);
         });
     });
 


### PR DESCRIPTION
- Four new endpoints + a throttle refactor wrapping up the desktop launcher feature set
- `GET /api/launcher/records?physics=vq3|cpm&page=N` - paginated recent records (100/page), minimal projection for the launcher's Records tab; web `/rankings` stays source of truth for rich filters
- `GET /api/launcher/maps?page=N&search=` - paginated maps newest first (50/page), optional name substring; advanced filters stay on web `/maps`
- `GET /api/launcher/me` - minimal "who am I" (id, mdd_id, name, country) cached client-side for the Profile button
- `POST /api/launcher/render-video` - queues a YouTube render via demome farm same path as web `/render-request` and the Discord bot's `start-discord-render`; accepts `demo_id` OR `file_hash` (launcher has hash locally); short-circuits with `already_queued` for existing entries; shares the 20/day quota with the web button
- `GET /api/launcher/render-status?file_hash=` - cheap single-demo status poll for the Library view
- Throttle buckets split from one `launcher-read` (6000/min) into `launcher-lookup` (6000/min, hash lookups only) + `launcher-browse` (600/min, all UI endpoints) so a Faster-mode rescan can't 429 the server browser / Records / Maps
- `launcher-upload` (300/min) unchanged
- Back-compat aliases `launcher-read` and `launcher` kept defined so external scripts don't break
- All new routes under `withoutMiddleware('throttle:api')` + appropriate ability gate (`launcher:read` for browse, `launcher:upload` for write ops)
- Render completion notification comes for free - DemomeController's `markPublished()` already fires `render_completed` Notification regardless of source, picked up by existing `/api/launcher/notifications`
- Validation pins physics to vq3|cpm, page 1-1000, file_hash to exactly 32 chars