### PR TITLE
Sessions hygiene, real client IPs, records perf

### DIFF
--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -278,6 +278,18 @@ class LauncherController extends Controller
     }
 
     /**
+     * Lightweight bell-badge poll target. Returns ONLY the unread
+     * counts (~30B JSON) so the launcher's background poll doesn't
+     * fetch 50 records + 50 system notifications every 3 minutes.
+     * The full /notifications endpoint is reserved for the Notifications
+     * view (mount + manual refresh).
+     */
+    public function notificationsUnreadCount(Request $request)
+    {
+        return response()->json($this->unreadCounts($request->user()->id));
+    }
+
+    /**
      * Minimal "who am I" for the launcher. Returns the fields the
      * launcher needs to wire up the top nav's Profile button (mdd_id
      * for the /profile/{id} link, name + country for the badge) and
@@ -325,13 +337,14 @@ class LauncherController extends Controller
 
         $physics = $data['physics'] ?? 'vq3';
         $page = $data['page'] ?? 1;
-        $perPage = 100;
+        $perPage = 50;
 
         $records = Record::query()
             ->where('physics', $physics)
             ->with(['user:id,name,plain_name,country,profile_photo_path'])
             ->orderBy('date_set', 'DESC')
-            ->paginate($perPage, ['id', 'name', 'country', 'mdd_id', 'mapname', 'rank', 'time', 'date_set', 'physics', 'mode'], 'page', $page);
+            ->orderBy('id', 'DESC')
+            ->simplePaginate($perPage, ['id', 'name', 'country', 'mdd_id', 'mapname', 'rank', 'time', 'date_set', 'physics', 'mode'], 'page', $page);
 
         return response()->json($records);
     }

--- a/app/Http/Controllers/BrowserSessionsController.php
+++ b/app/Http/Controllers/BrowserSessionsController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Per-row revoke for browser sessions. Jetstream ships with bulk
+ * "logout other browser sessions" only; this adds individual
+ * revocation so the user can sign out one device without touching the
+ * others.
+ *
+ * Session IDs are sensitive (they are the cookie value), so they are
+ * never exposed in HTML. The frontend receives a sha256(id) as an
+ * opaque `handle`; on revoke the server iterates the user's sessions
+ * and deletes the one whose hash matches.
+ */
+class BrowserSessionsController extends Controller
+{
+    public function destroy(Request $request, string $handle)
+    {
+        $user = Auth::user();
+        $currentId = $request->session()->getId();
+
+        $sessions = DB::connection(config('session.connection'))
+            ->table(config('session.table', 'sessions'))
+            ->where('user_id', $user->getAuthIdentifier())
+            ->select('id')
+            ->get();
+
+        foreach ($sessions as $row) {
+            if (hash('sha256', $row->id) !== $handle) {
+                continue;
+            }
+
+            // Block self-revoke: the current device should sign out via
+            // the normal logout flow so the session cookie gets cleared
+            // client-side too.
+            if ($row->id === $currentId) {
+                return response()->json(['error' => 'cannot_revoke_current'], 422);
+            }
+
+            DB::connection(config('session.connection'))
+                ->table(config('session.table', 'sessions'))
+                ->where('id', $row->id)
+                ->delete();
+
+            return response()->json(['ok' => true]);
+        }
+
+        return response()->json(['error' => 'not_found'], 404);
+    }
+}

