### PR TITLE
Fix map download link for map names containing '#'

### DIFF
--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1231,7 +1231,7 @@
                     <div class="flex flex-wrap gap-2 justify-center mb-4">
                         <!-- Download Button -->
                         <a
-                            :href="`/maps/download/${map.name}`"
+                            :href="`/maps/download/${encodeURIComponent(map.name)}`"
                             class="flex items-center gap-1.5 bg-gray-600/80 hover:bg-gray-600 text-white font-medium px-3 py-1.5 rounded-md transition-all text-xs hover:shadow-md"
                         >
                             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">


### PR DESCRIPTION
## Problem
On the map detail page, the "Download Map" button built its href by
interpolating the raw map name into `/maps/download/<name>`. For a map whose
name contains `#` (e.g. `#r1chu5-5`), the browser parsed `#` as a URL fragment,
so only `/maps/download/` was sent to the server and the download 404'd.

Reported on Discord: https://defrag.racing/maps/%23r1chu5-5 download broken,
while q3df.org handles the same map fine.

## Fix
URL-encode the map name when building the download href
(`encodeURIComponent(map.name)`), so `#` becomes `%23` and reaches the server
intact. Laravel decodes the route param back to `#r1chu5-5` for the `Map` lookup
in `WebController::map()`, which then redirects to the CDN pk3.

## Scope
- Single change: the Download Map button href in `MapView.vue`.
- Map cards (`MapCard` / `MapCardLine` / `MapCardLineSmall`) were never
  affected - they build the CDN URL directly from the `pk3` field and bypass the
  router.
- No impact on map filters / listing.
