### PR TITLE
DefragLive: ingest chat/serverstate into the web (phase 1, dormant)

### DIFF
--- a/app/Console/Commands/DefragliveWriteJson.php
+++ b/app/Console/Commands/DefragliveWriteJson.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\DefragliveJsonWriter;
+use Illuminate\Console\Command;
+
+/**
+ * Rewrites the public console.json/serverstate.json from the DB. Scheduled
+ * every minute (Kernel) to match the cadence of the old cron `docker cp` it
+ * replaces; the live extension still gets realtime updates over the WS, this
+ * file is only its initial-load / poll snapshot.
+ */
+class DefragliveWriteJson extends Command
+{
+    protected $signature = 'defraglive:write-json';
+
+    protected $description = 'Rebuild the public DefragLive console.json/serverstate.json from the DB (replaces the legacy bridge cron docker cp)';
+
+    public function handle(DefragliveJsonWriter $writer): int
+    {
+        if (!$writer->write()) {
+            $this->warn('services.defraglive.public_path not set - writer disabled, no files written.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Wrote console.json + serverstate.json to ' . config('services.defraglive.public_path'));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -69,6 +69,12 @@ class Kernel extends ConsoleKernel
         // Unlock demos stuck in 'processing' for more than 15 minutes and re-queue them
         $schedule->command('demos:unlock-stuck')->withoutOverlapping()->everyFiveMinutes();
 
+        // Rebuild the public DefragLive console.json/serverstate.json from the
+        // DB every minute - same cadence as the old cron `docker cp` out of the
+        // bridge container it replaces. No-ops until DEFRAGLIVE_PUBLIC_PATH is
+        // set (the VPS cutover), so it can't fight the legacy cron before then.
+        $schedule->command('defraglive:write-json')->withoutOverlapping()->everyMinute();
+
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();
 

--- a/app/Filament/Resources/DefragliveChatMessageResource.php
+++ b/app/Filament/Resources/DefragliveChatMessageResource.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DefragliveChatMessageResource\Pages;
+use App\Models\DefragliveChatMessage;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+/**
+ * Read + moderate the live DefragLive chat from the admin panel.
+ *
+ * Moderation here is a soft delete: the row is dropped from the next
+ * console.json rewrite (within a minute), so the message disappears from the
+ * extension overlay on its next poll/reload. Instant overlay removal via the
+ * ext_command/delete_message the extension already honours is a later slice.
+ * AUTOMATIC blacklist filtering is unaffected - it runs upstream in the bot.
+ */
+class DefragliveChatMessageResource extends Resource
+{
+    protected static ?string $model = DefragliveChatMessage::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-chat-bubble-left-right';
+
+    protected static ?string $navigationGroup = 'DefragLive';
+
+    protected static ?string $navigationLabel = 'Live Chat';
+
+    protected static ?int $navigationSort = 10;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function form(Form $form): Form
+    {
+        // Chat is ingested, never authored in the panel.
+        return $form->schema([]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->striped()
+            ->poll('10s')
+            ->defaultSort('id', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Time')
+                    ->dateTime('H:i:s')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('action')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'message' => 'success',
+                        'command' => 'info',
+                        'server_record_celebration' => 'warning',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('author')
+                    ->searchable()
+                    ->sortable()
+                    ->placeholder('--'),
+                Tables\Columns\TextColumn::make('content')
+                    ->wrap()
+                    ->limit(120)
+                    ->searchable()
+                    ->placeholder('--'),
+                Tables\Columns\TextColumn::make('resolved_user_id')
+                    ->label('User')
+                    ->placeholder('--')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('action')
+                    ->options([
+                        'message' => 'Message',
+                        'command' => 'Command',
+                        'afk_notification' => 'AFK notification',
+                        'afk_help' => 'AFK help',
+                        'server_record_celebration' => 'Record celebration',
+                        'ext_command' => 'Ext command',
+                    ])
+                    ->default('message'),
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\DeleteAction::make()
+                    ->label('Moderate')
+                    ->modalHeading('Remove this message?')
+                    ->successNotificationTitle('Message removed from chat'),
+                Tables\Actions\RestoreAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([SoftDeletingScope::class]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDefragliveChatMessages::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DefragliveChatMessageResource/Pages/ListDefragliveChatMessages.php
+++ b/app/Filament/Resources/DefragliveChatMessageResource/Pages/ListDefragliveChatMessages.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveChatMessageResource\Pages;
+
+use App\Filament\Resources\DefragliveChatMessageResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDefragliveChatMessages extends ListRecords
+{
+    protected static string $resource = DefragliveChatMessageResource::class;
+}

--- a/app/Http/Controllers/Api/DefragliveIngestController.php
+++ b/app/Http/Controllers/Api/DefragliveIngestController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\DefragliveChatMessage;
+use App\Models\DefragliveServerState;
+use Illuminate\Http\Request;
+
+/**
+ * Ingest endpoint the DefragLive WebSocket bridge POSTs every persisted
+ * broadcast to. Token-guarded server-to-server (DefragliveTokenMiddleware).
+ *
+ * The bridge keeps doing its realtime WS fan-out to the extension exactly as
+ * before; this is purely the persistence tap that makes the web the source of
+ * truth. We store the SAME set of actions the bridge wrote to console.json,
+ * and the full payload, so DefragliveJsonWriter can rebuild the public
+ * console.json/serverstate.json the legacy extension reads.
+ */
+class DefragliveIngestController extends Controller
+{
+    // Actions the bridge persisted to console.json (its save_message() set).
+    // Kept verbatim so the rebuilt console.json matches what the extension
+    // expects today.
+    private const CHAT_ACTIONS = [
+        'message',
+        'command',
+        'ext_command',
+        'afk_notification',
+        'afk_help',
+        'server_record_celebration',
+    ];
+
+    public function ingest(Request $request)
+    {
+        $data = $request->all();
+        $action = $data['action'] ?? null;
+
+        if (!$action || !is_string($action)) {
+            return response()->json(['error' => 'missing action'], 422);
+        }
+
+        if ($action === 'serverstate') {
+            // Single evolving snapshot - the bridge stored data['message'].
+            DefragliveServerState::query()->updateOrCreate(
+                ['id' => 1],
+                ['payload' => $data['message'] ?? []]
+            );
+
+            return response()->json(['status' => 'ok']);
+        }
+
+        if (in_array($action, self::CHAT_ACTIONS, true)) {
+            $message = is_array($data['message'] ?? null) ? $data['message'] : [];
+
+            DefragliveChatMessage::create([
+                'message_id'    => $message['id'] ?? null,
+                'action'        => $action,
+                'author'        => $message['author'] ?? null,
+                'content'       => $message['content'] ?? null,
+                'msg_timestamp' => $message['timestamp'] ?? null,
+                'payload'       => $data,
+            ]);
+
+            return response()->json(['status' => 'ok']);
+        }
+
+        // translation_result / settings_applied / current_settings / connect_*
+        // are realtime-only and not persisted - the live WS handles them.
+        return response()->json(['status' => 'ignored']);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -88,6 +88,7 @@ class Kernel extends HttpKernel
         'tournaments.news.pinned' => \App\Http\Middleware\TournamentPinnedNewsMiddleware::class,
         'tournaments.tournamentaccess' => \App\Http\Middleware\TournamentAccessMiddleware::class,
         'demome.token' => \App\Http\Middleware\DemomeTokenMiddleware::class,
+        'defraglive.token' => \App\Http\Middleware\DefragliveTokenMiddleware::class,
         'abilities' => \Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
         'ability' => \Laravel\Sanctum\Http\Middleware\CheckForAnyAbility::class,
         'log.api' => \App\Http\Middleware\LogApiCalls::class,

--- a/app/Http/Middleware/DefragliveTokenMiddleware.php
+++ b/app/Http/Middleware/DefragliveTokenMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DefragliveTokenMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $request->bearerToken();
+
+        if (!$token || $token !== config('services.defraglive.ingest_token')) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/DefragliveChatMessage.php
+++ b/app/Models/DefragliveChatMessage.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class DefragliveChatMessage extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'defraglive_chat_messages';
+
+    protected $fillable = [
+        'message_id',
+        'action',
+        'author',
+        'content',
+        'msg_timestamp',
+        'payload',
+        'resolved_user_id',
+        'resolved_mdd_id',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'msg_timestamp' => 'double',
+    ];
+
+    public function resolvedUser()
+    {
+        return $this->belongsTo(User::class, 'resolved_user_id');
+    }
+}

--- a/app/Models/DefragliveServerState.php
+++ b/app/Models/DefragliveServerState.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DefragliveServerState extends Model
+{
+    protected $table = 'defraglive_server_state';
+
+    protected $fillable = [
+        'payload',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+}

--- a/app/Services/DefragliveJsonWriter.php
+++ b/app/Services/DefragliveJsonWriter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DefragliveChatMessage;
+use App\Models\DefragliveServerState;
+
+/**
+ * Rebuilds the public console.json / serverstate.json from the DB.
+ *
+ * This is the drop-in replacement for the legacy cron `docker cp` that copied
+ * those files out of the bridge container. The current Twitch extension reads
+ * https://tw.defrag.racing/{console,serverstate}.json over HTTP for its
+ * initial load + polling, so as long as we write the SAME files, at the SAME
+ * path, in the SAME shape, the extension keeps working unchanged - no Twitch
+ * review needed while the new extension is being built.
+ *
+ * Disabled (no-op) until services.defraglive.public_path is set, so it can't
+ * fight the legacy cron before the VPS cutover.
+ */
+class DefragliveJsonWriter
+{
+    /** @return bool true if files were written, false if the writer is disabled. */
+    public function write(): bool
+    {
+        $dir = config('services.defraglive.public_path');
+
+        if (!$dir) {
+            return false;
+        }
+
+        $dir = rtrim($dir, '/');
+
+        $this->writeConsole($dir);
+        $this->writeServerState($dir);
+
+        return true;
+    }
+
+    private function writeConsole(string $dir): void
+    {
+        $limit = (int) config('services.defraglive.console_limit', 100);
+
+        // Last N non-deleted rows in arrival order, payloads verbatim - the
+        // same array-of-broadcast-objects shape the bridge's console.json had.
+        // Soft-deleted (moderated) rows are dropped by the SoftDeletes scope.
+        $payloads = DefragliveChatMessage::query()
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->pluck('payload')
+            ->reverse()
+            ->values()
+            ->all();
+
+        $this->atomicWrite($dir . '/console.json', $payloads);
+    }
+
+    private function writeServerState(string $dir): void
+    {
+        $state = DefragliveServerState::find(1);
+
+        // Empty state must serialise as {} (object), not [] - the extension
+        // spreads it into its serverstate reducer.
+        $this->atomicWrite($dir . '/serverstate.json', $state?->payload ?? new \stdClass());
+    }
+
+    private function atomicWrite(string $path, $data): void
+    {
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        // Write to a temp file then rename so a reader (the extension polling
+        // the file) never sees a half-written document.
+        $tmp = $path . '.tmp';
+        file_put_contents($tmp, $json, LOCK_EX);
+        rename($tmp, $path);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -60,6 +60,21 @@ return [
         'api_token' => env('DEMOME_API_TOKEN'),
     ],
 
+    'defraglive' => [
+        // Shared bearer token the DefragLive WebSocket bridge uses to POST
+        // chat / serverstate into the web (DefragliveIngestController).
+        'ingest_token' => env('DEFRAGLIVE_INGEST_TOKEN'),
+        // Filesystem dir the public tw.defrag.racing/{console,serverstate}.json
+        // are served from. defraglive:write-json rewrites those two files here
+        // from the DB every minute, replacing the old cron `docker cp` out of
+        // the bridge container. Empty = writer disabled (so it can't fight the
+        // legacy cron until the VPS cutover).
+        'public_path' => env('DEFRAGLIVE_PUBLIC_PATH', ''),
+        // How many recent messages console.json keeps (parity with the
+        // bridge's old last-100 behaviour the extension expects).
+        'console_limit' => (int) env('DEFRAGLIVE_CONSOLE_LIMIT', 100),
+    ],
+
     'storage_vps' => [
         'host'     => env('STORAGE_VPS_HOST'),
         'port'     => (int) env('STORAGE_VPS_PORT', 2258),

--- a/database/migrations/2026_06_04_000001_create_defraglive_chat_messages_table.php
+++ b/database/migrations/2026_06_04_000001_create_defraglive_chat_messages_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Persisted DefragLive chat / console stream.
+ *
+ * The Python WebSocket bridge POSTs every broadcast it persisted to
+ * console.json (message / command / ext_command / afk_notification /
+ * afk_help / server_record_celebration) into the web instead, making the DB
+ * the source of truth so the stream can be read + moderated from Filament and
+ * fed to the giveaway feature. The full original broadcast object is kept in
+ * `payload` so the public console.json the legacy Twitch extension reads can
+ * be reproduced byte-faithfully from the DB (see DefragliveJsonWriter).
+ *
+ * Content already passes the bot's filters.py blacklist BEFORE it reaches us;
+ * we store and serve it verbatim and never read anything pre-filter, so
+ * automatic moderation is unaffected by this integration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('defraglive_chat_messages', function (Blueprint $table) {
+            $table->id();
+
+            // The bot assigns each message a blake2b id (random-salted, so NOT
+            // reproducible). We store it as received and reuse it verbatim to
+            // target overlay deletes via the ext_command/delete_message the
+            // current extension already honours.
+            $table->string('message_id', 32)->nullable()->index();
+
+            // Broadcast action - mirrors the bridge's save_message() set.
+            $table->string('action', 32)->index();
+
+            $table->string('author')->nullable();
+            $table->text('content')->nullable();
+
+            // Float unix timestamp from the bot payload (its own clock).
+            $table->double('msg_timestamp')->nullable();
+
+            // Full original broadcast object {action, message:{...}} for
+            // faithful console.json reproduction - nothing is lost.
+            $table->json('payload');
+
+            // Identity resolution for the giveaway feature - deferred, so
+            // nullable for now (NameMatcher pass fills these later).
+            $table->unsignedBigInteger('resolved_user_id')->nullable()->index();
+            $table->unsignedBigInteger('resolved_mdd_id')->nullable();
+
+            // Manual moderation = soft delete. Excluded from the served
+            // console.json on the next rewrite; admin can restore.
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('defraglive_chat_messages');
+    }
+};

--- a/database/migrations/2026_06_04_000002_create_defraglive_server_state_table.php
+++ b/database/migrations/2026_06_04_000002_create_defraglive_server_state_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Latest DefragLive server-state snapshot.
+ *
+ * The extension only ever wants "now" (current map, players, who the bot is
+ * spectating), so this is a single evolving row (id = 1) the bridge upserts
+ * via the ingest API. DefragliveJsonWriter dumps `payload` straight to the
+ * public serverstate.json the extension feeds into updateServerstate().
+ *
+ * Per-tick spectate history for the giveaway leaderboard is a separate
+ * sampling table added in a later phase - this one is display-only.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('defraglive_server_state', function (Blueprint $table) {
+            $table->id();
+            $table->json('payload');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('defraglive_server_state');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -140,3 +140,12 @@ Route::prefix('demome')->middleware('demome.token')->withoutMiddleware('throttle
     Route::get('/video-metadata/{renderedVideo}', [\App\Http\Controllers\Api\DemomeController::class, 'videoMetadata']);
     Route::get('/videos-needing-metadata-update', [\App\Http\Controllers\Api\DemomeController::class, 'videosNeedingMetadataUpdate']);
 });
+
+// DefragLive bridge ingest. The Python WebSocket bridge POSTs each chat /
+// serverstate broadcast here so the web becomes the source of truth (DB +
+// Filament + giveaway), replacing console.json + the cron docker cp. The
+// bridge keeps its realtime WS fan-out to the extension untouched. Token-
+// guarded server-to-server, exempt from the api throttle like demome.
+Route::prefix('defraglive')->middleware('defraglive.token')->withoutMiddleware('throttle:api')->group(function () {
+    Route::post('/ingest', [\App\Http\Controllers\Api\DefragliveIngestController::class, 'ingest']);
+});


### PR DESCRIPTION
First step of moving the DefragLive realtime stack into the web so chat is
readable + moderatable from Filament (and later feeds the giveaway), without
disturbing the current bot/extension. Backward-compatible and inert until
activated.

- `defraglive_chat_messages` + `defraglive_server_state` tables. Chat rows keep
  the bot's message_id verbatim, the full broadcast payload (for faithful
  console.json rebuild), soft deletes for manual moderation, and nullable
  resolved_user_id/mdd_id for the future giveaway.
- `POST /api/defraglive/ingest`, bearer-token guarded (defraglive.token, mirrors
  demome). Persists the same action set the bridge wrote to console.json;
  serverstate is a single evolving row.
- `DefragliveJsonWriter` + `defraglive:write-json` (scheduled every minute)
  rebuild the public console.json/serverstate.json from the DB in the exact
  shape the legacy extension reads - drop-in replacement for the old cron
  `docker cp`. No-ops until `DEFRAGLIVE_PUBLIC_PATH` is set, so it can't fight
  the legacy cron before the VPS cutover.
- Filament "Live Chat" viewer (admin-only): read + moderate via soft delete.

Content already passes the bot's filters.py blacklist upstream, so automatic
moderation is unaffected. The bridge keeps its realtime WS fan-out to the
extension untouched. Companion bridge change (web-ingest POST) is in the
DefragLive-WebSocket-Bridge-Server repo. Activation (env + bridge .env +
retiring the cron) is a separate deliberate VPS step.