--- a/app/Http/Controllers/Inertia/UserProfileController.php
+++ b/app/Http/Controllers/Inertia/UserProfileController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Inertia;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Laravel\Jetstream\Http\Controllers\Inertia\UserProfileController as Base;
+
+/**
+ * Local override of Jetstream's UserProfileController. Only purpose:
+ * augment each session row with an opaque `handle` (sha256 of the
+ * session id) so the frontend can pass it back to
+ * BrowserSessionsController::destroy without exposing the real id.
+ *
+ * Everything else delegates to the parent.
+ */
+class UserProfileController extends Base
+{
+    public function sessions(Request $request)
+    {
+        if (config('session.driver') !== 'database') {
+            return collect();
+        }
+
+        $base = parent::sessions($request);
+
+        $idMap = DB::connection(config('session.connection'))
+            ->table(config('session.table', 'sessions'))
+            ->where('user_id', $request->user()->getAuthIdentifier())
+            ->orderByDesc('last_activity')
+            ->pluck('id')
+            ->values();
+
+        return $base->values()->map(function ($row, $i) use ($idMap) {
+            $sid = $idMap[$i] ?? null;
+            $row->handle = $sid ? hash('sha256', $sid) : null;
+            return $row;
+        });
+    }
+}

--- a/app/Http/Controllers/LauncherTokenController.php
+++ b/app/Http/Controllers/LauncherTokenController.php
@@ -26,6 +26,8 @@ class LauncherTokenController extends Controller
                 'label' => substr($t->name, strlen('launcher:')),
                 'last_used_at' => $t->last_used_at,
                 'created_at' => $t->created_at,
+                'last_used_ip' => $t->last_used_ip,
+                'last_used_user_agent' => $t->last_used_user_agent,
             ]);
 
         return response()->json(['tokens' => $tokens]);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -49,17 +49,16 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // Load the session cookie unconditionally for every /api/*
-            // request. We explicitly skip Sanctum's
-            // EnsureFrontendRequestsAreStateful here because that
-            // middleware only activates session loading when a Referer
-            // or Origin header is present — pasting an /api/... URL
-            // into a fresh tab doesn't include either and would 401 an
-            // otherwise logged-in user. Bearer-token clients are
-            // unaffected; the session is just unused for them.
+            // No StartSession on /api/* on purpose. Bearer-token
+            // clients (launcher etc.) are stateless and identify via
+            // Authorization header, not cookies; running StartSession
+            // on every poll created one anonymous row in `sessions`
+            // per request, flooding the Browser Sessions UI. Browser
+            // users hitting /api/* paste-into-tab still authenticate
+            // via EnsureFrontendRequestsAreStateful when the Referer
+            // / Origin header is present.
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/app/Http/Middleware/LogApiCalls.php
+++ b/app/Http/Middleware/LogApiCalls.php
@@ -42,6 +42,18 @@ class LogApiCalls
                     ? $token->id
                     : null;
 
