### PR TITLE
DefragLive: web-native migration foundation (ingest + Reverb + command relay)

### DIFF
--- a/app/Events/DefragliveStreamEvent.php
+++ b/app/Events/DefragliveStreamEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * One live DefragLive stream item, broadcast to the public `defraglive`
+ * channel over Reverb. Carries the exact broadcast object the Python bridge
+ * used to fan out over its raw WebSocket ({action, message:{...}}), so the new
+ * extension can listen for `.stream` and switch on payload.action - a direct
+ * parity replacement for the bridge's onConsoleMessage relay.
+ *
+ * ShouldBroadcastNow (not queued) so chat is instant and the realtime path
+ * doesn't depend on a queue worker draining.
+ */
+class DefragliveStreamEvent implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public array $payload)
+    {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return new Channel('defraglive');
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'stream';
+    }
+
+    public function broadcastWith(): array
+    {
+        return $this->payload;
+    }
+}

--- a/app/Events/DefragliveStreamEvent.php
+++ b/app/Events/DefragliveStreamEvent.php
@@ -26,6 +26,21 @@ class DefragliveStreamEvent implements ShouldBroadcastNow
     {
     }
 
+    /**
+     * Broadcast a payload on the `defraglive` channel, but only when Reverb is
+     * the active broadcaster. Single guarded entry point shared by the ingest
+     * tap, the command/relay endpoints and the moderation hook, so the whole
+     * realtime path stays dormant on prod until BROADCAST_DRIVER=reverb.
+     */
+    public static function dispatchLive(array $payload): void
+    {
+        if (config('broadcasting.default') !== 'reverb') {
+            return;
+        }
+
+        broadcast(new self($payload));
+    }
+
     public function broadcastOn(): Channel
     {
         return new Channel('defraglive');

--- a/app/Http/Controllers/Api/DefragliveController.php
+++ b/app/Http/Controllers/Api/DefragliveController.php
@@ -64,21 +64,55 @@ class DefragliveController extends Controller
         return response()->json(['status' => 'ok']);
     }
 
