### PR TITLE
Apply alias add/remove to Demos Top + demo attribution immediately

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -44,8 +44,13 @@ class Kernel extends ConsoleKernel
         // Process overdue Headhunter challenge disputes and auto-ban creators
         $schedule->command('headhunter:process-disputes')->withoutOverlapping()->daily();
 
-        // Rematch all unassigned demos against current user aliases (runs daily at 2am)
-        $schedule->command('demos:rematch-all')->withoutOverlapping()->dailyAt('02:00');
+        // Backstop rematch of all demos against current aliases. Manual alias
+        // add/remove now rematches the affected demos immediately (see
+        // AliasController + RematchAliasDemosJob), so this full ~360k-demo
+        // sweep is only insurance for what the targeted pass can't catch:
+        // colour-coded player_names, bulk MDD alias imports, account claims,
+        // and creating missing offline_records. Weekly is plenty for that.
+        $schedule->command('demos:rematch-all')->withoutOverlapping()->weeklyOn(1, '02:00');
 
         // Recalculate all player profile stats (WRs, totals, avg rank, etc.) daily at 3am
         $schedule->command('process-all-player-stats')->withoutOverlapping()->dailyAt('03:00');

--- a/app/Http/Controllers/AliasController.php
+++ b/app/Http/Controllers/AliasController.php
@@ -2,13 +2,47 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\UploadedDemo;
 use App\Models\UserAlias;
+use App\Jobs\RematchAliasDemosJob;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\ValidationException;
 
 class AliasController extends Controller
 {
+    /**
+     * A user's alias set changes who their demos cluster under on every map's
+     * Demos Top. That clustering is computed live but cached per map (keyed by
+     * a `demostop_gen:<map>` generation counter, 1h TTL backstop), and the
+     * auto-render queue reads a materialized `demos_top_ranks` table - neither
+     * of which knows an alias changed. Without this, a newly added/approved
+     * alias only takes visible effect after the cache happens to expire, which
+     * looked like "my alias does nothing". This bumps the generation counter
+     * (instant, cheap display invalidation) for every map the user has demos
+     * on; the next view recomputes the cluster live and picks up the alias.
+     * The heavier per-demo attribution + queue-table rebuild is handled by
+     * RematchAliasDemosJob, scoped to the maps that actually carry the nick.
+     */
+    private function refreshDemosTopForUser(?int $userId): void
+    {
+        if (! $userId) {
+            return;
+        }
+
+        $maps = UploadedDemo::where(function ($q) use ($userId) {
+                $q->where('user_id', $userId)->orWhere('suggested_user_id', $userId);
+            })
+            ->whereNotNull('map_name')
+            ->distinct()
+            ->pluck('map_name');
+
+        foreach ($maps as $map) {
+            Cache::increment('demostop_gen:' . $map);
+        }
+    }
+
     /**
      * Store a new alias
      */
@@ -49,8 +83,19 @@ class AliasController extends Controller
             'is_approved' => $isApproved,
         ]);
 
+        // Approved right away -> re-group this user's Demos Top now so the
+        // alias takes visible effect immediately, not on the next cache miss.
+        // (Pending aliases don't match anything until an admin approves them.)
+        if ($isApproved) {
+            $this->refreshDemosTopForUser($user->id);
+            // Scan demos recorded under this nick and attribute them now
+            // (suggested_user_id / matched_alias) instead of waiting for the
+            // nightly rematch.
+            RematchAliasDemosJob::dispatch($request->alias);
+        }
+
         $message = $isApproved
-            ? 'Alias added successfully! Demos will be rematched during the next scheduled run.'
+            ? 'Alias added - your demos are being re-grouped under this nickname now.'
             : 'Alias submitted for admin approval.';
 
         return back()->with('success', $message);
@@ -85,7 +130,15 @@ class AliasController extends Controller
             $unassignedCount++;
         }
 
+        $ownerId = $alias->user_id;
+        $removedNick = $alias->alias;
         $alias->delete();