+                // Stamp the token row with the current IP + UA so the
+                // user's profile can show "Connected apps" with where
+                // each launcher device is being used from. Sanctum
+                // already manages last_used_at; the two columns we
+                // touch were added in 2026_06_01_000002.
+                if ($token instanceof \Laravel\Sanctum\PersonalAccessToken) {
+                    $token->forceFill([
+                        'last_used_ip' => substr((string) $request->ip(), 0, 45),
+                        'last_used_user_agent' => substr((string) $request->userAgent(), 0, 255),
+                    ])->saveQuietly();
+                }
+
                 $queryString = $request->getQueryString();
 
                 ApiCallLog::create([

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -2,23 +2,13 @@
 
 namespace App\Http\Middleware;
 
-use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
+use Monicahq\Cloudflare\Http\Middleware\TrustProxies as Middleware;
 
 class TrustProxies extends Middleware
 {
-    /**
-     * The trusted proxies for this application.
-     *
-     * @var array<int, string>|string|null
-     */
     protected $proxies;
 
-    /**
-     * The headers that should be used to detect proxies.
-     *
-     * @var int
-     */
     protected $headers =
         Request::HEADER_X_FORWARDED_FOR |
         Request::HEADER_X_FORWARDED_HOST |

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-sftp-v3": "*",
         "mokhosh/filament-kanban": "^2.3",
+        "monicahq/laravel-cloudflare": "*",
         "opcodesio/log-viewer": "^3.1",
         "php-http/curl-client": "^2.3",
         "socialiteproviders/discord": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7bf92b7ca0ca8c0cfc853a90dd87ff70",
+    "content-hash": "99a8ba3bdda4d7c23da4c3fae65a538a",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -5063,6 +5063,93 @@
                 }
             ],
             "time": "2025-03-09T12:05:16+00:00"
+        },
+        {
+            "name": "monicahq/laravel-cloudflare",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/monicahq/laravel-cloudflare.git",
+                "reference": "7889d03f8a2939df82f5a85451c9dabf54bee267"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/monicahq/laravel-cloudflare/zipball/7889d03f8a2939df82f5a85451c9dabf54bee267",
+                "reference": "7889d03f8a2939df82f5a85451c9dabf54bee267",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "brainmaestro/composer-git-hooks": "^3.0",
+                "guzzlehttp/guzzle": "^6.3 || ^7.0",
+                "larastan/larastan": "^1.0 || ^2.4 || ^3.0",
+                "laravel/pint": "^1.15",
+                "mockery/mockery": "^1.4",
+                "ocramius/package-versions": "^1.5 || ^2.1",
+                "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0",
+                "vimeo/psalm": "^4.0 || ^5.6 || ^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Required to get cloudflares ip addresses (^6.5.5|^7.0)."
+            },
+            "type": "library",
+            "extra": {
+                "hooks": {
+                    "config": {
+                        "stop-on-failure": [
+                            "pre-commit"
+                        ]
+                    },
+                    "pre-commit": [
+                        "files=$(git diff --staged --name-only);\"$(dirname \"$0\")/../../vendor/bin/pint\" $files; git add $files"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Monicahq\\Cloudflare\\TrustedProxyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monicahq\\Cloudflare\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexis Saettler",
+                    "email": "alexis@saettler.org"
+                }
+            ],
+            "description": "Add Cloudflare ip addresses to trusted proxies for Laravel.",
+            "keywords": [
+                "cloudflare",
+                "laravel",
+                "php",
+                "proxies"
+            ],
+            "support": {
+                "issues": "https://github.com/monicahq/laravel-cloudflare/issues",
+                "source": "https://github.com/monicahq/laravel-cloudflare"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/asbiin",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-04T21:39:10+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -15793,5 +15880,5 @@
         "php": "^8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/database/migrations/2026_06_01_000001_add_physics_date_index_to_records_table.php
+++ b/database/migrations/2026_06_01_000001_add_physics_date_index_to_records_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->index(['physics', 'date_set', 'id'], 'idx_records_physics_date_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('records', function (Blueprint $table) {
+            $table->dropIndex('idx_records_physics_date_id');
+        });
+    }
+};

--- a/database/migrations/2026_06_01_000002_add_device_columns_to_personal_access_tokens_table.php
+++ b/database/migrations/2026_06_01_000002_add_device_columns_to_personal_access_tokens_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->string('last_used_ip', 45)->nullable()->after('last_used_at');
+            $table->string('last_used_user_agent', 255)->nullable()->after('last_used_ip');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropColumn(['last_used_ip', 'last_used_user_agent']);
+        });
+    }
+};

--- a/resources/js/Pages/Profile/Partials/LauncherTokensForm.vue
+++ b/resources/js/Pages/Profile/Partials/LauncherTokensForm.vue
@@ -75,8 +75,19 @@
     };
 
     const formatDate = (iso) => {
-        if (! iso) return '—';
+        if (! iso) return '-';
         return new Date(iso).toLocaleString();
+    };
+
+    // Parses our launcher's User-Agent string into a short label.
+    // Format we send from the launcher: "defrag-launcher/0.1.9 (windows)".
+    // Anything else (curl, postman, python-requests) we show verbatim so
+    // the user notices "that doesn't look like the launcher".
+    const formatAgent = (ua) => {
+        if (! ua) return null;
+        const m = ua.match(/^defrag-launcher\/(\S+)\s+\(([^)]+)\)/i);
+        if (m) return `Launcher ${m[1]} - ${m[2]}`;
+        return ua.length > 60 ? ua.slice(0, 60) + '...' : ua;
     };
 </script>
 