-    /** Generic bot command (e.g. spectate a player from the player list). bot_secret gated. */
+    /**
+     * Relay a structured ext_command from the extension to the bot (spectate,
+     * spectate_request, afk_control, connect, delete_message, ...). Broadcast
+     * in the exact origin:twitch / ext_command shape the bridge used, so the
+     * bot's existing handle_ws_command runs unchanged. bot_secret gated.
+     */
     public function command(Request $request)
     {
         if (!$this->validBotSecret($request)) {
             return response()->json(['error' => 'Invalid bot secret'], 403);
         }
 
-        $command = $request->input('command');
-        if (!is_string($command) || $command === '') {
-            return response()->json(['error' => 'No command'], 422);
+        $content = $request->input('content');
+        if (!is_array($content) || !isset($content['action'])) {
+            return response()->json(['error' => 'No command content'], 422);
         }
 
         DefragliveStreamEvent::dispatchLive([
-            'action' => 'execute_command',
-            'command' => $command,
+            'origin' => 'twitch',
+            'action' => 'ext_command',
+            'message' => [
+                'content' => $content,
+                'author' => $request->input('author', 'Guest'),
+            ],
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Viewer chat typed in the extension, relayed into the game. Broadcast as
+     * an origin:twitch message; the bot's on_ws_message says it in-game (and
+     * handles "!" proxy commands). Open + throttled, matching the bridge's old
+     * behaviour; the bot sanitises (strips ';' injections, filters.py).
+     */
+    public function say(Request $request)
+    {
+        $content = (string) $request->input('content', '');
+        if (trim($content) === '') {
+            return response()->json(['error' => 'Empty message'], 422);
+        }
+
+        DefragliveStreamEvent::dispatchLive([
+            'origin' => 'twitch',
+            'action' => 'message',
+            'message' => [
+                'content' => $content,
+                'author' => $request->input('author', 'Guest'),
+            ],
         ]);
 
         return response()->json(['status' => 'ok']);

--- a/app/Http/Controllers/Api/DefragliveController.php
+++ b/app/Http/Controllers/Api/DefragliveController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Events\DefragliveStreamEvent;
+use App\Http\Controllers\Controller;
+use App\Models\DefragliveServerState;
+use App\Models\DefragliveSetting;
+use App\Services\DefragliveSettingsService;
+use Illuminate\Http\Request;
+
+/**
+ * Command / relay surface for the web-native DefragLive (replaces the bridge's
+ * inbound handling of settings_batch / get_current_settings / command). The bot
+ * subscribes to the `defraglive` Reverb channel and acts on `execute_command`
+ * events broadcast here - same single-channel model the bridge used.
+ *
+ * Auth model mirrors the existing (deliberately lightweight) design: commands
+ * that drive the bot require the current bot_secret (which the extension
+ * already holds from serverstate, see PlayerList.js). Reading settings is open.
+ * Real per-viewer auth is a later hardening tied to the new extension.
+ */
+class DefragliveController extends Controller
+{
+    public function __construct(private DefragliveSettingsService $settings)
+    {
+    }
+
+    /** get_current_settings parity - the extension reads the current game settings. */
+    public function getSettings()
+    {
+        return response()->json(['settings' => DefragliveSetting::current()]);
+    }
+
+    /** settings_batch parity - the extension changes graphics; convert to cvars and drive the bot. */
+    public function applySettings(Request $request)
+    {
+        if (!$this->validBotSecret($request)) {
+            return response()->json(['error' => 'Invalid bot secret'], 403);
+        }
+
+        $settings = $request->input('settings', []);
+        if (!is_array($settings) || empty($settings)) {
+            return response()->json(['error' => 'No settings'], 422);
+        }
+
+        DefragliveSetting::store($settings);
+
+        // Drive the bot: one execute_command per cvar command (+ vid_restart).
+        foreach ($this->settings->convertToCommands($settings) as $command) {
+            DefragliveStreamEvent::dispatchLive([
+                'action' => 'execute_command',
+                'command' => $command,
+            ]);
+        }
+
+        // Update every viewer's UI.
+        DefragliveStreamEvent::dispatchLive([
+            'action' => 'settings_applied',
+            'settings' => $settings,
+            'username' => $request->input('username', 'Unknown User'),
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /** Generic bot command (e.g. spectate a player from the player list). bot_secret gated. */
+    public function command(Request $request)
+    {
+        if (!$this->validBotSecret($request)) {
+            return response()->json(['error' => 'Invalid bot secret'], 403);
+        }
+
+        $command = $request->input('command');
+        if (!is_string($command) || $command === '') {
+            return response()->json(['error' => 'No command'], 422);
+        }
+
+        DefragliveStreamEvent::dispatchLive([
+            'action' => 'execute_command',
+            'command' => $command,
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /** sync_settings parity - the bot pushes the live game state in (token-guarded route). */
+    public function syncSettings(Request $request)
+    {
+        $settings = $request->input('settings', []);
+        if (!is_array($settings)) {
+            return response()->json(['error' => 'No settings'], 422);
+        }
+
+        DefragliveSetting::store($settings);
+
+        DefragliveStreamEvent::dispatchLive([
+            'action' => 'current_settings',
+            'settings' => DefragliveSetting::current(),
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /** The request's bot_secret must match the bot's current serverstate secret. */
+    private function validBotSecret(Request $request): bool
+    {
+        $provided = (string) $request->input('bot_secret', '');
+        if ($provided === '') {
+            return false;
+        }
+
+        $state = DefragliveServerState::find(1)?->payload ?? [];
+        $current = (string) ($state['bot_secret'] ?? '');
+
+        return $current !== '' && hash_equals($current, $provided);
+    }
+}

--- a/app/Http/Controllers/Api/DefragliveIngestController.php
+++ b/app/Http/Controllers/Api/DefragliveIngestController.php
@@ -41,10 +41,20 @@ class DefragliveIngestController extends Controller
         }
 
         if ($action === 'serverstate') {
-            // Single evolving snapshot - the bridge stored data['message'].
-            DefragliveServerState::query()->updateOrCreate(
-                ['id' => 1],
-                ['payload' => $data['message'] ?? []]
+            // Single evolving snapshot (the bridge stored data['message']).
+            // The bridge POSTs concurrently (fire-and-forget threads), so use an
+            // atomic upsert keyed on id=1 - updateOrCreate would race two first
+            // inserts into duplicate rows (and id isn't fillable). This always
+            // keeps exactly one row.
+            DefragliveServerState::upsert(
+                [[
+                    'id' => 1,
+                    'payload' => json_encode($data['message'] ?? []),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]],
+                ['id'],
+                ['payload', 'updated_at']
             );
 
             return response()->json(['status' => 'ok']);

--- a/app/Http/Controllers/Api/DefragliveIngestController.php
+++ b/app/Http/Controllers/Api/DefragliveIngestController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Events\DefragliveStreamEvent;
 use App\Http\Controllers\Controller;
 use App\Models\DefragliveChatMessage;
 use App\Models\DefragliveServerState;
@@ -57,6 +58,8 @@ class DefragliveIngestController extends Controller
                 ['payload', 'updated_at']
             );
 
+            $this->broadcastLive($data);
+
             return response()->json(['status' => 'ok']);
         }
 
@@ -72,11 +75,29 @@ class DefragliveIngestController extends Controller
                 'payload'       => $data,
             ]);
 
+            $this->broadcastLive($data);
+
             return response()->json(['status' => 'ok']);
         }
 
         // translation_result / settings_applied / current_settings / connect_*
         // are realtime-only and not persisted - the live WS handles them.
         return response()->json(['status' => 'ignored']);
+    }
+
+    /**
+     * Fan the ingested item out live over Reverb to the `defraglive` channel
+     * (the web-native replacement for the bridge's WS broadcast). Guarded on
+     * the active broadcaster so it stays fully dormant on prod until
+     * BROADCAST_DRIVER=reverb is set - no log spam, no behaviour change, until
+     * the new extension is ready to consume it.
+     */
+    private function broadcastLive(array $data): void
+    {
+        if (config('broadcasting.default') !== 'reverb') {
+            return;
+        }
+
+        broadcast(new DefragliveStreamEvent($data));
     }
 }

--- a/app/Http/Controllers/Api/DefragliveIngestController.php
+++ b/app/Http/Controllers/Api/DefragliveIngestController.php
@@ -94,10 +94,6 @@ class DefragliveIngestController extends Controller
      */
     private function broadcastLive(array $data): void
     {
-        if (config('broadcasting.default') !== 'reverb') {
-            return;
-        }
-
-        broadcast(new DefragliveStreamEvent($data));
+        DefragliveStreamEvent::dispatchLive($data);
     }
 }

--- a/app/Models/DefragliveChatMessage.php
+++ b/app/Models/DefragliveChatMessage.php
@@ -2,12 +2,36 @@
 
 namespace App\Models;
 
+use App\Events\DefragliveStreamEvent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DefragliveChatMessage extends Model
 {
     use SoftDeletes;
+
+    protected static function booted(): void
+    {
+        // Admin moderation (soft delete) -> tell every overlay to remove the
+        // message instantly, in the exact ext_command/delete_message shape the
+        // extension's onConsoleMessage already honours. Force deletes (cleanup)
+        // don't broadcast. Dormant until Reverb is the active broadcaster.
+        static::deleted(function (DefragliveChatMessage $message) {
+            if ($message->isForceDeleting() || !$message->message_id) {
+                return;
+            }
+
+            DefragliveStreamEvent::dispatchLive([
+                'action' => 'ext_command',
+                'message' => [
+                    'content' => [
+                        'action' => 'delete_message',
+                        'id' => $message->message_id,
+                    ],
+                ],
+            ]);
+        });
+    }
 
     protected $table = 'defraglive_chat_messages';
 

--- a/app/Models/DefragliveSetting.php
+++ b/app/Models/DefragliveSetting.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DefragliveSetting extends Model
+{
+    protected $table = 'defraglive_settings';
+
+    protected $fillable = [
+        'payload',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+
+    /** Default game settings (parity with the bridge's get_current_settings fallback). */
+    public const DEFAULTS = [
+        'brightness' => 2, 'picmip' => 0, 'fullbright' => false, 'gamma' => 1.2,
+        'sky' => true, 'triggers' => false, 'clips' => false, 'slick' => false,
+        'drawgun' => false, 'angles' => false, 'lagometer' => false, 'snaps' => true,
+        'cgaz' => true, 'speedinfo' => true, 'speedorig' => false, 'inputs' => true,
+        'obs' => false, 'nodraw' => false, 'thirdperson' => false, 'miniview' => false,
+        'gibs' => false, 'blood' => false,
+    ];
+
+    public static function current(): array
+    {
+        return static::find(1)?->payload ?? self::DEFAULTS;
+    }
+
+    /** Race-safe singleton upsert (id=1), merging into whatever is stored. */
+    public static function store(array $settings): void
+    {
+        $merged = array_merge(static::current(), $settings);
+
+        static::upsert(
+            [[
+                'id' => 1,
+                'payload' => json_encode($merged),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]],
+            ['id'],
+            ['payload', 'updated_at']
+        );
+    }
+}

--- a/app/Services/DefragliveSettingsService.php
+++ b/app/Services/DefragliveSettingsService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Converts the extension's UI settings into Quake 3 console commands the bot
+ * executes. Direct port of the bridge's convert_settings_to_commands() so the
+ * web-native path produces byte-identical cvar commands.
+ */
+class DefragliveSettingsService
+{
+    /**
+     * cvar map ported verbatim from server.py setting_configs. toggle => the
+     * two values for off/on; range => value passed through; vid_restart =>
+     * needs a single trailing vid_restart; format_decimals => one-decimal float
+     * (gamma).
+     */
+    private const CONFIGS = [
+        'triggers'    => ['cvar' => 'r_rendertriggerBrushes', 'type' => 'toggle', 'values' => [0, 1]],
+        'sky'         => ['cvar' => 'r_fastsky', 'type' => 'toggle', 'values' => [1, 0]],
+        'clips'       => ['cvar' => 'r_renderClipBrushes', 'type' => 'toggle', 'values' => [0, 1]],
+        'slick'       => ['cvar' => 'r_renderSlickSurfaces', 'type' => 'toggle', 'values' => [0, 1]],
+        'brightness'  => ['cvar' => 'r_mapoverbrightbits', 'type' => 'range', 'vid_restart' => true],
+        'picmip'      => ['cvar' => 'r_picmip', 'type' => 'range', 'vid_restart' => true],
+        'fullbright'  => ['cvar' => 'r_fullbright', 'type' => 'toggle', 'values' => [0, 1], 'vid_restart' => true],
+        'gamma'       => ['cvar' => 'r_gamma', 'type' => 'range', 'format_decimals' => true],
+        'drawgun'     => ['cvar' => 'cg_drawgun', 'type' => 'toggle', 'values' => [2, 1]],
+        'angles'      => ['cvar' => 'df_chs1_Info6', 'type' => 'toggle', 'values' => [0, 40]],
+        'lagometer'   => ['cvar' => 'cg_lagometer', 'type' => 'toggle', 'values' => [0, 1]],
+        'snaps'       => ['cvar' => 'mdd_snap', 'type' => 'toggle', 'values' => [0, 3]],
+        'cgaz'        => ['cvar' => 'mdd_cgaz', 'type' => 'toggle', 'values' => [0, 1]],
+        'speedinfo'   => ['cvar' => 'df_chs1_Info5', 'type' => 'toggle', 'values' => [0, 23]],
+        'speedorig'   => ['cvar' => 'df_drawSpeed', 'type' => 'toggle', 'values' => [0, 1]],
+        'inputs'      => ['cvar' => 'df_chs0_draw', 'type' => 'toggle', 'values' => [0, 1]],
+        'obs'         => ['cvar' => 'df_chs1_Info7', 'type' => 'toggle', 'values' => [0, 50]],
+        'nodraw'      => ['cvar' => 'df_mp_NoDrawRadius', 'type' => 'toggle', 'values' => [100, 100000]],
+        'thirdperson' => ['cvar' => 'cg_thirdperson', 'type' => 'toggle', 'values' => [0, 1]],
+        'miniview'    => ['cvar' => 'df_ghosts_MiniviewDraw', 'type' => 'toggle', 'values' => [0, 6]],
+        'gibs'        => ['cvar' => 'cg_gibs', 'type' => 'toggle', 'values' => [0, 1]],
+        'blood'       => ['cvar' => 'com_blood', 'type' => 'toggle', 'values' => [0, 1]],
+    ];
+
+    /** @return string[] list of "cvar value" command strings (+ trailing vid_restart if needed). */
+    public function convertToCommands(array $settings): array
+    {
+        $commands = [];
+        $needsVidRestart = false;
+
+        foreach ($settings as $key => $value) {
+            if (!isset(self::CONFIGS[$key])) {
+                continue;
+            }
+
+            $cfg = self::CONFIGS[$key];
+
+            if (!empty($cfg['vid_restart'])) {
+                $needsVidRestart = true;
+            }
+
+            if ($cfg['type'] === 'toggle') {
+                $resolved = is_bool($value)
+                    ? ($value ? $cfg['values'][1] : $cfg['values'][0])
+                    : $value;
+            } else { // range
+                $resolved = !empty($cfg['format_decimals'])
+                    ? number_format((float) $value, 1)
+                    : $value;
+            }
+
+            $commands[] = $cfg['cvar'] . ' ' . $resolved;
+        }
+
+        // vid_restart must come AFTER all the setting commands (parity with the
+        // bridge), and only once.
+        if ($needsVidRestart) {
+            $commands[] = 'vid_restart';
+        }
+
+        return $commands;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "laravel/framework": "^10.10",
         "laravel/jetstream": "^4.2",
         "laravel/octane": "^2.2",
+        "laravel/reverb": "^1.10",
         "laravel/sanctum": "^3.3",
         "laravel/scout": "^10.8",
         "laravel/socialite": "^5.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99a8ba3bdda4d7c23da4c3fae65a538a",
+    "content-hash": "2e2209ab123db07e41d6556b6aeddbf5",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -637,6 +637,136 @@
                 }
             ],
             "time": "2023-12-11T17:09:12+00:00"
+        },
+        {
+            "name": "clue/redis-protocol",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/redis-protocol.git",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\Redis\\Protocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A streaming Redis protocol (RESP) parser and serializer written in pure PHP.",
+            "homepage": "https://github.com/clue/redis-protocol",
+            "keywords": [
+                "parser",
+                "protocol",
+                "redis",
+                "resp",
+                "serializer",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/redis-protocol/issues",
+                "source": "https://github.com/clue/redis-protocol/tree/v0.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-07T11:06:28+00:00"
+        },
+        {
+            "name": "clue/redis-react",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-redis.git",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-redis/zipball/84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-protocol": "^0.3.2",
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.0 || ^1.1",
+                "react/promise-timer": "^1.11",
+                "react/socket": "^1.16"
+            },
+            "require-dev": {
+                "clue/block-react": "^1.5",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Redis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Async Redis client implementation, built on top of ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-redis",
+            "keywords": [
+                "async",
+                "client",
+                "database",
+                "reactphp",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-redis/issues",
+                "source": "https://github.com/clue/reactphp-redis/tree/v2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-03T16:18:33+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -1657,6 +1787,53 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "filament/actions",
@@ -3610,6 +3787,85 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.1.25"
             },
             "time": "2024-08-12T22:06:33+00:00"
+        },
+        {
+            "name": "laravel/reverb",
+            "version": "v1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/reverb.git",
+                "reference": "43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac",
+                "reference": "43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-react": "^2.6",
+                "guzzlehttp/psr7": "^2.6",
+                "illuminate/console": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.47|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.15|^0.2.0|^0.3.0",
+                "php": "^8.2",
+                "pusher/pusher-php-server": "^7.2",
+                "ratchet/rfc6455": "^0.4",
+                "react/promise-timer": "^1.10",
+                "react/socket": "^1.14",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^6.3|^7.0|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "phpstan/phpstan": "^1.10",
+                "ratchet/pawl": "^0.4.1",
+                "react/async": "^4.2",
+                "react/http": "^1.9"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Reverb\\ApplicationManagerServiceProvider",
+                        "Laravel\\Reverb\\ReverbServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Reverb\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Joe Dixon",
+                    "email": "joe@laravel.com"
+                }
+            ],
+            "description": "Laravel Reverb provides a real-time WebSocket communication backend for Laravel applications.",
+            "keywords": [
+                "WebSockets",
+                "laravel",
+                "real-time",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/reverb/issues",
+                "source": "https://github.com/laravel/reverb/tree/v1.10.2"
+            },
+            "time": "2026-05-10T15:47:52+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -7316,6 +7572,66 @@
             "time": "2025-03-16T03:05:19+00:00"
         },
         {
+            "name": "pusher/pusher-php-server",
+            "version": "7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pusher/pusher-http-php.git",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/4aa139ed2a2a805cd265449b691198beee1309d2",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.2",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "overtrue/phplint": "^2.3",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pusher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library for interacting with the Pusher REST API",
+            "keywords": [
+                "events",
+                "messaging",
+                "php-pusher-server",
+                "publish",
+                "push",
+                "pusher",
+                "real time",
+                "real-time",
+                "realtime",
+                "rest",
+                "trigger"
+            ],
+            "support": {
+                "issues": "https://github.com/pusher/pusher-http-php/issues",
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
+            },
+            "time": "2026-05-18T13:11:36+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -7526,6 +7842,595 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "ratchet/rfc6455",
+            "version": "v0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ratchetphp/RFC6455.git",
+                "reference": "859d95f85dda0912c6d5b936d036d044e3af47ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/859d95f85dda0912c6d5b936d036d044e3af47ef",
+                "reference": "859d95f85dda0912c6d5b936d036d044e3af47ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "psr/http-factory-implementation": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "guzzlehttp/psr7": "^2.7",
+                "phpunit/phpunit": "^9.5",
+                "react/socket": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ratchet\\RFC6455\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Matt Bonneau",
+                    "role": "Developer"
+                }
+            ],
+            "description": "RFC6455 WebSocket protocol handler",
+            "homepage": "http://socketo.me",
+            "keywords": [
+                "WebSockets",
+                "rfc6455",
+                "websocket"
+            ],
+            "support": {
+                "chat": "https://gitter.im/reactphp/reactphp",
+                "issues": "https://github.com/ratchetphp/RFC6455/issues",
+                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.0"
+            },
+            "time": "2025-02-24T01:18:22+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/promise-timer",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise-timer.git",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/4f70306ed66b8b44768941ca7f142092600fafc1",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7.0 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
+            "homepage": "https://github.com/reactphp/promise-timer",
+            "keywords": [
+                "async",
+                "event-loop",
+                "promise",
+                "reactphp",
+                "timeout",
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise-timer/issues",
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:27:45+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "roadrunner-php/roadrunner-api-dto",
@@ -15880,5 +16785,5 @@
         "php": "^8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -179,7 +179,7 @@ return [
          */
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
-        // App\Providers\BroadcastServiceProvider::class,
+        App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\Filament\AdminPanelProvider::class,
         App\Providers\RouteServiceProvider::class,

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -30,6 +30,23 @@ return [
 
     'connections' => [
 
+        'reverb' => [
+            'driver' => 'reverb',
+            'key' => env('REVERB_APP_KEY'),
+            'secret' => env('REVERB_APP_SECRET'),
+            'app_id' => env('REVERB_APP_ID'),
+            'options' => [
+                'host' => env('REVERB_HOST'),
+                'port' => env('REVERB_PORT', 443),
+                'scheme' => env('REVERB_SCHEME', 'https'),
+                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                'path' => env('REVERB_SERVER_PATH', ''),
+            ],
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+        ],
+
         'pusher' => [
             'driver' => 'pusher',
             'key' => env('PUSHER_APP_KEY'),

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -1,0 +1,102 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Reverb Server
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default server used by Reverb to handle
+    | incoming messages as well as broadcasting message to all your
+    | connected clients. At this time only "reverb" is supported.
+    |
+    */
+
+    'default' => env('REVERB_SERVER', 'reverb'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Servers
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define details for each of the supported Reverb servers.
+    | Each server has its own configuration options that are defined in
+    | the array below. You should ensure all the options are present.
+    |
+    */
+
+    'servers' => [
+
+        'reverb' => [
+            'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
+            'port' => env('REVERB_SERVER_PORT', 8080),
+            'path' => env('REVERB_SERVER_PATH', ''),
+            'hostname' => env('REVERB_HOST'),
+            'options' => [
+                'tls' => [],
+            ],
+            'max_request_size' => env('REVERB_MAX_REQUEST_SIZE', 10_000),
+            'scaling' => [
+                'enabled' => env('REVERB_SCALING_ENABLED', false),
+                'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
+                'server' => [
+                    'url' => env('REDIS_URL'),
+                    'host' => env('REDIS_HOST', '127.0.0.1'),
+                    'port' => env('REDIS_PORT', '6379'),
+                    'username' => env('REDIS_USERNAME'),
+                    'password' => env('REDIS_PASSWORD'),
+                    'database' => env('REDIS_DB', '0'),
+                    'timeout' => env('REDIS_TIMEOUT', 60),
+                ],
+            ],
+            'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
+            'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Applications
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define how Reverb applications are managed. If you choose
+    | to use the "config" provider, you may define an array of apps which
+    | your server will support, including their connection credentials.
+    |
+    */
+
+    'apps' => [
+
+        'provider' => 'config',
+
+        'apps' => [
+            [
+                'key' => env('REVERB_APP_KEY'),
+                'secret' => env('REVERB_APP_SECRET'),
+                'app_id' => env('REVERB_APP_ID'),
+                'options' => [
+                    'host' => env('REVERB_HOST'),
+                    'port' => env('REVERB_PORT', 443),
+                    'scheme' => env('REVERB_SCHEME', 'https'),
+                    'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                ],
+                'allowed_origins' => ['*'],
+                'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
+                'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
+                'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
+                'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
+                'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
+                'rate_limiting' => [
+                    'enabled' => env('REVERB_APP_RATE_LIMITING_ENABLED', false),
+                    'max_attempts' => env('REVERB_APP_RATE_LIMIT_MAX_ATTEMPTS', 60),
+                    'decay_seconds' => env('REVERB_APP_RATE_LIMIT_DECAY_SECONDS', 60),
+                    'terminate_on_limit' => env('REVERB_APP_RATE_LIMIT_TERMINATE', false),
+                ],
+            ],
+        ],
+
+    ],
+
+];

--- a/database/migrations/2026_06_04_000003_create_defraglive_settings_table.php
+++ b/database/migrations/2026_06_04_000003_create_defraglive_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Current DefragLive game settings (single evolving row, id=1) - the
+ * web-native replacement for the bridge's current_settings.json. The extension
+ * reads it (get_current_settings parity) and the bot syncs the live game state
+ * into it (sync_settings parity).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('defraglive_settings', function (Blueprint $table) {
+            $table->id();
+            $table->json('payload');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('defraglive_settings');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -148,4 +148,16 @@ Route::prefix('demome')->middleware('demome.token')->withoutMiddleware('throttle
 // guarded server-to-server, exempt from the api throttle like demome.
 Route::prefix('defraglive')->middleware('defraglive.token')->withoutMiddleware('throttle:api')->group(function () {
     Route::post('/ingest', [\App\Http\Controllers\Api\DefragliveIngestController::class, 'ingest']);
+    // Bot pushes the live game settings in (sync_settings parity).
+    Route::post('/sync-settings', [\App\Http\Controllers\Api\DefragliveController::class, 'syncSettings']);
+});
+
+// DefragLive extension-facing command surface. Public (the Twitch extension
+// calls these), throttled; anything that drives the bot is bot_secret-gated
+// inside the controller. Replaces the bridge's inbound settings/command WS
+// handling.
+Route::prefix('defraglive')->middleware('throttle:120,1')->group(function () {
+    Route::get('/settings', [\App\Http\Controllers\Api\DefragliveController::class, 'getSettings']);
+    Route::post('/settings', [\App\Http\Controllers\Api\DefragliveController::class, 'applySettings']);
+    Route::post('/command', [\App\Http\Controllers\Api\DefragliveController::class, 'command']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,4 +160,5 @@ Route::prefix('defraglive')->middleware('throttle:120,1')->group(function () {
     Route::get('/settings', [\App\Http\Controllers\Api\DefragliveController::class, 'getSettings']);
     Route::post('/settings', [\App\Http\Controllers\Api\DefragliveController::class, 'applySettings']);
     Route::post('/command', [\App\Http\Controllers\Api\DefragliveController::class, 'command']);
+    Route::post('/say', [\App\Http\Controllers\Api\DefragliveController::class, 'say']);
 });


### PR DESCRIPTION
First, web-side half of moving the DefragLive realtime stack off the standalone
Python bridge and into the web. Backward-compatible and dormant until activated;
the old bridge/extension keep running.

Already live:
- defraglive_chat_messages + defraglive_server_state tables; POST
  /api/defraglive/ingest (token-guarded) persists chat/serverstate.
- Filament "Live Chat" admin: read the stream, moderate via soft delete.
- console.json/serverstate.json rebuilt from the DB (defraglive:write-json),
  replacing the cron docker cp.

Dormant until BROADCAST_DRIVER=reverb:
- Laravel Reverb installed; DefragliveStreamEvent broadcasts each ingested item
  on the public 'defraglive' channel ({action, message} parity with the bridge).
- Command/relay endpoints (single channel, bot + extension filter by action):
  GET/POST /settings (settings_batch -> cvar execute_command + settings_applied),
  POST /command (relays structured ext_command: spectate / spectate_request /
  afk_control / connect / delete_message, bot_secret gated), POST /say (viewer
  chat into the game), POST /sync-settings (bot pushes live state).
- Moderation: soft-deleting a message broadcasts the ext_command/delete_message
  the extension honours, so overlays remove it instantly.

Companion branches: DefragLive web-migration (new bot transport),
defraglive-extension web-migration (new extension). Prod activation (Reverb env
+ reverb:start + nginx WS proxy) and the bot/extension flip are separate steps
gated on Twitch approval of the new extension.
