### PR TITLE
Launcher API: mark-as-read mutations for notifications

### DIFF
--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -191,6 +191,93 @@ class LauncherController extends Controller
     }
 
     /**
+     * Per-row toggle for a record notification. Flips `read` and
+     * returns the new state + fresh unread counts so the launcher
+     * can update its badge without a separate /notifications poll.
+     * 404 when the row doesn't exist OR belongs to a different user
+     * (the where on user_id is what enforces tenant isolation).
+     */
+    public function notificationRecordToggle(Request $request, int $id)
+    {
+        $userId = $request->user()->id;
+        $row = RecordNotification::where('user_id', $userId)->where('id', $id)->first();
+        if (! $row) {
+            return response()->json(['error' => 'not_found'], 404);
+        }
+        $row->read = ! $row->read;
+        $row->save();
+        return response()->json([
+            'id' => $row->id,
+            'read' => (bool) $row->read,
+            'unread' => $this->unreadCounts($userId),
+        ]);
+    }
+
+    /** Mark every record notification for this user as read. */
+    public function notificationRecordsMarkRead(Request $request)
+    {
+        $userId = $request->user()->id;
+        RecordNotification::where('user_id', $userId)->where('read', false)->update(['read' => true]);
+        return response()->json(['unread' => $this->unreadCounts($userId)]);
+    }
+
+    /** Mark every record notification for this user as unread. */
+    public function notificationRecordsMarkUnread(Request $request)
+    {
+        $userId = $request->user()->id;
+        RecordNotification::where('user_id', $userId)->where('read', true)->update(['read' => false]);
+        return response()->json(['unread' => $this->unreadCounts($userId)]);
+    }
+
+    /** System notification equivalents. Same shape as the record ones. */
+    public function notificationSystemToggle(Request $request, int $id)
+    {
+        $userId = $request->user()->id;
+        $row = Notification::where('user_id', $userId)->where('id', $id)->first();
+        if (! $row) {
+            return response()->json(['error' => 'not_found'], 404);
+        }
+        $row->read = ! $row->read;
+        $row->save();
+        return response()->json([
+            'id' => $row->id,
+            'read' => (bool) $row->read,
+            'unread' => $this->unreadCounts($userId),
+        ]);
+    }
+
+    public function notificationSystemMarkRead(Request $request)
+    {
+        $userId = $request->user()->id;
+        Notification::where('user_id', $userId)->where('read', false)->update(['read' => true]);
+        return response()->json(['unread' => $this->unreadCounts($userId)]);
+    }
+
+    public function notificationSystemMarkUnread(Request $request)
+    {
+        $userId = $request->user()->id;
+        Notification::where('user_id', $userId)->where('read', true)->update(['read' => false]);
+        return response()->json(['unread' => $this->unreadCounts($userId)]);
+    }
+
+    /**
+     * Shared unread-count payload returned by every mark-read/unread
+     * mutation above. Keeps the launcher bell badge in sync with what
+     * the server just changed, without a separate /notifications
+     * round-trip.
+     */
+    private function unreadCounts(int $userId): array
+    {
+        $records = RecordNotification::where('user_id', $userId)->where('read', false)->count();
+        $system = Notification::where('user_id', $userId)->where('read', false)->count();
+        return [
+            'records' => $records,
+            'system' => $system,
+            'total' => $records + $system,
+        ];
+    }
+
+    /**
      * Minimal "who am I" for the launcher. Returns the fields the
      * launcher needs to wire up the top nav's Profile button (mdd_id
      * for the /profile/{id} link, name + country for the badge) and

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,6 +71,19 @@ Route::prefix('launcher')
             Route::get('/records', [\App\Http\Controllers\Api\LauncherController::class, 'records']);
             Route::get('/maps', [\App\Http\Controllers\Api\LauncherController::class, 'maps']);
             Route::get('/render-status', [\App\Http\Controllers\Api\LauncherController::class, 'renderStatus']);
+
+            // Mark-as-read / mark-as-unread for the launcher Notifications
+            // tab. Per-row toggle covers normal interaction; bulk endpoints
+            // back the "Mark all as read/unread" buttons so a user with 50
+            // unread doesn't fire 50 round-trips. Same throttle bucket as
+            // the read endpoints - all mutations here are tiny single-row
+            // updates (or one UPDATE for the bulk variants).
+            Route::post('/notifications/records/{id}/toggle', [\App\Http\Controllers\Api\LauncherController::class, 'notificationRecordToggle']);
+            Route::post('/notifications/records/mark-read', [\App\Http\Controllers\Api\LauncherController::class, 'notificationRecordsMarkRead']);
+            Route::post('/notifications/records/mark-unread', [\App\Http\Controllers\Api\LauncherController::class, 'notificationRecordsMarkUnread']);
+            Route::post('/notifications/system/{id}/toggle', [\App\Http\Controllers\Api\LauncherController::class, 'notificationSystemToggle']);
+            Route::post('/notifications/system/mark-read', [\App\Http\Controllers\Api\LauncherController::class, 'notificationSystemMarkRead']);
+            Route::post('/notifications/system/mark-unread', [\App\Http\Controllers\Api\LauncherController::class, 'notificationSystemMarkUnread']);
         });
 
         // Render-video is a write op (queues a job, costs render farm


### PR DESCRIPTION
## Summary
- Adds 6 POST endpoints under the existing `launcher-browse` throttle bucket (300/min) so the desktop launcher's Notifications tab can flip read state without going through the session-auth web routes
- Every response carries fresh `{ records, system, total }` unread counts so the launcher bell badge updates without a separate `/notifications` round-trip
- Per-user isolation enforced via `where('user_id', auth()->id())` on every query, same pattern the existing read endpoint uses

## Endpoints
```
POST /api/launcher/notifications/records/{id}/toggle
POST /api/launcher/notifications/records/mark-read
POST /api/launcher/notifications/records/mark-unread
POST /api/launcher/notifications/system/{id}/toggle
POST /api/launcher/notifications/system/mark-read
POST /api/launcher/notifications/system/mark-unread
```