@@ -163,6 +174,11 @@
                     <div class="text-white font-medium truncate">{{ t.label }}</div>
                     <div class="text-xs text-gray-500 mt-0.5">
                         Created {{ formatDate(t.created_at) }} · Last used {{ formatDate(t.last_used_at) }}
+                    </div>
+                    <div v-if="t.last_used_ip || t.last_used_user_agent" class="text-xs text-gray-500 mt-0.5">
+                        <span v-if="formatAgent(t.last_used_user_agent)" class="text-gray-400">{{ formatAgent(t.last_used_user_agent) }}</span>
+                        <span v-if="t.last_used_ip && formatAgent(t.last_used_user_agent)"> · </span>
+                        <span v-if="t.last_used_ip" class="font-mono">{{ t.last_used_ip }}</span>
                     </div>
                 </div>
                 <button

--- a/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
+++ b/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
@@ -1,18 +1,20 @@
 <script setup>
 import { ref } from 'vue';
-import { useForm } from '@inertiajs/vue3';
+import { router, useForm } from '@inertiajs/vue3';
+import axios from 'axios';
 import DialogModal from '@/Components/Laravel/DialogModal.vue';
 import InputError from '@/Components/Laravel/InputError.vue';
 import PrimaryButton from '@/Components/Laravel/PrimaryButton.vue';
 import SecondaryButton from '@/Components/Laravel/SecondaryButton.vue';
 import TextInput from '@/Components/Laravel/TextInput.vue';
 
