### PR TITLE
Add rolling 24h upload-count endpoint for demome bot throttle

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 
 class DemomeController extends Controller
@@ -1055,6 +1056,32 @@ class DemomeController extends Controller
             'auto' => $auto,
             'web' => $web,
             'discord' => $discord,
+        ]);
+    }
+
+    /**
+     * Rolling N-hour upload count + when the oldest upload in the window expires.
+     * Bot uses this for a proactive throttle that respects YouTube's rolling 24h
+     * channel-level cap (uploadLimitExceeded), which `uploadCountsToday` doesn't
+     * catch — that one resets at local midnight, YouTube's cap doesn't.
+     */
+    public function recentUploadCount(Request $request)
+    {
+        $hours = max(1, min(168, (int) $request->input('hours', 24)));
+        $since = Carbon::now()->subHours($hours);
+
+        $base = RenderedVideo::where('status', 'completed')
+            ->whereNotNull('youtube_url')
+            ->where('updated_at', '>=', $since);
+
+        $count = (clone $base)->count();
+        $oldest = (clone $base)->orderBy('updated_at', 'asc')->first();
+
+        return response()->json([
+            'count' => $count,
+            'hours' => $hours,
+            'oldest_at' => $oldest?->updated_at?->toIso8601String(),
+            'oldest_expires_at' => $oldest?->updated_at?->addHours($hours)->toIso8601String(),
         ]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -132,6 +132,7 @@ Route::prefix('demome')->middleware('demome.token')->withoutMiddleware('throttle
     Route::get('/lookup-by-hash/{hash}', [\App\Http\Controllers\Api\DemomeController::class, 'lookupByHash']);
     Route::post('/swap-video/{renderedVideo}', [\App\Http\Controllers\Api\DemomeController::class, 'swapVideo']);
     Route::get('/upload-counts-today', [\App\Http\Controllers\Api\DemomeController::class, 'uploadCountsToday']);
+    Route::get('/recent-upload-count', [\App\Http\Controllers\Api\DemomeController::class, 'recentUploadCount']);
     Route::get('/publish-counts-today', [\App\Http\Controllers\Api\DemomeController::class, 'publishCountsToday']);
     Route::post('/auto-approve-publish', [\App\Http\Controllers\Api\DemomeController::class, 'autoApprovePublish']);
     Route::get('/video-metadata/{renderedVideo}', [\App\Http\Controllers\Api\DemomeController::class, 'videoMetadata']);


### PR DESCRIPTION
## Summary
- Adds `GET /api/demome/recent-upload-count?hours=24` returning `{count, hours, oldest_at, oldest_expires_at}`
- Bot needs this to throttle ahead of YouTube's rolling 24h channel cap, which the existing `/upload-counts-today` (calendar-day, resets at local midnight) can't detect
- Backend-only change; matching bot logic in demome-bot ships separately