### PR TITLE
Launcher web integration: download page, promo, dual changelog feed

### DIFF
--- a/app/Http/Controllers/LauncherController.php
+++ b/app/Http/Controllers/LauncherController.php
@@ -3,12 +3,137 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class LauncherController extends Controller
 {
+    /**
+     * Public download page for the desktop launcher.
+     *
+     * Fetches the latest release metadata from GitHub (cached 1 hour) and
+     * passes a categorized assets map to the Inertia page so the frontend
+     * can render per-platform download buttons without hardcoding URLs that
+     * would rot on every new release.
+     */
+    public function page(): Response
+    {
+        $release = Cache::get('launcher:release');
+        if ($release === null) {
+            $release = $this->fetchLatestRelease();
+            if ($release !== null) {
+                Cache::put('launcher:release', $release, now()->addHour());
+            }
+        }
+
+        $version = $release['tag_name'] ?? null;
+        if ($version !== null) {
+            $version = preg_replace('/^launcher-v/', '', $version);
+        }
+
+        $assets = collect($release['assets'] ?? []);
+        $categorized = $this->categorizeAssets($assets);
+
+        return Inertia::render('Launcher', [
+            'version'    => $version,
+            'published'  => $release['published_at'] ?? null,
+            'assets'     => $categorized,
+            'releaseUrl' => $release['html_url'] ?? 'https://github.com/Defrag-racing/defrag-racing-launcher/releases/latest',
+            'changelogUrl' => 'https://github.com/Defrag-racing/defrag-racing-launcher/blob/main/CHANGELOG.md',
+        ]);
+    }
+
+    /**
+     * Fetch the latest published release from GitHub. Returns null on any
+     * failure (network, 404 when no non-draft releases exist yet, rate
+     * limit, malformed JSON). The page renders gracefully with no assets
+     * in that case, and the caller decides whether to cache the result.
+     */
+    protected function fetchLatestRelease(): ?array
+    {
+        try {
+            $response = Http::timeout(10)
+                ->retry(2, 500, throw: false)
+                ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                ->get('https://api.github.com/repos/Defrag-racing/defrag-racing-launcher/releases/latest');
+
+            if (! $response->successful()) {
+                Log::warning('launcher release fetch failed', [
+                    'status' => $response->status(),
+                ]);
+                return null;
+            }
+
+            return $response->json();
+        } catch (\Throwable $e) {
+            Log::warning('launcher release fetch exception', [
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Group GH release assets into windows/macos/linux buckets keyed by
+     * recognised installer kinds. .sig signature files and source archives
+     * are dropped - they exist for the updater + GitHub's source-code zips
+     * but aren't useful as direct downloads from the web page.
+     */
+    protected function categorizeAssets(Collection $assets): array
+    {
+        $by = ['windows' => [], 'macos' => [], 'linux' => []];
+
+        foreach ($assets as $asset) {
+            $name = strtolower($asset['name'] ?? '');
+            $size = $asset['size'] ?? 0;
+            $url  = $asset['browser_download_url'] ?? null;
+            if (! $url || ! $name) continue;
+            if (str_ends_with($name, '.sig')) continue;
+            if (str_ends_with($name, '.json')) continue;
+            if (preg_match('/source.*\.(zip|tar\.gz)$/', $name)) continue;
+            if (str_contains($name, 'updater') && str_ends_with($name, '.tar.gz')) continue;
+            if (str_contains($name, 'updater') && str_ends_with($name, '.app.tar.gz')) continue;
+            if (str_ends_with($name, '.app.tar.gz')) continue;
+
+            $entry = [
+                'name' => $asset['name'],
+                'size' => $size,
+                'url'  => $url,
+            ];
+
+            if (str_ends_with($name, '.msi')) {
+                $by['windows'][] = $entry + ['kind' => 'msi', 'label' => 'Installer (.msi)', 'recommended' => true];
+            } elseif (str_ends_with($name, '.exe')) {
+                $by['windows'][] = $entry + ['kind' => 'exe', 'label' => 'Setup (.exe)', 'recommended' => false];
+            } elseif (str_ends_with($name, '.dmg')) {
+                $isArm = str_contains($name, 'aarch64') || str_contains($name, 'arm64');
+                $by['macos'][] = $entry + [
+                    'kind'  => $isArm ? 'dmg-arm' : 'dmg-intel',
+                    'label' => $isArm ? 'Apple Silicon (.dmg)' : 'Intel (.dmg)',
+                    'recommended' => $isArm,
+                ];
+            } elseif (str_ends_with($name, '.appimage')) {
+                $by['linux'][] = $entry + ['kind' => 'appimage', 'label' => 'AppImage', 'recommended' => true];
+            } elseif (str_ends_with($name, '.deb')) {
+                $by['linux'][] = $entry + ['kind' => 'deb', 'label' => 'Debian / Ubuntu (.deb)', 'recommended' => false];
+            } elseif (str_ends_with($name, '.rpm')) {
+                $by['linux'][] = $entry + ['kind' => 'rpm', 'label' => 'Fedora / RHEL (.rpm)', 'recommended' => false];
+            }
+        }
+
+        $sortOrder = ['msi', 'exe', 'dmg-arm', 'dmg-intel', 'appimage', 'deb', 'rpm'];
+        foreach ($by as $os => $list) {
+            usort($by[$os], fn($a, $b) => array_search($a['kind'], $sortOrder) <=> array_search($b['kind'], $sortOrder));
+        }
+
+        return $by;
+    }
+
+
     /**
      * Mirror of the launcher's signed update manifest. The launcher's
      * tauri-plugin-updater tries this endpoint first because GitHub is

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -16,9 +16,62 @@ use App\Models\PlayerRating;
 use App\Models\PlayerModel;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 
 class WebController extends Controller
 {
+    /**
+     * Recent commits for the desktop launcher, pulled from the GitHub API.
+     * The launcher lives in a separate repo that isn't checked out on the
+     * web server, so unlike the web changelog (read from local `git log`)
+     * we have to fetch these over HTTP. Cached for an hour - GitHub's
+     * unauthenticated limit is 60 req/h per IP and one call/hour stays
+     * comfortably under it. Returns the same shape as the web changelog
+     * (hash/title/description/date/author) so the frontend renders both
+     * feeds with one template.
+     */
+    private function launcherCommits(int $limit = 100) {
+        return Cache::remember("launcher_commits_v1_{$limit}", 3600, function () use ($limit) {
+            try {
+                $resp = Http::withHeaders([
+                    'User-Agent' => 'defrag-racing-web',
+                    'Accept' => 'application/vnd.github+json',
+                ])->timeout(8)->get(
+                    'https://api.github.com/repos/Defrag-racing/defrag-racing-launcher/commits',
+                    ['per_page' => min($limit, 100)]
+                );
+
+                if (! $resp->ok()) return [];
+
+                $commits = [];
+                foreach ($resp->json() as $c) {
+                    $message = $c['commit']['message'] ?? '';
+                    $lines = explode("\n", $message);
+                    $title = trim($lines[0] ?? '');
+                    if ($title === '') continue;
+                    if (str_starts_with($title, 'Merge pull request') || str_starts_with($title, 'Merge branch')) continue;
+
+                    $body = trim(implode("\n", array_slice($lines, 1)));
+                    $body = preg_replace('/\n*Co-Authored-By:.*$/s', '', $body);
+                    $body = trim($body);
+
+                    $rawDate = $c['commit']['author']['date'] ?? null;
+                    $author = $c['commit']['author']['name'] ?? ($c['author']['login'] ?? '');
+
+                    $commits[] = [
+                        'hash' => substr($c['sha'] ?? '', 0, 7),
+                        'title' => $title,
+                        'description' => $body,
+                        'date' => $rawDate ? date('Y-m-d', strtotime($rawDate)) : null,
+                        'author' => $author,
+                    ];
+                }
+                return $commits;
+            } catch (\Throwable $e) {
+                return [];
+            }
+        });
+    }
     public function home() {
         $announcements = Cache::remember('home:announcements', 300, function () {
             $latest = Announcement::where('type', 'home')->orderBy('created_at', 'DESC')->first();
@@ -128,6 +181,9 @@ class WebController extends Controller
             return array_slice($commits, 0, 5);
         });
 
+        // Recent launcher changelog (GitHub API, separate repo)
+        $recentChangelogLauncher = array_slice($this->launcherCommits(15), 0, 5);
+
         // Upcoming/current tournaments
         $upcomingTournaments = Cache::remember('home:upcoming_tournaments', 600, function () {
             return Tournament::where(function ($q) {
@@ -164,6 +220,7 @@ class WebController extends Controller
             ->with('recentWorldRecords', $recentWorldRecords)
             ->with('rankingHighlights', $rankingHighlights)
             ->with('recentChangelog', $recentChangelog)
+            ->with('recentChangelogLauncher', $recentChangelogLauncher)
             ->with('upcomingTournaments', $upcomingTournaments)
             ->with('latestModel', $latestModel)
             ->with('latestMap', $latestMap);
@@ -240,8 +297,13 @@ class WebController extends Controller
             return array_reverse($commits);
         });
 
+        // Launcher commits (GitHub API). API returns newest-first; reverse
+        // to oldest-first so the roadmap reads chronologically like the web list.
+        $launcherCommits = array_reverse($this->launcherCommits(100));
+
         return Inertia::render('Roadmap', [
             'commits' => $commits,
+            'launcherCommits' => $launcherCommits,
         ]);
     }
 }

--- a/resources/js/Components/LauncherBanner.vue
+++ b/resources/js/Components/LauncherBanner.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    variant: { type: String, default: 'servers' },
+});
+
+const STORAGE_KEYS = {
+    servers: 'launcher_banner_dismissed_servers',
+    demos: 'launcher_banner_dismissed_demos',
+};
+
+const dismissed = ref(true);
+
+onMounted(() => {
+    const key = STORAGE_KEYS[props.variant] || STORAGE_KEYS.servers;
+    dismissed.value = localStorage.getItem(key) === '1';
+});
+
+const dismiss = () => {
+    dismissed.value = true;
+    const key = STORAGE_KEYS[props.variant] || STORAGE_KEYS.servers;
+    localStorage.setItem(key, '1');
+};
+
+const copy = computed(() => {
+    if (props.variant === 'demos') return {
+        title: 'Never lose a demo again',
+        text: 'The Defrag Racing Launcher watches your demos folder and uploads new runs to defrag.racing automatically.',
+    };
+    return {
+        title: 'Make the Connect button work',
+        text: 'The Defrag Racing Launcher opens defrag:// links in Q3 and lets you browse servers from your desktop.',
+    };
+});
+</script>
+
+<template>
+    <div v-if="!dismissed"
+         class="mb-4 rounded-xl border border-blue-500/30 bg-gradient-to-r from-blue-950/60 to-blue-900/20 px-4 py-3 flex items-start gap-3">
+        <div class="shrink-0 mt-0.5 w-9 h-9 rounded-lg bg-blue-500/20 flex items-center justify-center">
+            <svg class="w-5 h-5 text-blue-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                <polyline points="7 10 12 15 17 10"/>
+                <line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+        </div>
+        <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-white">{{ copy.title }}</div>
+            <div class="text-xs text-gray-400 mt-0.5">{{ copy.text }}</div>
+        </div>
+        <Link :href="route('launcher')"
+              class="shrink-0 self-center px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-xs font-semibold transition-colors whitespace-nowrap">
+            Get the launcher
+        </Link>
+        <button type="button"
+                @click="dismiss"
+                class="shrink-0 self-start p-1 rounded-lg hover:bg-white/10 text-gray-400 hover:text-gray-200 transition-colors"
+                aria-label="Dismiss">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+</template>

--- a/resources/js/Pages/Demos/Index.vue
+++ b/resources/js/Pages/Demos/Index.vue
@@ -11,6 +11,7 @@ export default {
 import { Head, Link, useForm, router, usePage } from '@inertiajs/vue3';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import Pagination from '@/Components/Basic/Pagination.vue';
+import LauncherBanner from '@/Components/LauncherBanner.vue';
 
 const $page = usePage();
 
@@ -1333,8 +1334,28 @@ watch(selectedPhysics, () => {
                             <h1 class="text-4xl md:text-5xl font-black text-gray-300/90">Demos</h1>
                         </div>
                         <p class="text-sm text-gray-400">Upload and manage demo files</p>
-                        <p class="text-xs text-gray-500 mt-1">Special thanks to <Link href="/profile/549" class="text-gray-300 hover:text-white underline transition-colors">Enter</Link> for his demo collection that helped populate this database.</p>
+                        <p class="text-xs text-gray-500 mt-1">
+                            <span class="relative group inline-block">
+                                <span class="cursor-help border-b border-dotted border-gray-600 text-gray-400">Special thanks</span>
+                                <span class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-opacity absolute left-0 top-full z-30 w-64 rounded-lg bg-gray-900 border border-white/10 px-3 py-2 text-xs text-gray-300 shadow-xl leading-snug">
+                                    Special thanks to <Link href="/profile/549" class="text-gray-200 hover:text-white underline transition-colors">Enter</Link> for his demo collection that helped populate this database.
+                                </span>
+                            </span>
+                        </p>
                     </div>
+
+                    <!-- TEMP hidden: launcher header chip (re-enable once render is confirmed working)
+                    <Link :href="route('launcher')"
+                          class="flex items-center gap-2 bg-gradient-to-r from-blue-600/30 to-blue-500/15 hover:from-blue-600/40 hover:to-blue-500/25 backdrop-blur-sm px-3 py-2 rounded-lg border border-blue-400/40 hover:border-blue-300/60 transition-colors text-sm">
+                        <svg class="w-5 h-5 text-blue-300 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/>
+                            <line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                        <span class="font-bold text-white whitespace-nowrap">Get the launcher</span>
+                        <span class="hidden sm:inline text-blue-200/80 font-semibold text-xs">auto backup demos + many more features</span>
+                    </Link>
+                    -->
 
                     <!-- Limits Info (Right Side) -->
                     <div class="flex flex-col gap-2">
@@ -1392,6 +1413,10 @@ watch(selectedPhysics, () => {
 
         <div class="overflow-x-hidden">
             <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12">
+
+                <!-- TEMP hidden: dismissible launcher banner (re-enable once render is confirmed working)
+                <LauncherBanner variant="demos" />
+                -->
 
                 <!-- Upload Section (visible to all users; guests will have restricted actions) -->
                 <div class="bg-black/40 backdrop-blur-sm rounded-xl p-3 mb-4 shadow-2xl border border-white/5">

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -24,6 +24,7 @@
         recentWorldRecords: Array,
         rankingHighlights: Object,
         recentChangelog: Array,
+        recentChangelogLauncher: Array,
         upcomingTournaments: Array,
         latestModel: Object,
         latestMap: Object,
@@ -48,6 +49,12 @@
         localStorage.setItem('gettingStarted_discord', discordChecked.value ? '1' : '0');
     };
 
+    const launcherChecked = ref(localStorage.getItem('gettingStarted_launcher') === '1');
+    const toggleLauncher = () => {
+        launcherChecked.value = !launcherChecked.value;
+        localStorage.setItem('gettingStarted_launcher', launcherChecked.value ? '1' : '0');
+    };
+
     const formatTime = (ms) => {
         if (!ms) return '-';
         const totalSec = ms / 1000;
@@ -63,6 +70,19 @@
     const onCommitEnter = (e, commit) => { hoveredCommit.value = commit; commitTooltipPos.value = { x: e.clientX, y: e.clientY }; };
     const onCommitMove = (e) => { commitTooltipPos.value = { x: e.clientX, y: e.clientY }; };
     const onCommitLeave = () => { hoveredCommit.value = null; };
+
+    // Recent Changes feed: Website (this repo) vs. Launcher (separate repo,
+    // fetched from GitHub in the controller). Tab switches the feed + the
+    // GitHub repo the commit links point at.
+    const changesTab = ref('web');
+    const CHANGES_REPOS = {
+        web: 'https://github.com/defrag-racing/defrag-racing-project',
+        launcher: 'https://github.com/Defrag-racing/defrag-racing-launcher',
+    };
+    const activeChangelog = computed(() => changesTab.value === 'web'
+        ? (props.recentChangelog || [])
+        : (props.recentChangelogLauncher || []));
+    const changesRepoUrl = computed(() => CHANGES_REPOS[changesTab.value]);
 
     const timeAgo = (dateStr) => {
         if (!dateStr) return '';
@@ -351,22 +371,33 @@
             <!-- Row 2: Changelog -->
             <div>
                 <div class="bg-black/40 backdrop-blur-sm rounded-xl border border-white/10 overflow-hidden">
-                    <div class="flex items-center justify-between px-5 py-3 border-b border-white/5">
+                    <div class="flex items-center justify-between px-5 py-3 border-b border-white/5 gap-3 flex-wrap">
                         <h2 class="text-sm font-bold text-white flex items-center gap-2">
                             <svg class="w-4 h-4 text-cyan-400" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" /></svg>
                             Recent Changes
                         </h2>
-                        <Link href="/roadmap" class="text-xs text-blue-400 hover:text-blue-300 font-medium">Roadmap</Link>
+                        <div class="flex items-center gap-3">
+                            <!-- Website / Launcher tabs -->
+                            <div class="flex bg-white/5 rounded-lg overflow-hidden text-[11px]">
+                                <button
+                                    v-for="tab in [{ v: 'web', label: 'Website' }, { v: 'launcher', label: 'Launcher' }]"
+                                    :key="tab.v"
+                                    @click="changesTab = tab.v"
+                                    :class="['px-3 py-1 font-semibold transition-colors', changesTab === tab.v ? 'bg-cyan-500/25 text-cyan-200' : 'text-gray-400 hover:text-gray-200']"
+                                >{{ tab.label }}</button>
+                            </div>
+                            <Link href="/roadmap" class="text-xs text-blue-400 hover:text-blue-300 font-medium">Roadmap</Link>
+                        </div>
                     </div>
-                    <div v-if="recentChangelog && recentChangelog.length > 0" class="p-4 space-y-1">
-                        <div v-for="commit in recentChangelog" :key="commit.hash"
+                    <div v-if="activeChangelog.length > 0" class="p-4 space-y-1">
+                        <div v-for="commit in activeChangelog" :key="commit.hash"
                              class="relative pl-5 border-l-2 border-green-500/20"
                              :class="commit.description ? 'cursor-help' : ''"
                              @mouseenter="commit.description ? onCommitEnter($event, commit) : null"
                              @mousemove="commit.description ? onCommitMove($event) : null"
                              @mouseleave="onCommitLeave">
                             <div class="absolute left-0 top-2.5 w-3 h-0.5 bg-green-500/20"></div>
-                            <a :href="`https://github.com/defrag-racing/defrag-racing-project/commit/${commit.hash}`" target="_blank" class="flex items-center gap-2 px-2 py-1.5 bg-gradient-to-r from-green-500/10 to-transparent hover:from-green-500/20 rounded transition-all">
+                            <a :href="`${changesRepoUrl}/commit/${commit.hash}`" target="_blank" class="flex items-center gap-2 px-2 py-1.5 bg-gradient-to-r from-green-500/10 to-transparent hover:from-green-500/20 rounded transition-all">
                                 <div class="w-1.5 h-1.5 bg-green-400 rounded-full flex-shrink-0"></div>
                                 <span class="text-[10px] font-mono text-gray-500 w-16 flex-shrink-0">{{ commit.date }}</span>
                                 <span class="text-xs font-mono text-green-400/70">{{ commit.hash }}</span>
@@ -374,7 +405,9 @@
                             </a>
                         </div>
                     </div>
-                    <div v-else class="px-5 py-8 text-center text-sm text-gray-500">No recent changes</div>
+                    <div v-else class="px-5 py-8 text-center text-sm text-gray-500">
+                        {{ changesTab === 'launcher' ? 'No launcher changes to show' : 'No recent changes' }}
+                    </div>
                 </div>
             </div>
 
@@ -448,6 +481,24 @@
                             </div>
                         </Link>
                         <button v-if="isAuthenticated" @click="toggleDownload" :class="['shrink-0 w-10 rounded-lg border-2 flex items-center justify-center transition-all', downloadChecked ? 'bg-green-500/20 border-green-500 text-green-400' : 'border-white/20 hover:border-white/40 text-transparent hover:text-white/20']">
+                            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                        </button>
+                    </div>
+
+                    <!-- Download Launcher -->
+                    <div class="flex gap-2 items-stretch">
+                        <Link :href="route('launcher')" :class="['flex-1 backdrop-blur-sm rounded-xl border p-5 transition-all group', launcherChecked ? 'bg-green-500/10 border-green-500/30' : 'bg-black/40 border-white/10 hover:border-blue-500/50']">
+                            <div class="flex items-center gap-4">
+                                <div :class="['p-3 rounded-lg shrink-0', launcherChecked ? 'bg-green-500/20' : 'bg-blue-500/20']">
+                                    <svg :class="['w-6 h-6', launcherChecked ? 'text-green-400' : 'text-blue-400']" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4m4-5 5 5m0 0 5-5m-5 5V3" /></svg>
+                                </div>
+                                <div class="flex-1 min-w-0">
+                                    <h3 :class="['text-base font-bold transition-colors', launcherChecked ? 'text-green-400' : 'text-white group-hover:text-blue-400']">Download Launcher</h3>
+                                    <p class="text-xs text-gray-400 mt-0.5">Auto-backup demos, 1-click Connect &amp; more</p>
+                                </div>
+                            </div>
+                        </Link>
+                        <button v-if="isAuthenticated" @click="toggleLauncher" :class="['shrink-0 w-10 rounded-lg border-2 flex items-center justify-center transition-all', launcherChecked ? 'bg-green-500/20 border-green-500 text-green-400' : 'border-white/20 hover:border-white/40 text-transparent hover:text-white/20']">
                             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                         </button>
                     </div>

--- a/resources/js/Pages/Launcher.vue
+++ b/resources/js/Pages/Launcher.vue
@@ -1,0 +1,208 @@
+<script>
+import MainLayout from '@/Layouts/MainLayout.vue';
+
+export default {
+    layout: MainLayout,
+};
+</script>
+
+<script setup>
+import { Head, Link } from '@inertiajs/vue3';
+import { computed, ref, onMounted } from 'vue';
+
+const props = defineProps({
+    version: { type: String, default: null },
+    published: { type: String, default: null },
+    assets: { type: Object, default: () => ({ windows: [], macos: [], linux: [] }) },
+    releaseUrl: { type: String, default: 'https://github.com/Defrag-racing/defrag-racing-launcher/releases/latest' },
+    changelogUrl: { type: String, default: 'https://github.com/Defrag-racing/defrag-racing-launcher/blob/main/CHANGELOG.md' },
+});
+
+const detectedOS = ref(null);
+const detectedArm = ref(false);
+
+onMounted(() => {
+    const ua = (navigator.userAgent || '').toLowerCase();
+    if (ua.includes('windows')) detectedOS.value = 'windows';
+    else if (ua.includes('mac')) detectedOS.value = 'macos';
+    else if (ua.includes('linux') && !ua.includes('android')) detectedOS.value = 'linux';
+
+    if (detectedOS.value === 'macos') {
+        const platform = (navigator.userAgentData?.platform || navigator.platform || '').toLowerCase();
+        const arch = navigator.userAgentData?.getHighEntropyValues
+            ? null
+            : (ua.includes('arm') || platform.includes('arm') ? 'arm' : 'intel');
+        if (arch === 'arm') detectedArm.value = true;
+        navigator.userAgentData?.getHighEntropyValues?.(['architecture']).then(v => {
+            if ((v.architecture || '').toLowerCase() === 'arm') detectedArm.value = true;
+        }).catch(() => {});
+    }
+});
+
+const platforms = [
+    { id: 'windows', label: 'Windows', tagline: 'Windows 10 / 11 (64-bit)' },
+    { id: 'macos', label: 'macOS', tagline: 'Intel + Apple Silicon' },
+    { id: 'linux', label: 'Linux', tagline: 'AppImage / .deb / .rpm' },
+];
+
+const primaryAsset = computed(() => {
+    if (!detectedOS.value) return null;
+    const list = props.assets?.[detectedOS.value] || [];
+    if (!list.length) return null;
+    if (detectedOS.value === 'macos') {
+        const wanted = detectedArm.value ? 'dmg-arm' : 'dmg-intel';
+        return list.find(a => a.kind === wanted) || list[0];
+    }
+    return list.find(a => a.recommended) || list[0];
+});
+
+const primaryLabel = computed(() => {
+    if (!detectedOS.value) return '';
+    return platforms.find(p => p.id === detectedOS.value)?.label || '';
+});
+
+const formatSize = (bytes) => {
+    if (!bytes) return '';
+    const mb = bytes / (1024 * 1024);
+    return mb.toFixed(1) + ' MB';
+};
+
+const publishedLabel = computed(() => {
+    if (!props.published) return '';
+    const d = new Date(props.published);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+});
+
+const features = [
+    {
+        title: 'Auto-backup your demos',
+        body: 'Drops a watcher on your Defrag demos folder and uploads new runs to defrag.racing in the background. You never lose a demo, even on a crash.',
+        icon: 'cloud-upload',
+    },
+    {
+        title: 'defrag:// Connect that works',
+        body: 'Every Connect button on this site opens your Quake 3 engine and joins the server. No copy-pasting /connect into the console.',
+        icon: 'plug',
+    },
+    {
+        title: 'Native server browser',
+        body: 'Browse the same server list as the website, with the same filters, from a small desktop window. Quick-launch a server in two clicks.',
+        icon: 'list',
+    },
+    {
+        title: 'Records + notifications on the desktop',
+        body: 'Bell-badge notifications when someone breaks your record. Records and Maps tabs let you check times without opening a browser.',
+        icon: 'bell',
+    },
+];
+</script>
+
+<template>
+    <Head title="Download Launcher" />
+
+    <div class="relative pt-10 pb-16">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+
+            <div class="text-center mb-10">
+                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 border border-blue-500/30 text-blue-300 text-[11px] font-semibold uppercase tracking-wider mb-4">
+                    Desktop launcher
+                </div>
+                <h1 class="text-4xl md:text-5xl font-black text-white mb-4 leading-tight">
+                    Defrag Racing <span class="text-blue-500">Launcher</span>
+                </h1>
+                <p class="text-base text-gray-400 max-w-2xl mx-auto mb-8">
+                    Auto-backup your demos, browse servers natively, and make every
+                    <code class="text-blue-300 bg-blue-500/10 px-1.5 py-0.5 rounded text-sm">defrag://</code>
+                    connect button on this site work.
+                </p>
+
+                <div v-if="primaryAsset" class="flex flex-col items-center gap-3">
+                    <a :href="primaryAsset.url"
+                       class="inline-flex items-center gap-3 px-8 py-4 rounded-xl bg-blue-600 hover:bg-blue-500 active:bg-blue-700 transition-colors text-white text-base font-bold shadow-2xl shadow-blue-500/20">
+                        <svg v-if="detectedOS === 'windows'" class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.5l9.6-1.3v9.3H0V3.5zm0 17l9.6 1.3v-9.2H0v7.9zM10.7 22.0l12.8 1.8V12.5H10.7v9.5zm0-19.9V11.3h12.8V0L10.7 2.1z"/></svg>
+                        <svg v-else-if="detectedOS === 'macos'" class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 12.04c.03-2.94 2.4-4.36 2.51-4.43-1.37-2-3.5-2.28-4.26-2.31-1.81-.18-3.54 1.07-4.46 1.07-.94 0-2.34-1.05-3.85-1.02-1.98.03-3.81 1.15-4.83 2.92-2.06 3.57-.53 8.85 1.48 11.74.98 1.42 2.14 3 3.66 2.95 1.47-.06 2.02-.95 3.8-.95 1.77 0 2.27.95 3.82.92 1.58-.03 2.58-1.44 3.55-2.86 1.12-1.64 1.58-3.23 1.6-3.31-.04-.02-3.05-1.17-3.08-4.64M14.13 3.84c.81-.99 1.36-2.36 1.21-3.74-1.17.05-2.6.78-3.44 1.77-.75.87-1.41 2.27-1.23 3.61 1.31.1 2.65-.66 3.46-1.64"/></svg>
+                        <svg v-else-if="detectedOS === 'linux'" class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489.117.766.422 1.484.974 2.077-.046.135-.078.27-.099.402-.077.473.011.852.156 1.218.292.732.881 1.327 1.622 1.683.741.357 1.55.589 2.31.677.752.087 1.45.025 1.92-.227.376-.202.61-.516.71-.86l.027-.044-.001-.04c.131-.34.182-.69.215-1.012.027-.26.04-.518.07-.768.13-1.054.45-2.118.92-3.144 1.094-2.41 3.057-3.81 3.91-5.156.842-1.328 1.052-2.412.952-3.317-.245-2.207-.86-3.516-2.137-4.226-.78-.434-1.62-.624-2.49-.624-.74 0-1.49.137-2.234.351-.27-.054-.572-.139-.85-.27-.6-.275-1.078-.71-1.355-1.243-.18-.353-.27-.74-.27-1.142 0-.378.075-.74.244-1.082.183-.367.515-.74.93-.92.413-.18.85-.18 1.314 0z"/></svg>
+                        Download for {{ primaryLabel }}
+                    </a>
+                    <div class="text-xs text-gray-500">
+                        <span v-if="version">v{{ version }}</span>
+                        <span v-if="version && primaryAsset.label"> - </span>
+                        <span>{{ primaryAsset.label }}</span>
+                        <span v-if="primaryAsset.size"> ({{ formatSize(primaryAsset.size) }})</span>
+                    </div>
+                </div>
+                <div v-else-if="version" class="text-sm text-gray-500">
+                    Pick your platform below. Current version: <span class="text-gray-300 font-semibold">v{{ version }}</span>
+                </div>
+                <div v-else class="text-sm text-gray-500">
+                    Pick your platform below.
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10">
+                <div v-for="p in platforms" :key="p.id"
+                     class="bg-black/40 backdrop-blur-sm rounded-2xl p-5 border border-white/10 hover:border-blue-500/40 transition-all">
+                    <div class="flex items-center gap-3 mb-4">
+                        <div class="w-12 h-12 rounded-xl bg-white/5 flex items-center justify-center">
+                            <svg v-if="p.id === 'windows'" class="w-7 h-7 text-blue-300" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.5l9.6-1.3v9.3H0V3.5zm0 17l9.6 1.3v-9.2H0v7.9zM10.7 22.0l12.8 1.8V12.5H10.7v9.5zm0-19.9V11.3h12.8V0L10.7 2.1z"/></svg>
+                            <svg v-else-if="p.id === 'macos'" class="w-7 h-7 text-gray-200" viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 12.04c.03-2.94 2.4-4.36 2.51-4.43-1.37-2-3.5-2.28-4.26-2.31-1.81-.18-3.54 1.07-4.46 1.07-.94 0-2.34-1.05-3.85-1.02-1.98.03-3.81 1.15-4.83 2.92-2.06 3.57-.53 8.85 1.48 11.74.98 1.42 2.14 3 3.66 2.95 1.47-.06 2.02-.95 3.8-.95 1.77 0 2.27.95 3.82.92 1.58-.03 2.58-1.44 3.55-2.86 1.12-1.64 1.58-3.23 1.6-3.31-.04-.02-3.05-1.17-3.08-4.64M14.13 3.84c.81-.99 1.36-2.36 1.21-3.74-1.17.05-2.6.78-3.44 1.77-.75.87-1.41 2.27-1.23 3.61 1.31.1 2.65-.66 3.46-1.64"/></svg>
+                            <svg v-else-if="p.id === 'linux'" class="w-7 h-7 text-yellow-300" viewBox="0 0 24 24" fill="currentColor"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489.117.766.422 1.484.974 2.077-.046.135-.078.27-.099.402-.077.473.011.852.156 1.218.292.732.881 1.327 1.622 1.683.741.357 1.55.589 2.31.677.752.087 1.45.025 1.92-.227.376-.202.61-.516.71-.86l.027-.044-.001-.04c.131-.34.182-.69.215-1.012.027-.26.04-.518.07-.768.13-1.054.45-2.118.92-3.144 1.094-2.41 3.057-3.81 3.91-5.156.842-1.328 1.052-2.412.952-3.317-.245-2.207-.86-3.516-2.137-4.226-.78-.434-1.62-.624-2.49-.624-.74 0-1.49.137-2.234.351-.27-.054-.572-.139-.85-.27-.6-.275-1.078-.71-1.355-1.243-.18-.353-.27-.74-.27-1.142 0-.378.075-.74.244-1.082.183-.367.515-.74.93-.92.413-.18.85-.18 1.314 0z"/></svg>
+                        </div>
+                        <div>
+                            <div class="text-white font-bold text-lg leading-tight">{{ p.label }}</div>
+                            <div class="text-xs text-gray-500">{{ p.tagline }}</div>
+                        </div>
+                    </div>
+                    <div class="space-y-2">
+                        <a v-for="a in (assets?.[p.id] || [])" :key="a.name"
+                           :href="a.url"
+                           class="flex items-center justify-between gap-2 p-3 rounded-lg bg-white/5 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/40 transition-all group">
+                            <div class="min-w-0">
+                                <div class="flex items-center gap-2">
+                                    <span class="text-sm text-white font-semibold truncate">{{ a.label }}</span>
+                                    <span v-if="a.recommended" class="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase bg-blue-500/20 text-blue-300 tracking-wider shrink-0">Best</span>
+                                </div>
+                                <div class="text-xs text-gray-500">{{ formatSize(a.size) }}</div>
+                            </div>
+                            <svg class="w-4 h-4 text-gray-500 group-hover:text-blue-300 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        </a>
+                        <div v-if="!assets?.[p.id]?.length" class="text-xs text-gray-500 italic px-3 py-2">
+                            Not available in this release.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="text-center mb-12 text-sm text-gray-500">
+                Need another format or an older version? See
+                <a :href="releaseUrl" target="_blank" rel="noopener" class="text-blue-400 hover:text-blue-300 underline">all assets on GitHub</a>.
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
+                <div v-for="f in features" :key="f.title"
+                     class="bg-black/30 backdrop-blur-sm rounded-2xl p-5 border border-white/10">
+                    <div class="flex items-start gap-3">
+                        <div class="shrink-0 w-10 h-10 rounded-lg bg-blue-500/15 flex items-center justify-center text-blue-300">
+                            <svg v-if="f.icon === 'cloud-upload'" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 16l-4-4-4 4"/><path d="M12 12v9"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>
+                            <svg v-else-if="f.icon === 'plug'" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6"/><path d="M15 2v6"/><path d="M6 8h12v4a6 6 0 0 1-12 0V8z"/><path d="M12 18v4"/></svg>
+                            <svg v-else-if="f.icon === 'list'" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><circle cx="3.5" cy="6" r="1.5"/><circle cx="3.5" cy="12" r="1.5"/><circle cx="3.5" cy="18" r="1.5"/></svg>
+                            <svg v-else-if="f.icon === 'bell'" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+                        </div>
+                        <div>
+                            <div class="text-white font-semibold mb-1">{{ f.title }}</div>
+                            <div class="text-sm text-gray-400 leading-relaxed">{{ f.body }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="text-center text-sm text-gray-500 space-x-2">
+                <a :href="changelogUrl" target="_blank" rel="noopener" class="text-blue-400 hover:text-blue-300 underline">
+                    What's new<span v-if="version"> in v{{ version }}</span>
+                </a>
+                <span v-if="publishedLabel">- released {{ publishedLabel }}</span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Roadmap.vue
+++ b/resources/js/Pages/Roadmap.vue
@@ -1,9 +1,13 @@
 <script setup>
 import { Head } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 const props = defineProps({
     commits: {
+        type: Array,
+        default: () => [],
+    },
+    launcherCommits: {
         type: Array,
         default: () => [],
     },
@@ -15,7 +19,16 @@ const onCommitEnter = (e, commit) => { hoveredCommit.value = commit; commitToolt
 const onCommitMove = (e) => { commitTooltipPos.value = { x: e.clientX, y: e.clientY }; };
 const onCommitLeave = () => { hoveredCommit.value = null; };
 
-const commitItems = props.commits;
+// Web (this repo, read from local git log) vs. Launcher (separate repo,
+// fetched from the GitHub API in the controller). Tab switches which
+// feed + which GitHub repo the commit links point at.
+const activeRepo = ref('web');
+const REPOS = {
+    web: 'https://github.com/defrag-racing/defrag-racing-project',
+    launcher: 'https://github.com/Defrag-racing/defrag-racing-launcher',
+};
+const commitItems = computed(() => activeRepo.value === 'web' ? props.commits : props.launcherCommits);
+const repoUrl = computed(() => REPOS[activeRepo.value]);
 </script>
 
 <template>
@@ -60,14 +73,28 @@ const commitItems = props.commits;
             <!-- DONE — Commits from git -->
             <div class="bg-black/40 rounded-xl p-8 shadow-2xl border border-white/5 mb-8">
                 <div>
-                    <h3 class="text-xl font-bold text-green-400 mb-4 flex items-center gap-2">
-                        <span class="text-2xl">✅</span> Done — {{ commitItems.length }} Commits
-                    </h3>
-                    <div class="ml-8 space-y-2 max-h-[800px] overflow-y-auto pr-4">
+                    <div class="flex items-center justify-between gap-3 mb-4 flex-wrap">
+                        <h3 class="text-xl font-bold text-green-400 flex items-center gap-2">
+                            <span class="text-2xl">✅</span> Done — {{ commitItems.length }} Commits
+                        </h3>
+                        <!-- Repo tabs -->
+                        <div class="flex bg-white/5 rounded-lg overflow-hidden text-sm">
+                            <button
+                                v-for="tab in [{ v: 'web', label: 'Website' }, { v: 'launcher', label: 'Launcher' }]"
+                                :key="tab.v"
+                                @click="activeRepo = tab.v"
+                                :class="['px-4 py-1.5 font-semibold transition-colors', activeRepo === tab.v ? 'bg-green-500/25 text-green-200' : 'text-gray-400 hover:text-gray-200']"
+                            >{{ tab.label }}</button>
+                        </div>
+                    </div>
+                    <div v-if="!commitItems.length" class="ml-8 text-sm text-gray-500 italic py-6">
+                        No commits to show here yet.
+                    </div>
+                    <div v-else class="ml-8 space-y-2 max-h-[800px] overflow-y-auto pr-4">
                         <div v-for="(commit, index) in commitItems" :key="commit.hash" class="relative pl-6 border-l-2 border-green-500/20">
                             <div class="absolute left-0 top-2 w-4 h-0.5 bg-green-500/20"></div>
                             <div>
-                                <a :href="`https://github.com/defrag-racing/defrag-racing-project/commit/${commit.hash}`" target="_blank" class="flex items-center gap-2 px-2 py-1.5 bg-gradient-to-r from-green-500/10 to-transparent hover:from-green-500/20 rounded cursor-pointer transition-all"
+                                <a :href="`${repoUrl}/commit/${commit.hash}`" target="_blank" class="flex items-center gap-2 px-2 py-1.5 bg-gradient-to-r from-green-500/10 to-transparent hover:from-green-500/20 rounded cursor-pointer transition-all"
                                     @mouseenter="onCommitEnter($event, commit)"
                                     @mousemove="onCommitMove"
                                     @mouseleave="onCommitLeave"

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { Head, usePage } from '@inertiajs/vue3';
+import { Head, Link, usePage } from '@inertiajs/vue3';
 import { router } from '@inertiajs/vue3';
 import { defineAsyncComponent, onMounted, onUnmounted, ref, computed, watch } from 'vue';
 import OnlinePlayer from '@/Components/OnlinePlayer.vue';
 import CopyButton from '@/Components/Basic/CopyButton.vue';
+import LauncherBanner from '@/Components/LauncherBanner.vue';
 const AddToMaplistModal = defineAsyncComponent(() => import('@/Components/Maplists/AddToMaplistModal.vue'));
 
 const page = usePage();
@@ -379,6 +380,19 @@ const getFunctionName = (abbr) => {
                         Live Servers
                     </h1>
 
+                    <!-- TEMP hidden: launcher header chip (re-enable once render is confirmed working)
+                    <Link :href="route('launcher')"
+                          class="flex items-center gap-2 bg-gradient-to-r from-blue-600/30 to-blue-500/15 hover:from-blue-600/40 hover:to-blue-500/25 backdrop-blur-sm px-3 py-2 rounded-lg border border-blue-400/40 hover:border-blue-300/60 transition-colors text-sm">
+                        <svg class="w-5 h-5 text-blue-300 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/>
+                            <line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                        <span class="font-bold text-white whitespace-nowrap">Get the launcher</span>
+                        <span class="hidden sm:inline text-blue-200/80 font-semibold text-xs">connect to servers in 1 click + many more features</span>
+                    </Link>
+                    -->
+
                     <div class="flex items-center gap-3 text-sm">
                         <div class="flex items-center gap-2 bg-black/40 backdrop-blur-sm px-3 py-2 rounded-lg border border-blue-400/30">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5 text-blue-400">
@@ -490,6 +504,9 @@ const getFunctionName = (abbr) => {
 
         <!-- Servers Grid/List -->
         <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12" style="margin-top: -22rem;">
+            <!-- TEMP hidden: dismissible launcher banner (re-enable once render is confirmed working)
+            <LauncherBanner variant="servers" />
+            -->
             <!-- Loading skeleton while deferred data loads -->
             <div v-if="!serversLoaded" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <div v-for="i in 6" :key="i" class="bg-black/40 backdrop-blur-sm rounded-2xl border border-white/10 overflow-hidden animate-pulse">

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,8 @@ Route::get('/servers/json', [EndpointController::class, 'index'])->name('servers
 // for CN/RU users who have trouble reaching GitHub directly.
 Route::get('/launcher/latest.json', [LauncherController::class, 'latestManifest'])->name('launcher.manifest');
 
+Route::get('/launcher', [LauncherController::class, 'page'])->name('launcher');
+
 Route::get('/maps', [MapsController::class, 'index'])->name('maps');
 Route::get('/maps/filters', [MapsController::class, 'filters'])->name('maps.filters');
 Route::get('/maps/random', [MapsController::class, 'random'])->name('maps.random');


### PR DESCRIPTION
## What
Web-side integration for the desktop launcher.

### Download page
- New public `/launcher` route (`LauncherController@page` + `Launcher.vue`).
- Pulls the latest GitHub release (cached 1h), detects the visitor's OS/arch, and renders per-platform download buttons. No hardcoded asset URLs, so it survives every new release.
- Graceful fallback to the GitHub releases page if the API is unreachable.

### Recent Changes feed: Website / Launcher tabs
- Home "Recent Changes" card and the `/roadmap` page now have **Website / Launcher** tabs.
- Web commits still come from local `git log`; launcher commits are fetched from the GitHub API (separate repo, not checked out on the web server), cached 1h, and normalized to the same shape so one template renders both feeds.
- Commit links point at the correct repo per tab.

### Get Started + promo
- New **Download Launcher** card in the Home "Get Started" grid.
- Inline "Get the launcher" header chip + dismissible `LauncherBanner` on Servers and Demos (per-page copy, localStorage-dismissed).
- **Both promo surfaces are commented out for now** until the launcher's YouTube render flow is confirmed working in production. Re-enable by uncommenting (search `TEMP hidden`).