-defineProps({
+const props = defineProps({
     sessions: Array,
 });
 
 const confirmingLogout = ref(false);
 const passwordInput = ref(null);
+const revokingHandle = ref(null);
 
 const form = useForm({
     password: '',
@@ -37,6 +39,23 @@ const closeModal = () => {
     confirmingLogout.value = false;
 
     form.reset();
+};
+
+const revokeOne = async (session) => {
+    if (! session.handle || session.is_current_device) return;
+    if (revokingHandle.value) return;
+    if (! confirm('Sign out this session?')) return;
+    revokingHandle.value = session.handle;
+    try {
+        await axios.delete(route('browser-sessions.destroy', session.handle));
+        router.reload({ only: ['sessions'], preserveScroll: true });
+    } catch (e) {
+        alert(e.response?.data?.error === 'cannot_revoke_current'
+            ? 'Cannot revoke the current session this way - use the regular logout.'
+            : 'Failed to revoke session.');
+    } finally {
+        revokingHandle.value = null;
+    }
 };
 </script>
 
@@ -66,31 +85,43 @@ const closeModal = () => {
 
             <!-- Other Browser Sessions -->
             <div v-if="sessions.length > 0" class="space-y-3">
-                <div v-for="(session, i) in sessions" :key="i" class="flex items-center">
-                    <div>
-                        <svg v-if="session.agent.is_desktop" class="w-6 h-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25" />
-                        </svg>
+                <div v-for="(session, i) in sessions" :key="i" class="flex items-center justify-between gap-3">
+                    <div class="flex items-center min-w-0">
+                        <div>
+                            <svg v-if="session.agent.is_desktop" class="w-6 h-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25" />
+                            </svg>
 
-                        <svg v-else class="w-6 h-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
-                        </svg>
-                    </div>
-
-                    <div class="ms-3">
-                        <div class="text-xs text-gray-400">
-                            {{ session.agent.platform ? session.agent.platform : 'Unknown' }} - {{ session.agent.browser ? session.agent.browser : 'Unknown' }}
+                            <svg v-else class="w-6 h-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                            </svg>
                         </div>
 
-                        <div>
-                            <div class="text-xs text-gray-500">
-                                {{ session.ip_address }},
+                        <div class="ms-3 min-w-0">
+                            <div class="text-xs text-gray-400 truncate">
+                                {{ session.agent.platform ? session.agent.platform : 'Unknown' }} - {{ session.agent.browser ? session.agent.browser : 'Unknown' }}
+                            </div>
 
-                                <span v-if="session.is_current_device" class="text-green-500 font-semibold">This device</span>
-                                <span v-else>Last active {{ session.last_active }}</span>
+                            <div>
+                                <div class="text-xs text-gray-500 truncate">
+                                    {{ session.ip_address }},
+
+                                    <span v-if="session.is_current_device" class="text-green-500 font-semibold">This device</span>
+                                    <span v-else>Last active {{ session.last_active }}</span>
+                                </div>
                             </div>
                         </div>
                     </div>
+
+                    <button
+                        v-if="!session.is_current_device && session.handle"
+                        type="button"
+                        :disabled="revokingHandle === session.handle"
+                        @click="revokeOne(session)"
+                        class="text-xs px-2 py-1 rounded bg-red-500/15 hover:bg-red-500/25 text-red-300 flex-shrink-0 disabled:opacity-50"
+                    >
+                        {{ revokingHandle === session.handle ? 'Signing out...' : 'Sign out' }}
+                    </button>
                 </div>
             </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,6 +68,7 @@ Route::prefix('launcher')
             Route::get('/me', [\App\Http\Controllers\Api\LauncherController::class, 'me']);
             Route::get('/servers', [\App\Http\Controllers\Api\LauncherController::class, 'servers']);
             Route::get('/notifications', [\App\Http\Controllers\Api\LauncherController::class, 'notifications']);
+            Route::get('/notifications/unread-count', [\App\Http\Controllers\Api\LauncherController::class, 'notificationsUnreadCount']);
             Route::get('/records', [\App\Http\Controllers\Api\LauncherController::class, 'records']);
             Route::get('/maps', [\App\Http\Controllers\Api\LauncherController::class, 'maps']);
             Route::get('/render-status', [\App\Http\Controllers\Api\LauncherController::class, 'renderStatus']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -288,8 +288,13 @@ Route::get('/announcements', [ChangelogController::class, 'announcements'])->nam
 
 // Settings (overrides Jetstream's /user/profile)
 Route::middleware(['auth'])->group(function () {
-    Route::get('/user/settings', [\Laravel\Jetstream\Http\Controllers\Inertia\UserProfileController::class, 'show'])->name('settings.show');
+    Route::get('/user/settings', [\App\Http\Controllers\Inertia\UserProfileController::class, 'show'])->name('settings.show');
     Route::redirect('/user/profile', '/user/settings', 301);
+
+    // Per-row browser session revoke. Handle is sha256(session.id) so
+    // we never put the real session id (= cookie value) into the HTML.
+    Route::delete('/user/browser-sessions/{handle}', [\App\Http\Controllers\BrowserSessionsController::class, 'destroy'])
+        ->name('browser-sessions.destroy');
 
     // Launcher personal access tokens
     Route::get('/user/launcher-tokens', [\App\Http\Controllers\LauncherTokenController::class, 'index'])->name('launcher-tokens.index');


### PR DESCRIPTION
## Summary
- Cloudflare-aware `TrustProxies` via `monicahq/laravel-cloudflare` so audit logs and Browser Sessions show the real client IP, not Cloudflare edge
- Drop `StartSession` from the `/api/*` middleware group - Bearer-token clients (launcher) no longer create one anonymous `sessions` row per poll
- Track launcher devices on `personal_access_tokens` (new `last_used_ip` + `last_used_user_agent` columns). The Launcher Tokens section now shows "Launcher X.Y.Z - platform" and the IP each device is being used from
- Per-row "Sign out" button on Browser Sessions using `sha256(session.id)` as an opaque handle - real session ids never enter HTML
- `/api/launcher/records` switches to `simplePaginate(50)` and gets a composite `(physics, date_set, id)` index - drops the endpoint from ~3s to <500ms
- New `/api/launcher/notifications/unread-count` (~30B JSON) for the launcher's bell badge poll; full `/notifications` reserved for the Notifications view