### PR TITLE
Security tab: consistent chip-style destructive buttons

### DIFF
--- a/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
+++ b/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
@@ -126,9 +126,13 @@ const revokeOne = async (session) => {
             </div>
 
             <div class="flex justify-end pt-1">
-                <PrimaryButton @click="confirmLogout">
-                    Log Out Other Browser Sessions
-                </PrimaryButton>
+                <button
+                    type="button"
+                    @click="confirmLogout"
+                    class="text-xs px-2 py-1 rounded bg-red-500/15 hover:bg-red-500/25 text-red-300"
+                >
+                    Sign out all other sessions
+                </button>
             </div>
 
             <!-- Log Out Other Devices Confirmation Modal -->

--- a/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
+++ b/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
@@ -189,7 +189,7 @@ const disableTwoFactorAuthentication = () => {
                 </div>
             </div>
 
-            <div class="flex flex-wrap gap-2 pt-1">
+            <div class="flex flex-wrap justify-end gap-2 pt-1">
                 <div v-if="! twoFactorEnabled">
                     <ConfirmsPassword @confirmed="enableTwoFactorAuthentication">
                         <PrimaryButton type="button" :class="{ 'opacity-25': enabling }" :disabled="enabling">
@@ -198,7 +198,7 @@ const disableTwoFactorAuthentication = () => {
                     </ConfirmsPassword>
                 </div>
 
-                <div v-else class="flex flex-wrap gap-2">
+                <div v-else class="flex flex-wrap justify-end gap-2">
                     <ConfirmsPassword @confirmed="confirmTwoFactorAuthentication">
                         <PrimaryButton
                             v-if="confirming"


### PR DESCRIPTION
## Summary
- Bulk "Log out other browser sessions" PrimaryButton replaced with the same red chip style used by the per-row Sign out + Launcher token Revoke buttons (renamed to "Sign out all other sessions")
- Two-factor button row gets `justify-end` so Enable/Disable/Show Codes/etc. align with the rest of the Security column
- No behavior change; password-confirmation flow + endpoints untouched
