### PR TITLE
Add automated nightly backup (DB + media to Backblaze B2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ PRODUCTION_CREDENTIALS.md
 # Don't commit one-off player rename commands
 /app/Console/Commands/RenamePlayer.php
 *.sql
+*.sql.gz
+*.sql.zip
 
 # Documentation/instruction files (local only)
 ODFE_GETDFSTATUS.md

--- a/database/migrations/2026_03_20_181312_add_publish_approved_to_rendered_videos.php
+++ b/database/migrations/2026_03_20_181312_add_publish_approved_to_rendered_videos.php
@@ -11,14 +11,27 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('rendered_videos', function (Blueprint $table) {
-            $table->boolean('publish_approved')->default(false)->after('published_at');
-        });
+        // Schema::table change isn't transactional in MySQL, so a previous
+        // failed run of this migration may have already added the column
+        // even though the migrations table wasn't marked.
+        if (!Schema::hasColumn('rendered_videos', 'publish_approved')) {
+            Schema::table('rendered_videos', function (Blueprint $table) {
+                // No ->after() - the sibling migration 2026_03_20_200000 that
+                // adds `published_at` sorts lexicographically AFTER this one,
+                // so on a fresh DB `published_at` doesn't exist yet. Column
+                // position in MySQL is purely cosmetic.
+                $table->boolean('publish_approved')->default(false);
+            });
+        }
 
-        // Mark already-published videos as approved
-        DB::table('rendered_videos')
-            ->whereNotNull('published_at')
-            ->update(['publish_approved' => true]);
+        // Mark already-published videos as approved. Skip on a fresh DB where
+        // `published_at` hasn't been added yet (sibling migration 2026_03_20_200000
+        // runs after this one due to lex order) - nothing to backfill anyway.
+        if (Schema::hasColumn('rendered_videos', 'published_at')) {
+            DB::table('rendered_videos')
+                ->whereNotNull('published_at')
+                ->update(['publish_approved' => true]);
+        }
     }
 
     /**

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -73,6 +73,7 @@
     const renderRequested = ref(false);
     const renderError = ref(null);
     const showRenderConfirm = ref(false);
+    const etiquetteAccepted = ref(false);
 
     const renderedVideo = computed(() => {
         const videos = props.record.rendered_videos;
@@ -105,15 +106,17 @@
 
     const confirmRender = () => {
         renderError.value = null;
+        etiquetteAccepted.value = false;
         showRenderConfirm.value = true;
     };
 
     const cancelRender = () => {
         showRenderConfirm.value = false;
+        etiquetteAccepted.value = false;
     };
 
     const requestRender = async () => {
-        if (renderRequesting.value || !canRequestRender.value) return;
+        if (renderRequesting.value || !canRequestRender.value || !etiquetteAccepted.value) return;
         renderRequesting.value = true;
         renderError.value = null;
         try {
@@ -922,7 +925,7 @@
     <!-- Render Confirm Dialog -->
     <Teleport to="body" v-if="showRenderConfirm">
         <div class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60" @click.self="cancelRender">
-            <div class="bg-gray-900 border border-white/10 rounded-xl p-5 shadow-2xl max-w-sm mx-4">
+            <div class="bg-gray-900 border border-white/10 rounded-xl p-5 shadow-2xl max-w-md mx-4">
                 <template v-if="!renderRequested">
                     <div class="flex items-center gap-3 mb-3">
                         <div class="w-10 h-10 rounded-lg bg-red-500/20 flex items-center justify-center">
@@ -930,13 +933,29 @@
                         </div>
                         <h3 class="text-sm font-bold text-white">Render to YouTube?</h3>
                     </div>
-                    <p class="text-xs text-gray-400 mb-4">This will queue the demo for rendering to a YouTube video. The process may take several minutes.</p>
+                    <p class="text-xs text-gray-400 mb-3">This will queue the demo for rendering to a YouTube video. The process may take several minutes.</p>
+
+                    <div class="border border-white/10 bg-white/[0.02] rounded-lg p-3 mb-3">
+                        <h4 class="text-xs font-bold text-white mb-2">Render etiquette</h4>
+                        <ul class="text-[11px] text-gray-400 space-y-1.5 list-disc pl-4">
+                            <li>Render the best attempt you have. Don't dump your whole time history when you already have, or will soon have, a better time.</li>
+                            <li>Same map, near identical times a few ms apart? Pick one.</li>
+                            <li>Exception: a run with a specific cool trick or something worth showing off. A slower time is totally fine then.</li>
+                            <li>Renders aren't free - we're capped by a daily YouTube upload limit, so spending it on time history burns the budget for everyone.</li>
+                        </ul>
+                    </div>
+
+                    <label class="flex items-start gap-2 mb-3 cursor-pointer select-none">
+                        <input type="checkbox" v-model="etiquetteAccepted" class="mt-0.5 w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-red-600 focus:ring-red-500 focus:ring-offset-0">
+                        <span class="text-xs text-gray-300">I have read and will follow the render etiquette.</span>
+                    </label>
+
                     <p v-if="renderError" class="text-xs text-red-400 mb-3">{{ renderError }}</p>
                     <div class="flex gap-2 justify-end">
                         <button @click="cancelRender" class="px-3 py-1.5 text-xs font-medium text-gray-400 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors">
                             Cancel
                         </button>
-                        <button @click="requestRender" :disabled="renderRequesting" class="px-3 py-1.5 text-xs font-bold text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 rounded-lg transition-colors">
+                        <button @click="requestRender" :disabled="renderRequesting || !etiquetteAccepted" class="px-3 py-1.5 text-xs font-bold text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors">
                             {{ renderRequesting ? '...' : 'Render' }}
                         </button>
                     </div>

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Záloha defrag.racing
+#   1) DB dump + .env  -> B2 "defrag-backups"  (datované, rotované, write-only klíč)
+#   2) Média (mirror)  -> B2 "defrag-media"    (inkrementálně, read+write klíč)
+#
+# Spouštěno cronem z current/scripts/backup.sh.
+# Žádná tajemství zde nejsou - creds se čtou z .env za běhu.
+
+set -euo pipefail
+
+# ---- Konfigurace ----
+ENV_FILE="/var/www/defrag-racing-project/production/current/.env"
+APP_DIR="/var/www/defrag-racing-project/production/current"
+BASEQ3_DIR="/var/www/defrag-racing-project/production/deploy/baseq3"
+BACKUP_DIR="/root/backups"
+STAMP="$(date +%F-%H%M)"
+
+read_env() { grep -E "^$1=" "$ENV_FILE" | head -n1 | cut -d '=' -f2- | tr -d "\"'"; }
+
+# ---- DB creds ----
+DB_DATABASE="$(read_env DB_DATABASE)"
+DB_USERNAME="$(read_env DB_USERNAME)"
+DB_PASSWORD="$(read_env DB_PASSWORD)"
+# ---- B2 backups (write-only) ----
+B2_BACKUP_KEY_ID="$(read_env B2_BACKUP_KEY_ID)"
+B2_BACKUP_APP_KEY="$(read_env B2_BACKUP_APP_KEY)"
+B2_BACKUP_BUCKET="$(read_env B2_BACKUP_BUCKET)"; B2_BACKUP_BUCKET="${B2_BACKUP_BUCKET:-defrag-backups}"
+# ---- B2 media (read+write) ----
+B2_MEDIA_KEY_ID="$(read_env B2_MEDIA_KEY_ID)"
+B2_MEDIA_APP_KEY="$(read_env B2_MEDIA_APP_KEY)"
+B2_MEDIA_BUCKET="$(read_env B2_MEDIA_BUCKET)"; B2_MEDIA_BUCKET="${B2_MEDIA_BUCKET:-defrag-media}"
+
+for v in DB_DATABASE DB_USERNAME B2_BACKUP_KEY_ID B2_BACKUP_APP_KEY; do
+  [ -z "${!v}" ] && { echo "CHYBA: $v nenalezeno v $ENV_FILE" >&2; exit 1; }
+done
+
+mkdir -p "$BACKUP_DIR"
+DB_FILE="$BACKUP_DIR/db-$STAMP.sql.gz"
+FILES_FILE="$BACKUP_DIR/files-$STAMP.tar.gz"
+echo "[$(date)] === Start zálohy $STAMP ==="
+
+# ===== 1) DB + .env -> defrag-backups (datované) =====
+mysqldump --single-transaction --quick --routines --triggers --no-tablespaces \
+  -u "$DB_USERNAME" -p"$DB_PASSWORD" "$DB_DATABASE" | gzip > "$DB_FILE"
+tar czhf "$FILES_FILE" -C "$APP_DIR" .env      # -h dereferencuje symlink .env
+gzip -t "$DB_FILE"; gzip -t "$FILES_FILE"
+echo "[$(date)] DB+env dump OK ($(du -h "$DB_FILE" | cut -f1))"
+
+export RCLONE_CONFIG_B2BACKUP_TYPE=b2
+export RCLONE_CONFIG_B2BACKUP_ACCOUNT="$B2_BACKUP_KEY_ID"
+export RCLONE_CONFIG_B2BACKUP_KEY="$B2_BACKUP_APP_KEY"
+rclone copy "$DB_FILE"    b2backup:"$B2_BACKUP_BUCKET"/ --no-check-dest
+rclone copy "$FILES_FILE" b2backup:"$B2_BACKUP_BUCKET"/ --no-check-dest
+echo "[$(date)] DB+env upload na B2 OK"
+
+# Po úspěšném uploadu lokální dump nedržíme - vše je na B2.
+rm -f "$DB_FILE" "$FILES_FILE"
+
+# ===== 2) Média mirror -> defrag-media (inkrementálně, jen přidává/přepisuje) =====
+if [ -n "$B2_MEDIA_KEY_ID" ] && [ -n "$B2_MEDIA_APP_KEY" ]; then
+  export RCLONE_CONFIG_B2MEDIA_TYPE=b2
+  export RCLONE_CONFIG_B2MEDIA_ACCOUNT="$B2_MEDIA_KEY_ID"
+  export RCLONE_CONFIG_B2MEDIA_KEY="$B2_MEDIA_APP_KEY"
+
+  # 2a) uživatelská média + modely + náhledy (storage/app/public, ~13 GB)
+  rclone copy "$APP_DIR/storage/app/public/" b2media:"$B2_MEDIA_BUCKET"/public/ \
+    --fast-list --transfers 8 --exclude "temp_*/**" --exclude "*.tmp"
+
+  # 2b) base Quake assety (pak0-pak8, gitignored, ~664 MB)
+  if [ -d "$BASEQ3_DIR" ]; then
+    rclone copy "$BASEQ3_DIR/" b2media:"$B2_MEDIA_BUCKET"/baseq3/ \
+      --fast-list --transfers 8
+  fi
+  echo "[$(date)] Média mirror na B2 OK"
+else
+  echo "[$(date)] Média přeskočena (B2_MEDIA_* není v .env)"
+fi
+
+echo "[$(date)] === Záloha $STAMP DOKONČENA ==="


### PR DESCRIPTION
1. **Automated nightly backup** (`scripts/backup.sh`, cron) covering everything not in git:
   - **DB + `.env`** -> dated, rotated copies to the **write-only** B2 bucket `defrag-backups` (Object Lock 14d, lifecycle delete ~30d).
   - **Media** -> incremental mirror of `storage/app/public` (avatars, model GIFs, extracted models, levelshots) + the gitignored `deploy/baseq3` base Quake assets, to B2 bucket `defrag-media`.

2. **`.gitignore`**: ignore `*.sql.gz` / `*.sql.zip` so downloaded DB dumps stop showing as untracked (`*.sql` already covered, gzip slipped through).

3. **Render etiquette gate** (`MapRecord.vue` + migration): the Render to YouTube dialog now shows etiquette guidelines and requires an explicit checkbox before a render can be queued, to curb low-value renders against the daily YouTube upload cap. The `publish_approved` migration is made idempotent (guard with `hasColumn()`, only backfill from `published_at` when it exists).