+
+        // Removing an alias splits clusters back apart - re-group Demos Top
+        // and re-attribute the demos that were recorded under that nick
+        // against the remaining alias set.
+        $this->refreshDemosTopForUser($ownerId);
+        RematchAliasDemosJob::dispatch($removedNick);
 
         $message = 'Alias deleted successfully.';
         if ($unassignedCount > 0) {

--- a/app/Jobs/RematchAliasDemosJob.php
+++ b/app/Jobs/RematchAliasDemosJob.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\UploadedDemo;
+use App\Services\DemoAutoAssigner;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Scan demos recorded under a just-added/removed alias nickname and refresh
+ * their stored name-match attribution (suggested_user_id / matched_alias)
+ * against the CURRENT alias set - immediately, instead of waiting for the
+ * nightly demos:rematch-all.
+ *
+ * The map's live Demos Top re-resolves identity on every (re)compute, so the
+ * leaderboard only needs the cache generation bumped to reflect a new alias.
+ * This job is for the per-demo attribution other surfaces read (profile demo
+ * lists, the demos browser) and for rebuilding the materialized queue ranks
+ * on the maps that actually carry the nick.
+ *
+ * Matches on the normalised plain nickname, so demos whose player_name is
+ * stored with Quake colour codes are left to the nightly rematch backstop.
+ */
+class RematchAliasDemosJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $alias)
+    {
+    }
+
+    public function handle(DemoAutoAssigner $assigner): void
+    {
+        $needle = mb_strtolower(trim($this->alias));
+        if ($needle === '') {
+            return;
+        }
+
+        $maps = [];
+        UploadedDemo::whereRaw('LOWER(TRIM(player_name)) = ?', [$needle])
+            ->whereNotNull('map_name')
+            ->chunkById(500, function ($demos) use ($assigner, &$maps) {
+                foreach ($demos as $demo) {
+                    $assigner->updateNameMatchOnly($demo);
+                    $maps[$demo->map_name] = true;
+                }
+            });
+
+        // Re-group + rebuild only the maps that actually carry this nick.
+        foreach (array_keys($maps) as $map) {
+            Cache::increment('demostop_gen:' . $map);
+            RebuildDemosTopRanksJob::dispatch($map);
+        }
+    }
+}

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -336,21 +336,26 @@
         return props.record.user?.id === userId;
     });
 
-    // For offline records and online demos in Demos Top, ALWAYS show player_name from demo file
-    // For regular online records, use user's login name
+    // A row that resolved to a registered profile (via its cluster's alias
+    // match) shows that PROFILE's name — even for an offline demo. The demo
+    // file's nick is just one of the player's aliases, so once we know whose
+    // profile it is we display the profile, consistent with the avatar +
+    // profile link (getRoute) which already use record.user. Only fall back
+    // to the raw demo player_name when no profile was matched.
     const displayName = computed(() => {
-        // ALWAYS use player_name for offline records (from demo file)
+        // Offline records: profile name if matched, else the demo file nick.
         if (isOfflineRecord.value) {
-            return props.record.player_name || props.record.name;
+            return props.record.user?.name ?? props.record.player_name ?? props.record.name;
         }
         // For online demos assigned to records, ALWAYS use the 'name' field from backend
         // Backend sets this to record owner's name (either user.name or record.name)
         if (isOnlineDemo.value && props.record.record_id && props.record.name) {
             return props.record.name;
         }
-        // For online demos NOT assigned to records (fallback-assigned), use player_name from demo
+        // Online demos NOT assigned to records (fallback): profile name if
+        // matched, else the demo file nick.
         if (isOnlineDemo.value) {
-            return props.record.player_name || props.record.name;
+            return props.record.user?.name ?? props.record.player_name ?? props.record.name;
         }
         // For regular online records, use user's login name
         return props.record.user?.name ?? props.record.name;


### PR DESCRIPTION
## Problem

Adding or approving a manual alias appeared to do nothing. A map's Demos Top clustering is resolved live but cached per map (`demostop_gen:<map>`, 1h TTL), and per-demo attribution (`suggested_user_id` / `matched_alias`) only refreshed on the nightly `demos:rematch-all`. So a freshly added alias didn't surface until the cache expired or a new record forced a rebuild — the demo kept showing as a separate, unlinked player.

## Changes

- **`AliasController` (store/destroy)** bump `demostop_gen` for every map the user has demos on (instant, cheap invalidation of the live-resolved Demos Top) and dispatch `RematchAliasDemosJob`.
- **`RematchAliasDemosJob` (new)** scans demos recorded under the nick, refreshes `suggested_user_id` / `matched_alias` against the current alias set, and rebuilds the materialized queue ranks for maps carrying the nick. Matches on the normalised plain nick; colour-coded names are left to the backstop.
- **`MapRecord.vue`** shows the resolved profile name on an offline / Demos-Top row instead of the raw demo nick, consistent with the avatar + profile link.
- **`Kernel.php`** `demos:rematch-all` daily → weekly (Mon 02:00) — now only a backstop for colour-coded names, bulk MDD imports, account claims and missing `offline_records`.

## Testing

Verified locally: adding alias `uN-DeaD!w00dy-` (user 41) → all demos under that nick get `suggested_user_id=41, conf=100` across maps, `demostop_gen` bumped, and the offline reps resolve to their profile on Demos Top (`buildReps` returns `resolved_profile_key=user:X`). `php -l` + `schedule:list` clean; Octane + queue reloaded.
