### PR TITLE
Launcher render: clearer confirm copy, link renders to MDD record, fix source enum

### DIFF
--- a/app/Filament/Resources/RenderedVideoResource.php
+++ b/app/Filament/Resources/RenderedVideoResource.php
@@ -85,6 +85,7 @@ class RenderedVideoResource extends Resource
                                 'discord' => 'Discord',
                                 'web' => 'Web',
                                 'auto' => 'Auto',
+                                'launcher' => 'DefragLauncher',
                             ]),
                         Forms\Components\Toggle::make('is_visible')
                             ->label('Visible'),
@@ -189,10 +190,12 @@ class RenderedVideoResource extends Resource
                     ]),
 
                 Tables\Columns\BadgeColumn::make('source')
+                    ->formatStateUsing(fn ($state) => $state === 'launcher' ? 'DefragLauncher' : $state)
                     ->colors([
                         'info' => 'discord',
                         'success' => 'web',
                         'gray' => 'auto',
+                        'warning' => 'launcher',
                     ]),
 
                 Tables\Columns\TextColumn::make('priority')
@@ -267,6 +270,7 @@ class RenderedVideoResource extends Resource
                         'discord' => 'Discord',
                         'web' => 'Web',
                         'auto' => 'Auto',
+                        'launcher' => 'DefragLauncher',
                         'community_tasks' => 'Community Tasks',
                     ]),
                 Tables\Filters\SelectFilter::make('priority')

--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -475,7 +475,11 @@ class LauncherController extends Controller
             'time_ms' => $demo->time_ms,
             'gametype' => $demo->gametype,
             'demo_id' => $demo->id,
-            'record_id' => null,
+            // Inherit the demo's online record link so the render surfaces
+            // under that MDD record on the map (same as the web render flow).
+            // Null for offline / unmatched demos - those surface via the
+            // demo's own renderedVideo relation in Demos Top instead.
+            'record_id' => $demo->record_id,
             'user_id' => $user->id,
             'source' => 'launcher',
             'requested_by' => $user->name,

--- a/database/migrations/2026_06_02_000001_change_rendered_videos_source_to_string.php
+++ b/database/migrations/2026_06_02_000001_change_rendered_videos_source_to_string.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * `source` was an ENUM('discord','web','auto'). Code writes many more
+ * values (launcher, migration, community_tasks, demome, manual, ...),
+ * and MySQL in non-strict mode silently coerces any value outside the
+ * enum to '' - so launcher renders were landing with source = '' and
+ * could never be backfilled. Convert to a plain VARCHAR so every source
+ * the app uses is stored verbatim and new ones never get truncated.
+ *
+ * Done via raw SQL (not ->change()) because doctrine/dbal doesn't model
+ * MySQL ENUM columns and would choke on the diff. MODIFY keeps the
+ * existing index on the column.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE rendered_videos MODIFY source VARCHAR(50) NOT NULL DEFAULT 'auto'");
+    }
+
+    public function down(): void
+    {
+        // Anything outside the original enum (launcher, etc.) would be
+        // rejected by the enum on the way back, so normalize first.
+        DB::statement("UPDATE rendered_videos SET source = 'auto' WHERE source NOT IN ('discord','web','auto')");
+        DB::statement("ALTER TABLE rendered_videos MODIFY source ENUM('discord','web','auto') NOT NULL DEFAULT 'auto'");
+    }
+};

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -933,21 +933,27 @@
                         </div>
                         <h3 class="text-sm font-bold text-white">Render to YouTube?</h3>
                     </div>
-                    <p class="text-xs text-gray-400 mb-3">This will queue the demo for rendering to a YouTube video. The process may take several minutes.</p>
+                    <p class="text-xs text-gray-400 mb-3">This queues your demo to be rendered into a video and uploaded to the defrag.racing YouTube channel. Rendering can take several minutes.</p>
+
+                    <div class="border border-red-500/30 bg-red-500/[0.06] rounded-lg p-3 mb-3">
+                        <p class="text-[11px] text-gray-300 leading-relaxed">
+                            <span class="font-bold text-red-300">Renders cost real money.</span>
+                            The render farm time and storage are paid for by defrag.racing out of the project's own pocket, and YouTube caps how many videos demome can upload per day. Every render you queue spends part of that shared, limited budget - so please only render runs that are worth keeping.
+                        </p>
+                    </div>
 
                     <div class="border border-white/10 bg-white/[0.02] rounded-lg p-3 mb-3">
                         <h4 class="text-xs font-bold text-white mb-2">Render etiquette</h4>
                         <ul class="text-[11px] text-gray-400 space-y-1.5 list-disc pl-4">
-                            <li>Render the best attempt you have. Don't dump your whole time history when you already have, or will soon have, a better time.</li>
-                            <li>Same map, near identical times a few ms apart? Pick one.</li>
-                            <li>Exception: a run with a specific cool trick or something worth showing off. A slower time is totally fine then.</li>
-                            <li>Renders aren't free - we're capped by a daily YouTube upload limit, so spending it on time history burns the budget for everyone.</li>
+                            <li>Render your best run. Don't queue your whole time history when you already have - or will beat in minutes or hours - a faster time.</li>
+                            <li>Several near-identical times on the same map, a few ms apart? Pick one.</li>
+                            <li>Slower time but a genuinely cool trick or something worth showing off? That's totally fine, go for it.</li>
                         </ul>
                     </div>
 
                     <label class="flex items-start gap-2 mb-3 cursor-pointer select-none">
                         <input type="checkbox" v-model="etiquetteAccepted" class="mt-0.5 w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-red-600 focus:ring-red-500 focus:ring-offset-0">
-                        <span class="text-xs text-gray-300">I have read and will follow the render etiquette.</span>
+                        <span class="text-xs text-gray-300">I won't render my whole time history - just the runs actually worth keeping.</span>
                     </label>
 
                     <p v-if="renderError" class="text-xs text-red-400 mb-3">{{ renderError }}</p>


### PR DESCRIPTION
## What
Follow-ups after the launcher YouTube render flow went live end to end.

### Render confirmation copy (web modal)
Lead with a highlighted "Renders cost real money" callout (render farm time + storage paid by defrag.racing, daily YouTube upload cap via demome) instead of burying it as the last bullet. Tightened etiquette rules; checkbox now points at the real ask (don't render your whole time history).

### Launcher renders now attach to the record
`renderVideo` stubbed `record_id => null`, so a launcher-queued render never showed under the demo's MDD record on the map - even though the demo itself was correctly assigned to that record. Now inherits `$demo->record_id` (same as the web + demome flows). Offline / unmatched demos stay null and surface via Demos Top as before.

### Fix `source` enum coercion
`rendered_videos.source` was `ENUM('discord','web','auto')`. Writing `launcher` (and other real values like `demome` / `migration`) was silently coerced to `''` by MySQL in non-strict mode. Migration converts `source` to `VARCHAR(50)`; Filament gets a `DefragLauncher` option/badge/filter.

## Deploy notes
- Migration runs via deploy.py (`migrate --force`).
- One-off backfill for the 2 already-coerced rows (340964/340965): set `record_id` from their demo and `source='launcher'` (works once the column is no longer an enum).