### PR TITLE
DefragLive watch contest + spectate log; demome pace gate & 8/day; servers hover fix

### DIFF
--- a/app/Console/Commands/DefragliveCloseStaleSessions.php
+++ b/app/Console/Commands/DefragliveCloseStaleSessions.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\DefragliveWatchService;
+use Illuminate\Console\Command;
+
+/**
+ * Close any watch session left open after the bot stopped sending serverstate
+ * (crash / offline / paused). Scheduled every minute so dangling sessions don't
+ * mis-credit dead time and the public "currently watching" stays honest.
+ */
+class DefragliveCloseStaleSessions extends Command
+{
+    protected $signature = 'defraglive:close-stale-sessions';
+
+    protected $description = 'Close DefragLive watch sessions whose last tick is older than the gap cap';
+
+    public function handle(DefragliveWatchService $service): int
+    {
+        $closed = $service->closeStaleSessions();
+        $this->info("Closed {$closed} stale watch session(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/DefragliveDrawContest.php
+++ b/app/Console/Commands/DefragliveDrawContest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DefragliveContest;
+use App\Services\DefragliveWatchService;
+use Illuminate\Console\Command;
+
+/**
+ * Draw the watch-time-weighted raffle winner for a contest. Normally triggered
+ * from the Filament admin, but exposed as a command for scripting / re-runs.
+ */
+class DefragliveDrawContest extends Command
+{
+    protected $signature = 'defraglive:draw-contest {contest : Contest id}';
+
+    protected $description = 'Draw the DefragLive watch-time raffle winner for a contest';
+
+    public function handle(DefragliveWatchService $service): int
+    {
+        $contest = DefragliveContest::find($this->argument('contest'));
+        if (!$contest) {
+            $this->error('Contest not found.');
+
+            return self::FAILURE;
+        }
+
+        $winner = $service->draw($contest);
+        if (!$winner) {
+            $this->warn('No eligible entrants (nobody accrued at least one ticket). Contest left undrawn.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            'Winner: %s (%d s watched, %d/%d tickets, winning ticket %d).',
+            $contest->winner_name,
+            $contest->winner_seconds,
+            $contest->winner_tickets,
+            $contest->total_tickets,
+            $contest->winning_ticket
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/DefragliveRolloverContests.php
+++ b/app/Console/Commands/DefragliveRolloverContests.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DefragliveContest;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+/**
+ * Keep the $5 / 2-week contest cadence rolling: flip any active contest whose
+ * window has ended to "closed" (the winner is drawn manually so payout stays in
+ * human hands), then open the next two-week window continuing from the last
+ * one. Does nothing until the admin has seeded the first contest - it never
+ * springs a contest into existence on its own.
+ */
+class DefragliveRolloverContests extends Command
+{
+    protected $signature = 'defraglive:rollover-contests';
+
+    protected $description = 'Close ended DefragLive contests and open the next $5 / 2-week window';
+
+    /** Default contest length. */
+    private const PERIOD_DAYS = 14;
+
+    public function handle(): int
+    {
+        // 1) Close windows that have ended (leave undrawn for the admin).
+        $closed = DefragliveContest::where('status', DefragliveContest::STATUS_ACTIVE)
+            ->where('ends_at', '<', now())
+            ->update(['status' => DefragliveContest::STATUS_CLOSED]);
+
+        if ($closed) {
+            $this->info("Closed {$closed} ended contest(s).");
+        }
+
+        // 2) Only continue an existing cadence - never seed the first contest.
+        $last = DefragliveContest::orderByDesc('ends_at')->first();
+        if (!$last) {
+            $this->info('No contests yet - seed the first one in the admin. Nothing to roll over.');
+
+            return self::SUCCESS;
+        }
+
+        // Already covered for now? Nothing to do.
+        $hasCurrent = DefragliveContest::where('status', DefragliveContest::STATUS_ACTIVE)
+            ->where('starts_at', '<=', now())
+            ->where('ends_at', '>=', now())
+            ->exists();
+
+        if ($hasCurrent) {
+            return self::SUCCESS;
+        }
+
+        // Open the next window, continuing seamlessly from the last one.
+        $start = $last->ends_at->isFuture() ? $last->ends_at->copy() : now();
+        $end = $start->copy()->addDays(self::PERIOD_DAYS);
+
+        $contest = DefragliveContest::create([
+            'title' => 'DefragLive Watch - ' . $start->format('M j') . ' to ' . $end->format('M j'),
+            'starts_at' => $start,
+            'ends_at' => $end,
+            'prize_amount' => $last->prize_amount,
+            'prize_currency' => $last->prize_currency,
+            'status' => DefragliveContest::STATUS_ACTIVE,
+        ]);
+
+        $this->info("Opened contest #{$contest->id}: {$contest->title}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -75,6 +75,14 @@ class Kernel extends ConsoleKernel
         // set (the VPS cutover), so it can't fight the legacy cron before then.
         $schedule->command('defraglive:write-json')->withoutOverlapping()->everyMinute();
 
+        // Close DefragLive watch sessions left open after the bot goes offline,
+        // so dangling sessions don't accrue dead time toward the contest.
+        $schedule->command('defraglive:close-stale-sessions')->withoutOverlapping()->everyMinute();
+
+        // Keep the $5 / 2-week DefragLive contest cadence rolling (close ended
+        // windows, open the next). No-ops until the admin seeds the first one.
+        $schedule->command('defraglive:rollover-contests')->withoutOverlapping()->hourly();
+
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();
 

--- a/app/Filament/Pages/DefragliveSpectateLog.php
+++ b/app/Filament/Pages/DefragliveSpectateLog.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\DefragliveWatchSession;
+use App\Models\Map;
+use App\Support\Q3Color;
+use Filament\Pages\Page;
+
+/**
+ * Read-only scrollable log of what the bot has spectated: who, on which map,
+ * from when to when, and for how long. Backed entirely by the watch sessions
+ * we already record for the contest (no data of its own). A feed, not a table,
+ * to match the Live Chat panel.
+ */
+class DefragliveSpectateLog extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-eye';
+
+    protected static ?string $navigationLabel = 'Spectate Log';
+
+    protected static ?string $navigationGroup = 'DefragLive';
+
+    protected static ?int $navigationSort = 30;
+
+    protected static string $view = 'filament.pages.defraglive-spectate-log';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    private static function duration(int $s): string
+    {
+        $h = intdiv($s, 3600);
+        $m = intdiv($s % 3600, 60);
+        $sec = $s % 60;
+
+        return $h ? "{$h}h {$m}m" : ($m ? "{$m}m {$sec}s" : "{$sec}s");
+    }
+
+    protected function getViewData(): array
+    {
+        $sessions = DefragliveWatchSession::with('user:id,name,plain_name')
+            ->orderByDesc('started_at')
+            ->limit(300)
+            ->get();
+
+        // Batch-resolve map thumbnails for the visible maps (no N+1).
+        $thumbs = Map::whereIn('name', $sessions->pluck('mapname')->filter()->unique()->values())
+            ->pluck('thumbnail', 'name');
+
+        $rows = $sessions->map(function (DefragliveWatchSession $s) use ($thumbs) {
+            return [
+                'id' => $s->id,
+                'date' => optional($s->started_at)->format('M j'),
+                'from' => optional($s->started_at)->format('H:i:s'),
+                'to' => $s->ended_at ? $s->ended_at->format('H:i:s') : null,
+                'live' => $s->ended_at === null,
+                'duration' => self::duration((int) $s->seconds),
+                'player_html' => Q3Color::toHtml($s->player_name),
+                'mapname' => $s->mapname,
+                'map_thumb' => $s->mapname ? ($thumbs[$s->mapname] ?? null) : null,
+                'user' => $s->user ? [
+                    'id' => $s->user->id,
+                    'name' => $s->user->plain_name ?: $s->user->name,
+                ] : null,
+            ];
+        });
+
+        return [
+            'rows' => $rows,
+            'total' => DefragliveWatchSession::count(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DefragliveContestResource.php
+++ b/app/Filament/Resources/DefragliveContestResource.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DefragliveContestResource\Pages;
+use App\Models\DefragliveContest;
+use App\Services\DefragliveWatchService;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class DefragliveContestResource extends Resource
+{
+    protected static ?string $model = DefragliveContest::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-trophy';
+
+    protected static ?string $navigationGroup = 'DefragLive';
+
+    protected static ?string $navigationLabel = 'Watch Contests';
+
+    protected static ?int $navigationSort = 20;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Section::make('Contest')->schema([
+                Forms\Components\TextInput::make('title')
+                    ->required()
+                    ->maxLength(255)
+                    ->columnSpanFull(),
+                Forms\Components\DateTimePicker::make('starts_at')
+                    ->seconds(false)
+                    ->default(now())
+                    ->helperText('Server time is UTC. Defaults to now so the contest is live immediately.')
+                    ->required(),
+                Forms\Components\DateTimePicker::make('ends_at')
+                    ->seconds(false)
+                    ->default(now()->addDays(14))
+                    ->required()
+                    ->after('starts_at'),
+                Forms\Components\TextInput::make('prize_amount')
+                    ->numeric()
+                    ->default(5)
+                    ->required(),
+                Forms\Components\TextInput::make('prize_currency')
+                    ->default('USD')
+                    ->maxLength(8)
+                    ->required(),
+                Forms\Components\Select::make('status')
+                    ->options([
+                        DefragliveContest::STATUS_DRAFT => 'Draft',
+                        DefragliveContest::STATUS_ACTIVE => 'Active',
+                        DefragliveContest::STATUS_CLOSED => 'Closed',
+                        DefragliveContest::STATUS_PAID => 'Paid',
+                    ])
+                    ->default(DefragliveContest::STATUS_DRAFT)
+                    ->required(),
+                Forms\Components\Textarea::make('notes')
+                    ->columnSpanFull(),
+            ])->columns(2),
+
+            Forms\Components\Section::make('Winner (set at draw)')
+                ->schema([
+                    Forms\Components\TextInput::make('winner_name')->disabled()->dehydrated(false),
+                    Forms\Components\TextInput::make('winner_seconds')->disabled()->dehydrated(false)
+                        ->suffix('seconds watched'),
+                    Forms\Components\TextInput::make('winner_tickets')->disabled()->dehydrated(false),
+                    Forms\Components\TextInput::make('total_tickets')->disabled()->dehydrated(false),
+                    Forms\Components\TextInput::make('winning_ticket')->disabled()->dehydrated(false),
+                    Forms\Components\DateTimePicker::make('drawn_at')->disabled()->dehydrated(false),
+                ])
+                ->columns(2)
+                ->visible(fn (?DefragliveContest $record) => $record?->winner_name !== null),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->striped()
+            ->defaultSort('starts_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('title')->searchable()->wrap(),
+                Tables\Columns\TextColumn::make('starts_at')->dateTime('M j, H:i')->sortable(),
+                Tables\Columns\TextColumn::make('ends_at')->dateTime('M j, H:i')->sortable(),
+                Tables\Columns\TextColumn::make('prize_amount')
+                    ->formatStateUsing(fn ($state, DefragliveContest $r) => ($r->prize_currency === 'USD' ? '$' : '') . $state . ($r->prize_currency !== 'USD' ? ' ' . $r->prize_currency : '')),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state) => match ($state) {
+                        DefragliveContest::STATUS_ACTIVE => 'success',
+                        DefragliveContest::STATUS_CLOSED => 'warning',
+                        DefragliveContest::STATUS_PAID => 'info',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('winner_name')
+                    ->placeholder('-')
+                    ->formatStateUsing(fn (?string $state, DefragliveContest $r) => $state
+                        ? preg_replace('/\^[0-9A-Za-z]/', '', $state) . ($r->winner_tickets ? " ({$r->winner_tickets}/{$r->total_tickets})" : '')
+                        : '-'),
+            ])
+            ->actions([
+                // Run the watch-time-weighted raffle. Available once a period is
+                // closed (or active, e.g. an early draw) and not yet drawn.
+                Tables\Actions\Action::make('draw')
+                    ->label('Draw winner')
+                    ->icon('heroicon-o-sparkles')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription('Draw the raffle winner now? More watch time = more tickets, but any entrant can win. This sets the winner and closes the contest.')
+                    ->visible(fn (DefragliveContest $r) => $r->winner_name === null)
+                    ->action(function (DefragliveContest $record) {
+                        $winner = app(DefragliveWatchService::class)->draw($record);
+                        if (!$winner) {
+                            Notification::make()->title('No eligible entrants')
+                                ->body('Nobody accrued at least one ticket (1 minute watched). Contest left undrawn.')
+                                ->warning()->send();
+
+                            return;
+                        }
+                        Notification::make()->title('Winner drawn')
+                            ->body(preg_replace('/\^[0-9A-Za-z]/', '', $winner['name']) . " - {$winner['tickets']} tickets, won ticket {$record->fresh()->winning_ticket} of {$record->fresh()->total_tickets}.")
+                            ->success()->send();
+                    }),
+
+                // Mark a drawn contest as paid out.
+                Tables\Actions\Action::make('markPaid')
+                    ->label('Mark paid')
+                    ->icon('heroicon-o-banknotes')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->visible(fn (DefragliveContest $r) => $r->winner_name !== null && $r->status !== DefragliveContest::STATUS_PAID)
+                    ->action(function (DefragliveContest $record) {
+                        $record->update(['status' => DefragliveContest::STATUS_PAID]);
+                        Notification::make()->title('Marked as paid')->success()->send();
+                    }),
+
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDefragliveContests::route('/'),
+            'create' => Pages\CreateDefragliveContest::route('/create'),
+            'edit' => Pages\EditDefragliveContest::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DefragliveContestResource/Pages/CreateDefragliveContest.php
+++ b/app/Filament/Resources/DefragliveContestResource/Pages/CreateDefragliveContest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveContestResource\Pages;
+
+use App\Filament\Resources\DefragliveContestResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDefragliveContest extends CreateRecord
+{
+    protected static string $resource = DefragliveContestResource::class;
+}

--- a/app/Filament/Resources/DefragliveContestResource/Pages/EditDefragliveContest.php
+++ b/app/Filament/Resources/DefragliveContestResource/Pages/EditDefragliveContest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveContestResource\Pages;
+
+use App\Filament\Resources\DefragliveContestResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDefragliveContest extends EditRecord
+{
+    protected static string $resource = DefragliveContestResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DefragliveContestResource/Pages/ListDefragliveContests.php
+++ b/app/Filament/Resources/DefragliveContestResource/Pages/ListDefragliveContests.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveContestResource\Pages;
+
+use App\Filament\Resources\DefragliveContestResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDefragliveContests extends ListRecords
+{
+    protected static string $resource = DefragliveContestResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/DefragliveIngestController.php
+++ b/app/Http/Controllers/Api/DefragliveIngestController.php
@@ -6,7 +6,9 @@ use App\Events\DefragliveStreamEvent;
 use App\Http\Controllers\Controller;
 use App\Models\DefragliveChatMessage;
 use App\Models\DefragliveServerState;
+use App\Services\DefragliveWatchService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Ingest endpoint the DefragLive WebSocket bridge POSTs every persisted
@@ -57,6 +59,15 @@ class DefragliveIngestController extends Controller
                 ['id'],
                 ['payload', 'updated_at']
             );
+
+            // Fold this snapshot into the watch-time history powering the
+            // contest leaderboard. Never let it break ingest - the snapshot +
+            // realtime fan-out are what the live stream depends on.
+            try {
+                app(DefragliveWatchService::class)->accrue($data['message'] ?? []);
+            } catch (\Throwable $e) {
+                Log::warning('DefragLive watch accrual failed: ' . $e->getMessage());
+            }
 
             $this->broadcastLive($data);
 

--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -1001,7 +1001,24 @@ class DemomeController extends Controller
 
     public function autoApprovePublish(Request $request)
     {
-        $count = min((int) $request->input('count', 2), 5);
+        // Server-side daily publish cap (overrides whatever the bot asks for, so
+        // the daily volume is controlled here without touching the bot). Counts
+        // what already counts toward today: published today + approved-today but
+        // not yet published, so repeated 4h bot calls can't overshoot.
+        $dailyTarget = (int) \App\Models\SiteSetting::get('demome:daily_publish_target', 8);
+
+        $publishedToday = RenderedVideo::whereDate('published_at', today())->count();
+        $approvedTodayPending = RenderedVideo::where('publish_approved', true)
+            ->whereNull('published_at')
+            ->whereDate('updated_at', today())
+            ->count();
+        $remaining = max(0, $dailyTarget - $publishedToday - $approvedTodayPending);
+
+        $count = min((int) $request->input('count', 2), 5, $remaining);
+
+        if ($count <= 0) {
+            return response()->json(['approved' => 0, 'reason' => 'daily target reached', 'daily_target' => $dailyTarget]);
+        }
 
         $videos = \App\Services\RenderQueueService::getNextPublishBatch($count);
 

--- a/app/Http/Controllers/DefragliveContestController.php
+++ b/app/Http/Controllers/DefragliveContestController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DefragliveContest;
+use App\Models\DefragliveWatchSession;
+use App\Services\DefragliveWatchService;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+/**
+ * Public DefragLive watch-time contest page: the live leaderboard of the most-
+ * spectated players this period, the prize/countdown, the viewer's own odds,
+ * and past winners. The winner is a watch-time-weighted raffle, so the page
+ * shows tickets + odds, not just a ranking.
+ */
+class DefragliveContestController extends Controller
+{
+    public function index(Request $request, DefragliveWatchService $service)
+    {
+        $contest = DefragliveContest::current()->first();
+
+        $leaderboard = [];
+        $totalTickets = 0;
+        $myEntry = null;
+
+        if ($contest) {
+            $all = $service->leaderboard($contest, null);
+            $totalTickets = array_sum(array_map(
+                fn ($e) => $e['tickets'] >= 1 ? $e['tickets'] : 0,
+                $all
+            ));
+
+            $userId = auth()->id();
+            $mddId = auth()->user()?->mdd_id;
+
+            foreach ($all as $i => $e) {
+                if (($userId && $e['user_id'] === $userId)
+                    || ($mddId && $e['mdd_id'] === (int) $mddId)) {
+                    $myEntry = [
+                        'rank' => $i + 1,
+                        'seconds' => $e['seconds'],
+                        'tickets' => $e['tickets'],
+                        'odds' => $totalTickets > 0 ? round($e['tickets'] / $totalTickets * 100, 1) : 0,
+                    ];
+                    break;
+                }
+            }
+
+            $leaderboard = array_map($this->present(...), array_slice($all, 0, 10));
+        }
+
+        $open = DefragliveWatchSession::open()
+            ->where('last_seen_at', '>=', now()->subSeconds(DefragliveWatchService::GAP_CAP))
+            ->first();
+
+        return Inertia::render('DefragliveContest', [
+            'contest' => $contest ? [
+                'id' => $contest->id,
+                'title' => $contest->title,
+                'prize_amount' => $contest->prize_amount,
+                'prize_currency' => $contest->prize_currency,
+                'starts_at' => $contest->starts_at?->toIso8601String(),
+                'ends_at' => $contest->ends_at?->toIso8601String(),
+            ] : null,
+            'leaderboard' => $leaderboard,
+            'totalTickets' => $totalTickets,
+            'myEntry' => $myEntry,
+            'nowWatching' => $open ? [
+                'name' => $open->player_name,
+                'mapname' => $open->mapname,
+                'map_thumbnail' => $open->mapname
+                    ? \App\Models\Map::where('name', $open->mapname)->value('thumbnail')
+                    : null,
+            ] : null,
+            'pastWinners' => DefragliveContest::whereNotNull('winner_name')
+                ->orderByDesc('drawn_at')
+                ->limit(10)
+                ->get()
+                ->map(fn (DefragliveContest $c) => [
+                    'title' => $c->title,
+                    'winner_name' => $c->winner_name,
+                    'winner_user_id' => $c->winner_user_id,
+                    'prize_amount' => $c->prize_amount,
+                    'prize_currency' => $c->prize_currency,
+                    'drawn_at' => $c->drawn_at?->toDateString(),
+                    'status' => $c->status,
+                ]),
+            'hallOfFame' => $this->hallOfFame($service),
+        ]);
+    }
+
+    /**
+     * All-time winners: every drawn contest grouped by winner, ranked by number
+     * of wins then total prize won. A small hall of fame under the page.
+     */
+    private function hallOfFame(DefragliveWatchService $service): array
+    {
+        $won = DefragliveContest::whereNotNull('winner_name')
+            ->get(['winner_user_id', 'winner_mdd_id', 'winner_name', 'prize_amount', 'prize_currency']);
+
+        $groups = [];
+        foreach ($won as $c) {
+            $key = $c->winner_user_id
+                ? 'u:' . $c->winner_user_id
+                : 'n:' . $service->cleanName((string) $c->winner_name);
+
+            if (!isset($groups[$key])) {
+                $groups[$key] = [
+                    'winner_user_id' => $c->winner_user_id,
+                    'name' => $c->winner_name,
+                    'wins' => 0,
+                    'total' => 0.0,
+                    'currency' => $c->prize_currency,
+                ];
+            }
+            $groups[$key]['wins']++;
+            $groups[$key]['total'] += (float) $c->prize_amount;
+            $groups[$key]['name'] = $c->winner_name ?: $groups[$key]['name'];
+        }
+
+        $entries = array_values($groups);
+        usort($entries, fn ($a, $b) => [$b['wins'], $b['total']] <=> [$a['wins'], $a['total']]);
+        $entries = array_slice($entries, 0, 10);
+
+        $userIds = array_values(array_filter(array_column($entries, 'winner_user_id')));
+        $users = $userIds
+            ? \App\Models\User::whereIn('id', $userIds)
+                ->get(['id', 'name', 'profile_photo_path', 'country'])
+                ->keyBy('id')
+            : collect();
+
+        foreach ($entries as &$e) {
+            $u = $e['winner_user_id'] ? $users->get($e['winner_user_id']) : null;
+            $e['user'] = $u ? [
+                'id' => $u->id,
+                'profile_photo_path' => $u->profile_photo_path,
+                'country' => $u->country,
+            ] : null;
+        }
+
+        return $entries;
+    }
+
+    /** Shape one leaderboard entry for the page (colored name + resolved user). */
+    private function present(array $e): array
+    {
+        return [
+            'name' => $e['name'],
+            'seconds' => $e['seconds'],
+            'tickets' => $e['tickets'],
+            'mdd_id' => $e['mdd_id'],
+            'user' => $e['user'] ? [
+                'id' => $e['user']->id,
+                'name' => $e['user']->name,
+                'profile_photo_path' => $e['user']->profile_photo_path,
+                'country' => $e['user']->country,
+            ] : null,
+        ];
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -128,6 +128,17 @@ class HandleInertiaRequests extends Middleware
             'globalLatestAnnouncement'  =>      !$request->user() ? Cache::remember('global:latest_announcement', 300, function () {
                 return Announcement::where('type', 'home')->orderBy('created_at', 'DESC')->first(['id', 'title', 'created_at']);
             }) : null,
+            'defragliveContest'         =>      Cache::remember('defraglive:current_contest', 60, function () {
+                $contest = \App\Models\DefragliveContest::current()->first();
+
+                return $contest ? [
+                    'id' => $contest->id,
+                    'title' => $contest->title,
+                    'prize_amount' => $contest->prize_amount,
+                    'prize_currency' => $contest->prize_currency,
+                    'ends_at' => $contest->ends_at?->toIso8601String(),
+                ] : null;
+            }),
         ]);
     }
 

--- a/app/Models/DefragliveContest.php
+++ b/app/Models/DefragliveContest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A DefragLive watch-time contest window. Winner is drawn by a watch-time-
+ * weighted raffle over the watch sessions in [starts_at, ends_at]
+ * (DefragliveWatchService::draw). Default $5 / 2 weeks, but per-row.
+ */
+class DefragliveContest extends Model
+{
+    protected $table = 'defraglive_contests';
+
+    public const STATUS_DRAFT = 'draft';
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_CLOSED = 'closed';
+    public const STATUS_PAID = 'paid';
+
+    protected $fillable = [
+        'title',
+        'starts_at',
+        'ends_at',
+        'prize_amount',
+        'prize_currency',
+        'status',
+        'winner_mdd_id',
+        'winner_user_id',
+        'winner_name',
+        'winner_seconds',
+        'winner_tickets',
+        'total_tickets',
+        'winning_ticket',
+        'drawn_at',
+        'notes',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'drawn_at' => 'datetime',
+        'prize_amount' => 'decimal:2',
+        'winner_seconds' => 'integer',
+        'winner_tickets' => 'integer',
+        'total_tickets' => 'integer',
+        'winning_ticket' => 'integer',
+    ];
+
+    public function winner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'winner_user_id');
+    }
+
+    public function isOpenForWatching(): bool
+    {
+        $now = now();
+
+        return $this->starts_at && $this->ends_at
+            && $now->betweenIncluded($this->starts_at, $this->ends_at);
+    }
+
+    /** The contest currently accepting watch time (drives the public page). */
+    public function scopeCurrent($query)
+    {
+        return $query->where('status', self::STATUS_ACTIVE)
+            ->where('starts_at', '<=', now())
+            ->where('ends_at', '>=', now())
+            ->orderByDesc('starts_at');
+    }
+}

--- a/app/Models/DefragliveWatchSession.php
+++ b/app/Models/DefragliveWatchSession.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One continuous stretch the DefragLive bot spent spectating a single player.
+ * Written/extended by DefragliveWatchService::accrue() from the ingest
+ * serverstate branch. The contest leaderboard sums `seconds` per resolved
+ * player (mdd_id, else player_name_clean) over the contest window.
+ */
+class DefragliveWatchSession extends Model
+{
+    protected $table = 'defraglive_watch_sessions';
+
+    protected $fillable = [
+        'mdd_id',
+        'user_id',
+        'player_name',
+        'player_name_clean',
+        'ip',
+        'mapname',
+        'seconds',
+        'started_at',
+        'last_seen_at',
+        'ended_at',
+    ];
+
+    protected $casts = [
+        'seconds' => 'integer',
+        'started_at' => 'datetime',
+        'last_seen_at' => 'datetime',
+        'ended_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /** The single currently-open session (the bot watches one player at a time). */
+    public function scopeOpen($query)
+    {
+        return $query->whereNull('ended_at');
+    }
+}

--- a/app/Services/DefragliveWatchService.php
+++ b/app/Services/DefragliveWatchService.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DefragliveContest;
+use App\Models\DefragliveWatchSession;
+use App\Models\OnlinePlayer;
+use App\Models\Server;
+use App\Models\User;
+use App\Models\UserAlias;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Watch-time tracking + contest logic for DefragLive.
+ *
+ * The bot publishes a serverstate (~every 2.5s) carrying current_player - who
+ * it is spectating right now. The server_state table only keeps "now", so we
+ * accrue that history here into continuous watch sessions, then a contest is a
+ * window over those sessions and the winner is a watch-time-weighted raffle.
+ *
+ * Identity: the bot payload carries no mdd_id (svinfo doesn't expose it), so we
+ * resolve the watched player to a defrag account by the live OnlinePlayer map
+ * (precise client_id match, then clean-name), then UserAlias, falling back to
+ * the bare name (still tracked; payout handled manually).
+ */
+class DefragliveWatchService
+{
+    /**
+     * Max gap (seconds) between two ingest ticks we still count as continuous
+     * watching. Ticks arrive ~every 2.5s; a larger gap means the bot was paused
+     * / offline, so we don't credit that dead time.
+     */
+    public const GAP_CAP = 30;
+
+    /** Seconds of watch time per raffle ticket (1 minute = 1 ticket). */
+    public const SECONDS_PER_TICKET = 60;
+
+    /**
+     * Fold one serverstate snapshot into the open watch session. Called from
+     * the ingest serverstate branch. Cheap and idempotent-ish; safe under the
+     * bot's concurrent fire-and-forget POSTs via a row lock on the open session.
+     */
+    public function accrue(array $serverstate): void
+    {
+        $current = $serverstate['current_player'] ?? null;
+
+        // No one being spectated, or the bot is watching itself (idle) -> the
+        // current watch stretch is over; close it and credit nobody.
+        if (!is_array($current) || $this->isBot($current, $serverstate)) {
+            $this->closeOpenSession();
+
+            return;
+        }
+
+        $name = (string) ($current['n'] ?? '');
+        $clean = $this->cleanName($name);
+        if ($clean === '') {
+            $this->closeOpenSession();
+
+            return;
+        }
+
+        $ip = $serverstate['ip'] ?? null;
+        $mapname = $serverstate['mapname'] ?? null;
+        $identity = $this->resolve($current, $ip);
+        $key = $this->keyFor($identity['mdd_id'], $clean);
+
+        DB::transaction(function () use ($identity, $name, $clean, $ip, $mapname, $key) {
+            $open = DefragliveWatchSession::open()->lockForUpdate()->first();
+
+            if ($open) {
+                $openKey = $this->keyFor($open->mdd_id, $open->player_name_clean);
+                $delta = $open->last_seen_at
+                    ? now()->diffInSeconds($open->last_seen_at)
+                    : 0;
+
+                if ($openKey === $key && $delta <= self::GAP_CAP) {
+                    // Still on the same player within a normal tick gap: extend.
+                    $open->seconds += $delta;
+                    $open->last_seen_at = now();
+                    $open->mapname = $mapname ?: $open->mapname;
+                    // Backfill identity if it resolved later than the first tick.
+                    if (!$open->mdd_id && $identity['mdd_id']) {
+                        $open->mdd_id = $identity['mdd_id'];
+                        $open->user_id = $identity['user_id'];
+                    }
+                    $open->save();
+
+                    return;
+                }
+
+                // Switched player (or a gap big enough to be a new sitting):
+                // close the previous stretch at its last confirmed tick.
+                $open->ended_at = $open->last_seen_at ?? now();
+                $open->save();
+            }
+
+            $this->openSession($identity, $name, $clean, $ip, $mapname);
+        });
+    }
+
+    /** Close the currently open session, if any (player switch / idle / offline). */
+    public function closeOpenSession(): void
+    {
+        DB::transaction(function () {
+            $open = DefragliveWatchSession::open()->lockForUpdate()->first();
+            if ($open) {
+                $open->ended_at = $open->last_seen_at ?? now();
+                $open->save();
+            }
+        });
+    }
+
+    /**
+     * Close any open session whose last tick is older than the gap cap. Run on a
+     * schedule so a crashed/offline bot doesn't leave a session dangling open
+     * (and the public "currently watching" stays honest).
+     */
+    public function closeStaleSessions(): int
+    {
+        return DefragliveWatchSession::open()
+            ->where('last_seen_at', '<', now()->subSeconds(self::GAP_CAP))
+            ->update(['ended_at' => DB::raw('last_seen_at')]);
+    }
+
+    private function openSession(array $identity, string $name, string $clean, ?string $ip, ?string $mapname): void
+    {
+        DefragliveWatchSession::create([
+            'mdd_id' => $identity['mdd_id'],
+            'user_id' => $identity['user_id'],
+            'player_name' => $name,
+            'player_name_clean' => $clean,
+            'ip' => $ip,
+            'mapname' => $mapname,
+            'seconds' => 0,
+            'started_at' => now(),
+            'last_seen_at' => now(),
+            'ended_at' => null,
+        ]);
+    }
+
+    /**
+     * Resolve a watched player to [mdd_id, user_id]. Best effort, never throws.
+     * Order: precise live client_id on this server -> clean-name OnlinePlayer ->
+     * UserAlias -> unresolved (name only).
+     */
+    public function resolve(array $current, ?string $ip): array
+    {
+        $clean = $this->cleanName((string) ($current['n'] ?? ''));
+        $clientId = isset($current['id']) ? (int) $current['id'] : null;
+        $mddId = null;
+
+        // 1) Precise: the same client_id on the server with this ip.
+        if ($ip && $clientId !== null) {
+            $serverId = Server::where('ip', $ip)->value('id');
+            if ($serverId) {
+                $op = OnlinePlayer::where('server_id', $serverId)
+                    ->where('client_id', $clientId)
+                    ->whereNotNull('mdd_id')
+                    ->first();
+                if ($op && $op->mdd_id) {
+                    $mddId = (int) $op->mdd_id;
+                }
+            }
+        }
+
+        // 2) Clean-name match against the live player map.
+        if (!$mddId && $clean !== '') {
+            $op = OnlinePlayer::whereNotNull('mdd_id')
+                ->get(['name', 'mdd_id'])
+                ->first(fn ($p) => $this->cleanName((string) $p->name) === $clean);
+            if ($op && $op->mdd_id) {
+                $mddId = (int) $op->mdd_id;
+            }
+        }
+
+        // 3) Approved alias history.
+        if (!$mddId && $clean !== '') {
+            $alias = UserAlias::query()
+                ->whereNotNull('mdd_id')
+                ->get(['mdd_id', 'alias'])
+                ->first(fn ($a) => $this->cleanName((string) $a->alias) === $clean);
+            if ($alias && $alias->mdd_id) {
+                $mddId = (int) $alias->mdd_id;
+            }
+        }
+
+        $userId = $mddId ? User::where('mdd_id', $mddId)->value('id') : null;
+
+        return ['mdd_id' => $mddId, 'user_id' => $userId ? (int) $userId : null];
+    }
+
+    /**
+     * Aggregate watch time per player over a contest window. Returns rows sorted
+     * by total seconds desc: ['mdd_id','user_id','name','name_clean','seconds',
+     * 'tickets','user']. $limit null = everyone (used by the draw).
+     */
+    public function leaderboard(DefragliveContest $contest, ?int $limit = 10): array
+    {
+        $rows = DefragliveWatchSession::query()
+            ->where('started_at', '>=', $contest->starts_at)
+            ->where('started_at', '<=', $contest->ends_at)
+            ->orderBy('id')
+            ->get(['mdd_id', 'user_id', 'player_name', 'player_name_clean', 'seconds']);
+
+        $groups = [];
+        foreach ($rows as $r) {
+            $key = $this->keyFor($r->mdd_id, $r->player_name_clean);
+            if (!isset($groups[$key])) {
+                $groups[$key] = [
+                    'mdd_id' => $r->mdd_id ? (int) $r->mdd_id : null,
+                    'user_id' => $r->user_id ? (int) $r->user_id : null,
+                    'name' => $r->player_name,
+                    'name_clean' => $r->player_name_clean,
+                    'seconds' => 0,
+                ];
+            }
+            $groups[$key]['seconds'] += (int) $r->seconds;
+            // Keep the latest seen colored name / resolved identity.
+            $groups[$key]['name'] = $r->player_name ?: $groups[$key]['name'];
+            if ($r->mdd_id) {
+                $groups[$key]['mdd_id'] = (int) $r->mdd_id;
+            }
+            if ($r->user_id) {
+                $groups[$key]['user_id'] = (int) $r->user_id;
+            }
+        }
+
+        $entries = array_values($groups);
+        usort($entries, fn ($a, $b) => $b['seconds'] <=> $a['seconds']);
+
+        if ($limit !== null) {
+            $entries = array_slice($entries, 0, $limit);
+        }
+
+        // Attach a lightweight resolved user for display / profile links.
+        $userIds = array_values(array_filter(array_column($entries, 'user_id')));
+        $users = $userIds
+            ? User::whereIn('id', $userIds)
+                ->get(['id', 'name', 'plain_name', 'profile_photo_path', 'country', 'mdd_id'])
+                ->keyBy('id')
+            : collect();
+
+        foreach ($entries as &$e) {
+            $e['tickets'] = intdiv($e['seconds'], self::SECONDS_PER_TICKET);
+            $e['user'] = $e['user_id'] ? $users->get($e['user_id']) : null;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Draw the contest winner via a watch-time-weighted raffle (1 ticket per
+     * full minute watched). Persists winner + ticket transparency fields and
+     * marks the contest closed. Returns the winning entry, or null if nobody
+     * accrued at least one ticket.
+     */
+    public function draw(DefragliveContest $contest): ?array
+    {
+        $entries = array_values(array_filter(
+            $this->leaderboard($contest, null),
+            fn ($e) => $e['tickets'] >= 1
+        ));
+
+        $total = array_sum(array_column($entries, 'tickets'));
+        if ($total < 1) {
+            return null;
+        }
+
+        $winning = random_int(1, $total);
+        $cursor = 0;
+        $winner = null;
+        foreach ($entries as $e) {
+            $cursor += $e['tickets'];
+            if ($winning <= $cursor) {
+                $winner = $e;
+                break;
+            }
+        }
+        $winner = $winner ?? $entries[array_key_last($entries)];
+
+        $contest->update([
+            'winner_mdd_id' => $winner['mdd_id'],
+            'winner_user_id' => $winner['user_id'],
+            'winner_name' => $winner['name'],
+            'winner_seconds' => $winner['seconds'],
+            'winner_tickets' => $winner['tickets'],
+            'total_tickets' => $total,
+            'winning_ticket' => $winning,
+            'drawn_at' => now(),
+            'status' => DefragliveContest::STATUS_CLOSED,
+        ]);
+
+        return $winner;
+    }
+
+    /** Strip Quake 3 colour codes, collapse whitespace, lowercase: a stable key. */
+    public function cleanName(string $name): string
+    {
+        $plain = preg_replace('/\^[0-9A-Za-z]/', '', $name);
+        $plain = trim(preg_replace('/\s+/', ' ', $plain ?? ''));
+
+        return mb_strtolower($plain);
+    }
+
+    private function keyFor($mddId, ?string $clean): string
+    {
+        return $mddId ? 'mdd:' . (int) $mddId : 'name:' . (string) $clean;
+    }
+
+    /** Is the "current player" actually the bot self-spectating (idle)? */
+    private function isBot(array $current, array $serverstate): bool
+    {
+        $botId = $serverstate['bot_id'] ?? null;
+        if ($botId !== null && isset($current['id']) && (int) $current['id'] === (int) $botId) {
+            return true;
+        }
+
+        $name = mb_strtolower((string) ($current['n'] ?? ''));
+
+        return str_contains($name, 'defrag.live') || str_contains($name, 'defraglive');
+    }
+}

--- a/app/Services/DemosTopRankService.php
+++ b/app/Services/DemosTopRankService.php
@@ -172,6 +172,14 @@ class DemosTopRankService
             }
         }
 
+        // Field-relative time gate: the WR (rank-1) time is the map's pace, and
+        // anything more than `max_wr_ratio` times slower is off the field's
+        // level (e.g. a 2-minute run where the map is a 20-second league) and
+        // shouldn't be auto-rendered/published no matter its rank. Tunable via
+        // SiteSetting; 0/blank disables it.
+        $wrTime = optional($ranked->firstWhere('rank', 1))->time_ms;
+        $maxRatio = (float) \App\Models\SiteSetting::get('demome:max_wr_ratio', 2.0);
+
         // --- Persist ---------------------------------------------------------
         $rows = [];
         $now = now();
@@ -185,10 +193,15 @@ class DemosTopRankService
             // rank 1 (the map's best run in the field) is always worth
             // rendering, even on a tiny field where 1*2 > group_total would
             // otherwise exclude it.
+            $withinPace = $maxRatio <= 0
+                || $wrTime === null || $wrTime <= 0
+                || $e->time_ms <= $wrTime * $maxRatio;
+
             $eligible = $e->uploaded_demo_id !== null
                 && $e->rank !== null
                 && ($e->rank === 1 || $e->rank * 2 <= $groupTotal)
-                && $identicalOk;
+                && $identicalOk
+                && $withinPace;
 
             $rows[] = [
                 'map_name' => $mapName,

--- a/app/Services/RenderQueueService.php
+++ b/app/Services/RenderQueueService.php
@@ -332,6 +332,19 @@ class RenderQueueService
         $attempts = 0;
         $maxAttempts = count(self::PUBLISH_ROTATION) * 3;
 
+        // Same field-relative pace gate as the render eligibility: don't publish
+        // an already-rendered run that's more than `max_wr_ratio` times slower
+        // than the map WR (off the field's level). Cast float, safe to inline.
+        $maxRatio = (float) \App\Models\SiteSetting::get('demome:max_wr_ratio', 2.0);
+        $paceGate = $maxRatio > 0
+            ? "(NOT EXISTS (SELECT 1 FROM records r WHERE r.mapname = rendered_videos.map_name AND r.physics = rendered_videos.physics AND r.rank = 1 AND r.deleted_at IS NULL)"
+                . " OR EXISTS (SELECT 1 FROM records r WHERE r.mapname = rendered_videos.map_name AND r.physics = rendered_videos.physics AND r.rank = 1 AND r.deleted_at IS NULL AND rendered_videos.time_ms <= r.time * {$maxRatio}))"
+            : '1=1';
+
+        // Short runs (< 5s) are kept but deprioritized: only picked when nothing
+        // longer is available for the tier.
+        $shortThresholdMs = (int) \App\Models\SiteSetting::get('demome:short_demo_ms', 5000);
+
         // Avoid same map as recently published
         $recentPublishedMaps = RenderedVideo::where('status', 'completed')
             ->whereNotNull('published_at')
@@ -353,6 +366,9 @@ class RenderQueueService
                 ->where(fn($q) => $q->whereNull('publish_approved')->orWhere('publish_approved', false))
                 ->where('source', 'auto')
                 ->when(!empty($excludeMapNames), fn($q) => $q->whereNotIn('map_name', $excludeMapNames))
+                ->whereRaw($paceGate)
+                // Deprioritize short runs, then oldest-first within that.
+                ->orderByRaw("CASE WHEN time_ms < {$shortThresholdMs} THEN 1 ELSE 0 END ASC")
                 ->orderBy('created_at');
 
             $video = $baseQuery->where('quality_tier', $tier)->first();

--- a/database/migrations/2026_06_05_000001_create_defraglive_watch_sessions_table.php
+++ b/database/migrations/2026_06_05_000001_create_defraglive_watch_sessions_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Per-spectate watch history for the DefragLive watch-time contest.
+ *
+ * The server_state table only ever holds "now" (one evolving row), so the
+ * history of who the bot has spectated - the whole basis of the contest - is
+ * otherwise thrown away on every ingest. This table captures it as continuous
+ * spectate stretches instead of per-tick samples: one row per uninterrupted
+ * period the bot stayed on a single player, with the watched seconds accrued
+ * onto it (DefragliveWatchService::accrue, called from the ingest serverstate
+ * branch). A row stays "open" (ended_at null) while the bot is still on that
+ * player; switching player or the bot going idle/offline closes it.
+ *
+ * The player is resolved to a defrag account (mdd_id) / site user where
+ * possible, with player_name_clean as the grouping fallback when it isn't.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('defraglive_watch_sessions', function (Blueprint $table) {
+            $table->id();
+
+            // Resolved identity (best effort). Null when the watched player
+            // could not be matched to a site account - we still track them by
+            // name so the leaderboard is complete; payout is handled manually.
+            $table->unsignedBigInteger('mdd_id')->nullable()->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+
+            // The name as broadcast (Quake colour codes kept for display) plus a
+            // normalized, colour-stripped key used to group sessions of the same
+            // player when there is no mdd_id.
+            $table->string('player_name')->nullable();
+            $table->string('player_name_clean')->nullable()->index();
+
+            // Context, useful for the admin view and disambiguation.
+            $table->string('ip', 64)->nullable();
+            $table->string('mapname')->nullable();
+
+            // Accrued watch time for this continuous stretch.
+            $table->unsignedInteger('seconds')->default(0);
+
+            $table->timestamp('started_at')->index();
+            // Last ingest tick we counted toward this session. Drives both the
+            // capped accrual delta and "is this the open session" lookup.
+            $table->timestamp('last_seen_at');
+            // Null while the bot is still spectating this player.
+            $table->timestamp('ended_at')->nullable()->index();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('defraglive_watch_sessions');
+    }
+};

--- a/database/migrations/2026_06_05_000002_create_defraglive_contests_table.php
+++ b/database/migrations/2026_06_05_000002_create_defraglive_contests_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * DefragLive watch-time contests. A contest is a time window over the watch
+ * sessions; the winner is drawn by a watch-time-weighted raffle (more seconds
+ * spectated = more tickets, but lower-watched players can still win) so the
+ * same top grinder doesn't win every period.
+ *
+ * Default cadence is $5 every two weeks, but dates + prize are per-row so the
+ * admin can run any window. The raffle draw stores the ticket counts and the
+ * winning ticket index for transparency / reproducibility.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('defraglive_contests', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+
+            $table->timestamp('starts_at')->index();
+            $table->timestamp('ends_at')->index();
+
+            $table->decimal('prize_amount', 8, 2)->default(5.00);
+            $table->string('prize_currency', 8)->default('USD');
+
+            // draft -> active -> closed -> paid
+            $table->string('status', 16)->default('draft')->index();
+
+            // Winner (set at draw). Resolved where possible, name always kept.
+            $table->unsignedBigInteger('winner_mdd_id')->nullable();
+            $table->unsignedBigInteger('winner_user_id')->nullable()->index();
+            $table->string('winner_name')->nullable();
+            $table->unsignedInteger('winner_seconds')->nullable();
+
+            // Raffle transparency: winner's tickets out of the total pool, and
+            // the winning ticket index, so a draw can be explained / audited.
+            $table->unsignedInteger('winner_tickets')->nullable();
+            $table->unsignedInteger('total_tickets')->nullable();
+            $table->unsignedInteger('winning_ticket')->nullable();
+            $table->timestamp('drawn_at')->nullable();
+
+            $table->text('notes')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('defraglive_contests');
+    }
+};

--- a/resources/js/Components/DefragliveContestBanner.vue
+++ b/resources/js/Components/DefragliveContestBanner.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { Link, usePage } from '@inertiajs/vue3';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+
+// Sitewide nudge toward the contest while one is live, fed by the
+// `defragliveContest` shared Inertia prop (cached). Two layouts:
+//  - variant="floating" (default): dismissible fixed card, bottom-left.
+//  - variant="bar": a full-width one-line strip to drop into the footer area.
+const props = defineProps({
+    variant: { type: String, default: 'floating' },
+});
+
+const page = usePage();
+const contest = computed(() => page.props.defragliveContest || null);
+
+// Only the floating card is dismissible (per-contest, via localStorage).
+const dismissed = ref(false);
+const storageKey = computed(() => contest.value ? `dl_contest_banner_dismissed_${contest.value.id}` : null);
+
+const now = ref(Date.now());
+let timer = null;
+onMounted(() => {
+    if (props.variant === 'floating' && storageKey.value && localStorage.getItem(storageKey.value) === '1') {
+        dismissed.value = true;
+    }
+    timer = setInterval(() => { now.value = Date.now(); }, 1000);
+});
+onUnmounted(() => { if (timer) clearInterval(timer); });
+
+const dismiss = () => {
+    dismissed.value = true;
+    if (storageKey.value) localStorage.setItem(storageKey.value, '1');
+};
+
+const timeLeft = computed(() => {
+    if (!contest.value?.ends_at) return null;
+    const ms = new Date(contest.value.ends_at).getTime() - now.value;
+    if (ms <= 0) return null;
+    const s = Math.floor(ms / 1000);
+    const d = Math.floor(s / 86400);
+    const h = Math.floor((s % 86400) / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    if (d > 0) return `${d}d ${h}h left`;
+    if (h > 0) return `${h}h ${m}m left`;
+    return `${m}m left`;
+});
+
+const prize = computed(() => {
+    if (!contest.value) return '';
+    const c = contest.value;
+    return (c.prize_currency === 'USD' ? '$' : '') + c.prize_amount + (c.prize_currency !== 'USD' ? ' ' + c.prize_currency : '');
+});
+</script>
+
+<template>
+    <!-- Full-width one-line strip (footer) -->
+    <Link v-if="variant === 'bar' && contest" href="/defraglive/contest"
+        class="group block border-y border-[#9147ff]/30 bg-[#9147ff]/10 hover:bg-[#9147ff]/20 transition-colors">
+        <div class="max-w-8xl mx-auto px-4 py-2.5 flex items-center justify-center gap-x-3 gap-y-1 flex-wrap text-sm text-center">
+            <span class="text-lg leading-none">🏆</span>
+            <span class="font-bold text-white">DefragLive Contest is live</span>
+            <span class="text-gray-300">- win <span class="text-emerald-400 font-bold">{{ prize }}</span> as the most watched player</span>
+            <span v-if="timeLeft" class="text-amber-300 font-semibold">&middot; {{ timeLeft }}</span>
+            <span class="text-[#bf94ff] font-semibold group-hover:underline">Enter now -&gt;</span>
+        </div>
+    </Link>
+
+    <!-- Floating card (bottom-left, dismissible) -->
+    <Transition v-else
+        enter-active-class="transition duration-500 ease-out"
+        enter-from-class="translate-y-24 opacity-0"
+        enter-to-class="translate-y-0 opacity-100">
+        <Link v-if="contest && !dismissed" href="/defraglive/contest"
+            class="group fixed bottom-4 left-4 z-[150] w-[260px] rounded-xl border border-[#9147ff]/40 bg-black/70 backdrop-blur-md shadow-2xl overflow-hidden hover:border-[#9147ff]/80 transition-colors">
+            <div class="h-1 bg-[#9147ff]"></div>
+
+            <button type="button" @click.prevent.stop="dismiss"
+                class="absolute top-2 right-2 z-10 text-gray-500 hover:text-white w-5 h-5 flex items-center justify-center rounded hover:bg-white/10"
+                title="Dismiss">
+                <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
+            </button>
+
+            <div class="p-3.5">
+                <div class="flex items-center gap-2">
+                    <span class="text-xl">🏆</span>
+                    <div class="text-[11px] uppercase tracking-widest font-bold text-purple-300">Contest live</div>
+                </div>
+                <div class="mt-1 font-black text-white leading-tight">
+                    Win <span class="text-emerald-400">{{ prize }}</span> - most watched player
+                </div>
+                <div class="mt-1.5 flex items-center justify-between text-xs">
+                    <span v-if="timeLeft" class="text-amber-300 font-semibold">{{ timeLeft }}</span>
+                    <span class="text-[#bf94ff] font-semibold group-hover:underline ml-auto">Enter now -&gt;</span>
+                </div>
+            </div>
+        </Link>
+    </Transition>
+</template>

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -17,6 +17,7 @@
 
     import Footer from '@/Components/Footer.vue';
     import DonationProgressBar from '@/Components/DonationProgressBar.vue';
+    import DefragliveContestBanner from '@/Components/DefragliveContestBanner.vue';
 
     defineProps({
         title: String,
@@ -997,6 +998,11 @@
                 <slot />
             </main>
 
+            <!-- Contest one-liner (only while a contest is live).
+                 Hidden for now - soft-launching the contest page quietly first.
+                 Re-enable by uncommenting. -->
+            <!-- <DefragliveContestBanner variant="bar" /> -->
+
             <!-- Donation Progress Bar -->
             <div class="mt-4">
                 <DonationProgressBar />
@@ -1004,6 +1010,11 @@
 
             <Footer />
         </div>
+
+        <!-- Sitewide nudge while a contest is live (dismissible).
+             Hidden for now - soft-launching the contest page quietly first.
+             Re-enable by uncommenting. -->
+        <!-- <DefragliveContestBanner /> -->
     </div>
 </template>
 

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -1,0 +1,281 @@
+<script setup>
+import { Head, Link } from '@inertiajs/vue3';
+import { ref, computed, onMounted, onUnmounted, getCurrentInstance } from 'vue';
+
+const props = defineProps({
+    contest: Object,
+    leaderboard: Array,
+    totalTickets: Number,
+    myEntry: Object,
+    nowWatching: Object,
+    pastWinners: Array,
+    hallOfFame: Array,
+});
+
+const { proxy } = getCurrentInstance();
+const q3tohtml = proxy.q3tohtml;
+
+const TWITCH_CHANNEL = 'defraglive';
+
+// Live countdown to the end of the period.
+const now = ref(Date.now());
+let timer = null;
+onMounted(() => { timer = setInterval(() => { now.value = Date.now(); }, 1000); });
+onUnmounted(() => { if (timer) clearInterval(timer); });
+
+const timeLeft = computed(() => {
+    if (!props.contest?.ends_at) return null;
+    let ms = new Date(props.contest.ends_at).getTime() - now.value;
+    if (ms <= 0) return { d: 0, h: 0, m: 0, s: 0, ended: true };
+    const s = Math.floor(ms / 1000);
+    return {
+        d: Math.floor(s / 86400),
+        h: Math.floor((s % 86400) / 3600),
+        m: Math.floor((s % 3600) / 60),
+        s: s % 60,
+        ended: false,
+    };
+});
+
+const fmtWatch = (seconds) => {
+    const s = Math.max(0, Math.floor(seconds || 0));
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m ${s % 60}s`;
+    return `${s}s`;
+};
+
+const maxSeconds = computed(() => Math.max(1, ...(props.leaderboard || []).map(e => e.seconds || 0)));
+const odds = (tickets) => props.totalTickets > 0 ? (tickets / props.totalTickets * 100) : 0;
+const photo = (u) => u?.profile_photo_path ? '/storage/' + u.profile_photo_path : '/images/null.jpg';
+const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300' : i === 2 ? 'text-amber-600' : 'text-gray-500';
+</script>
+
+<template>
+    <Head title="DefragLive Watch Contest" />
+
+    <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-8">
+        <!-- Evergreen intro: what this is + live stream. Independent of any
+             single contest, so the explainer is never duplicated per period. -->
+        <div class="rounded-2xl border border-purple-500/20 bg-black/40 backdrop-blur-sm p-6 md:p-8 mb-6 shadow-2xl">
+            <div class="grid lg:grid-cols-3 gap-6 lg:gap-8 items-start">
+                <div class="lg:col-span-2">
+                    <div class="text-xs uppercase tracking-widest text-purple-300/80 font-semibold mb-1">DefragLive Watch Contest</div>
+                    <a :href="`https://twitch.tv/${TWITCH_CHANNEL}`" target="_blank" rel="noopener"
+                        class="inline-flex items-center gap-1.5 text-sm font-semibold text-[#a970ff] hover:text-[#bf94ff] hover:underline mb-2">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M11.64 5.93h1.43v4.28h-1.43m3.93-4.28H17v4.28h-1.43M7 2L3.43 5.57v12.86h4.28V22l3.58-3.57h2.85L20.57 12V2m-1.43 9.29l-2.85 2.85h-2.86l-2.5 2.5v-2.5H7.71V3.43h11.43z"/></svg>
+                        twitch.tv/{{ TWITCH_CHANNEL }}
+                    </a>
+                    <h1 class="text-3xl md:text-4xl font-black text-white">Get watched, get rewarded</h1>
+                    <div class="text-gray-400 mt-3 text-sm space-y-2 leading-relaxed">
+                        <p>
+                            <span class="text-gray-200 font-semibold">DefragLive</span> streams live defrag runs to Twitch around the clock,
+                            so anyone can experience defrag from anywhere - no install, no setup, just watch the action unfold.
+                        </p>
+                        <p>
+                            This contest is a <span class="text-gray-200 font-semibold">reward for the players who make that possible</span>:
+                            everyone who lets the bot spectate them is the one putting on the show for viewers around the world.
+                            The more the bot watches you, the more raffle tickets you earn - but anyone with a ticket can win.
+                        </p>
+                    </div>
+                    <div class="mt-3 flex items-start gap-2 text-sm text-amber-100 bg-amber-500/20 border border-amber-400/40 rounded-lg px-3.5 py-2.5">
+                        <svg class="w-5 h-5 shrink-0 mt-px text-amber-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span>This prize comes <strong class="text-white">straight out of my own pocket</strong> - it is <strong class="text-white">not</strong> funded by the donations you send to support the site. 100% a personal gift to the community.</span>
+                    </div>
+                </div>
+
+                <!-- Watch-live card - the whole thing links to Twitch. The
+                     interactive DefragLive overlay (player list, controls) only
+                     renders on twitch.tv itself (Twitch never shows extensions
+                     inside an embedded player), so we show the current map +
+                     who's being spectated from our own data and send people to
+                     Twitch for the full experience. -->
+                <a :href="`https://twitch.tv/${TWITCH_CHANNEL}`" target="_blank" rel="noopener"
+                    class="group block rounded-xl border border-[#9147ff]/30 hover:border-[#9147ff]/70 bg-black/40 backdrop-blur-sm shadow-2xl overflow-hidden transition-colors">
+                    <!-- Map thumbnail backdrop with the spectated player on top -->
+                    <div class="relative aspect-video bg-gray-950">
+                        <img :src="nowWatching?.map_thumbnail ? `/storage/${nowWatching.map_thumbnail}` : '/images/unknown.jpg'"
+                            class="absolute inset-0 w-full h-full object-cover opacity-80 group-hover:opacity-100 group-hover:scale-105 transition duration-300"
+                            onerror="this.onerror=null;this.src='/images/unknown.jpg'" alt="">
+                        <div class="absolute inset-0 bg-gradient-to-t from-black via-black/40 to-transparent"></div>
+
+                        <div class="absolute top-3 left-3 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-400 bg-black/60 rounded px-2 py-1">
+                            <span class="relative flex h-2.5 w-2.5">
+                                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75"></span>
+                                <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-red-500"></span>
+                            </span>
+                            Live now
+                        </div>
+
+                        <!-- Play affordance on hover -->
+                        <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition">
+                            <div class="w-16 h-16 rounded-full bg-[#9147ff]/90 flex items-center justify-center shadow-2xl">
+                                <svg class="w-7 h-7 text-white ml-1" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+                            </div>
+                        </div>
+
+                        <div class="absolute bottom-0 inset-x-0 p-4">
+                            <template v-if="nowWatching">
+                                <div class="text-[11px] uppercase tracking-wide text-gray-300">Now spectating</div>
+                                <div class="text-2xl md:text-3xl font-black leading-tight" v-html="q3tohtml(nowWatching.name)"></div>
+                                <div v-if="nowWatching.mapname" class="text-sm text-gray-300 mt-0.5">on <span class="font-semibold text-white">{{ nowWatching.mapname }}</span></div>
+                            </template>
+                            <template v-else>
+                                <div class="text-xl font-black text-white">DefragLive</div>
+                                <div class="text-sm text-gray-300">streaming defrag 24/7</div>
+                            </template>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col items-center text-center gap-2 p-4">
+                        <span class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-[#9147ff] group-hover:bg-[#772ce8] text-white font-bold transition-colors w-full justify-center">
+                            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M11.64 5.93h1.43v4.28h-1.43m3.93-4.28H17v4.28h-1.43M7 2L3.43 5.57v12.86h4.28V22l3.58-3.57h2.85L20.57 12V2m-1.43 9.29l-2.85 2.85h-2.86l-2.5 2.5v-2.5H7.71V3.43h11.43z"/></svg>
+                            Watch on Twitch
+                        </span>
+                        <div class="text-[11px] text-gray-500">The interactive overlay (player list, controls) works on Twitch.</div>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+        <!-- Current contest strip: the only part that rotates each period. -->
+        <div class="rounded-2xl border border-white/10 bg-black/40 backdrop-blur-sm p-5 md:p-6 mb-6 shadow-2xl">
+            <div v-if="contest" class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Current contest</div>
+                    <h2 class="text-xl md:text-2xl font-black text-white">{{ contest.title }}</h2>
+                    <div v-if="nowWatching" class="mt-2 flex items-center gap-2 text-sm">
+                        <span class="relative flex h-2.5 w-2.5">
+                            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75"></span>
+                            <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-red-500"></span>
+                        </span>
+                        <span class="text-gray-400">Now spectating</span>
+                        <span class="font-bold" v-html="q3tohtml(nowWatching.name)"></span>
+                        <span v-if="nowWatching.mapname" class="text-gray-500">on {{ nowWatching.mapname }}</span>
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-6 shrink-0">
+                    <div class="text-right">
+                        <div class="text-3xl md:text-4xl font-black text-emerald-400">
+                            {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ contest.prize_amount }}{{ contest.prize_currency !== 'USD' ? ' ' + contest.prize_currency : '' }}
+                        </div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500">prize</div>
+                    </div>
+                    <div v-if="timeLeft && !timeLeft.ended" class="flex gap-2 font-mono">
+                        <div v-for="part in [['d', timeLeft.d], ['h', timeLeft.h], ['m', timeLeft.m], ['s', timeLeft.s]]" :key="part[0]"
+                            class="bg-black/40 rounded-lg px-2.5 py-1 text-center min-w-[44px]">
+                            <div class="text-xl font-bold text-white">{{ String(part[1]).padStart(2, '0') }}</div>
+                            <div class="text-[10px] uppercase text-gray-500">{{ part[0] }}</div>
+                        </div>
+                    </div>
+                    <div v-else-if="timeLeft" class="text-sm text-amber-400 font-semibold">Period ended<br>awaiting draw</div>
+                </div>
+            </div>
+
+            <div v-else class="text-center py-2 text-gray-400">
+                <span class="font-semibold text-gray-300">No contest running right now.</span>
+                The next one starts soon - keep getting spectated and you'll be in it.
+            </div>
+        </div>
+
+        <!-- My odds -->
+        <div v-if="myEntry" class="rounded-xl border border-emerald-500/25 bg-black/40 backdrop-blur-sm p-4 mb-6 flex flex-wrap items-center gap-x-8 gap-y-2">
+            <div>
+                <div class="text-xs uppercase text-gray-500">Your rank</div>
+                <div class="text-2xl font-black text-white">#{{ myEntry.rank }}</div>
+            </div>
+            <div>
+                <div class="text-xs uppercase text-gray-500">Watched</div>
+                <div class="text-2xl font-black text-white">{{ fmtWatch(myEntry.seconds) }}</div>
+            </div>
+            <div>
+                <div class="text-xs uppercase text-gray-500">Tickets</div>
+                <div class="text-2xl font-black text-white">{{ myEntry.tickets }}</div>
+            </div>
+            <div>
+                <div class="text-xs uppercase text-gray-500">Win chance</div>
+                <div class="text-2xl font-black text-emerald-400">{{ myEntry.odds }}%</div>
+            </div>
+        </div>
+
+        <!-- Leaderboard -->
+        <div class="rounded-2xl border border-white/10 bg-black/40 backdrop-blur-sm overflow-hidden mb-8 shadow-2xl">
+            <div class="px-4 py-3 border-b border-white/10 flex items-center justify-between">
+                <h2 class="font-bold text-gray-200">Most watched this period</h2>
+                <span class="text-xs text-gray-500">{{ totalTickets }} tickets in the pool</span>
+            </div>
+
+            <div v-if="leaderboard.length" class="divide-y divide-white/5">
+                <div v-for="(e, i) in leaderboard" :key="i" class="flex items-center gap-3 px-4 py-3 hover:bg-white/5">
+                    <div class="w-7 text-center font-black text-lg" :class="rankColor(i)">{{ i + 1 }}</div>
+
+                    <img :src="photo(e.user)" class="w-8 h-8 rounded-full object-cover shrink-0" alt="">
+                    <img v-if="e.user?.country" :src="`/images/flags/${e.user.country}.png`" class="w-5 h-3.5 shrink-0" onerror="this.style.display='none'">
+
+                    <div class="min-w-0 flex-1">
+                        <component :is="e.user ? Link : 'span'" :href="e.user ? `/profile/${e.user.id}` : undefined"
+                            class="font-semibold truncate block" :class="e.user ? 'hover:underline' : ''"
+                            v-html="q3tohtml(e.name)"></component>
+                        <div class="mt-1 h-1.5 rounded-full bg-gray-800 overflow-hidden">
+                            <div class="h-full rounded-full bg-gradient-to-r from-purple-500 to-emerald-400"
+                                :style="{ width: Math.max(3, (e.seconds / maxSeconds) * 100) + '%' }"></div>
+                        </div>
+                    </div>
+
+                    <div class="text-right shrink-0">
+                        <div class="font-bold text-white tabular-nums">{{ fmtWatch(e.seconds) }}</div>
+                        <div class="text-xs text-gray-500">{{ e.tickets }} tickets &middot; {{ odds(e.tickets).toFixed(1) }}%</div>
+                    </div>
+                </div>
+            </div>
+
+            <div v-else class="px-4 py-12 text-center text-gray-500">
+                No watch time recorded yet this period. Hop on a server the bot is spectating!
+            </div>
+        </div>
+
+        <!-- Past winners -->
+        <div v-if="pastWinners.length">
+            <h2 class="font-bold text-gray-300 mb-3">Past winners</h2>
+            <div class="grid gap-2 sm:grid-cols-2">
+                <div v-for="(w, i) in pastWinners" :key="i"
+                    class="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/40 backdrop-blur-sm px-4 py-3">
+                    <div class="min-w-0">
+                        <component :is="w.winner_user_id ? Link : 'span'" :href="w.winner_user_id ? `/profile/${w.winner_user_id}` : undefined"
+                            class="font-semibold truncate block" v-html="q3tohtml(w.winner_name)"></component>
+                        <div class="text-xs text-gray-500 truncate">{{ w.title }}</div>
+                    </div>
+                    <div class="text-right shrink-0">
+                        <div class="font-bold text-emerald-400">{{ w.prize_currency === 'USD' ? '$' : '' }}{{ w.prize_amount }}</div>
+                        <div class="text-[11px] uppercase" :class="w.status === 'paid' ? 'text-emerald-500' : 'text-amber-500'">{{ w.status }}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Hall of Fame - all-time winners -->
+        <div v-if="hallOfFame.length" class="mt-8">
+            <h2 class="font-bold text-gray-300 mb-3 flex items-center gap-2">
+                <span>🏆</span> Hall of Fame <span class="text-xs font-normal text-gray-500">all-time winners</span>
+            </h2>
+            <div class="rounded-2xl border border-white/10 bg-black/40 backdrop-blur-sm overflow-hidden shadow-2xl divide-y divide-white/5">
+                <div v-for="(h, i) in hallOfFame" :key="i" class="flex items-center gap-3 px-4 py-3 hover:bg-white/5">
+                    <div class="w-7 text-center font-black text-lg" :class="rankColor(i)">{{ i + 1 }}</div>
+                    <img :src="photo(h.user)" class="w-8 h-8 rounded-full object-cover shrink-0" alt="">
+                    <img v-if="h.user?.country" :src="`/images/flags/${h.user.country}.png`" class="w-5 h-3.5 shrink-0" onerror="this.style.display='none'">
+                    <component :is="h.user ? Link : 'span'" :href="h.user ? `/profile/${h.user.id}` : undefined"
+                        class="min-w-0 flex-1 font-semibold truncate" :class="h.user ? 'hover:underline' : ''"
+                        v-html="q3tohtml(h.name)"></component>
+                    <div class="text-right shrink-0">
+                        <div class="font-bold text-white">{{ h.wins }} {{ h.wins === 1 ? 'win' : 'wins' }}</div>
+                        <div class="text-xs text-emerald-400">{{ h.currency === 'USD' ? '$' : '' }}{{ h.total.toFixed(2) }}{{ h.currency !== 'USD' ? ' ' + h.currency : '' }} won</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -669,7 +669,7 @@ const getFunctionName = (abbr) => {
                              black ^0 as a dark silhouette, white ^7
                              bright, brights (yellow/cyan/magenta)
                              punchy. -->
-                        <div v-if="server.online_players.length > 0" :class="['mb-4 mt-2 map-hover-fade', hoveredMapServer === server.id ? 'opacity-0 pointer-events-none' : 'opacity-100']">
+                        <div v-if="server.online_players.length > 0" :class="['mb-4 mt-2 map-hover-fade relative z-20', hoveredMapServer === server.id ? 'opacity-0 pointer-events-none' : 'opacity-100']">
                             <div class="rounded-lg p-2 border border-white/10 backdrop-blur-[4px]" style="background: rgba(71,85,105,0.55);">
                                 <div class="space-y-1.5">
                                     <OnlinePlayer v-for="player in server.online_players" :key="player.name" :player="player" />

--- a/resources/views/filament/pages/defraglive-spectate-log.blade.php
+++ b/resources/views/filament/pages/defraglive-spectate-log.blade.php
@@ -1,0 +1,67 @@
+<x-filament-panels::page>
+    <div class="flex items-center justify-between gap-3 mb-2">
+        <div class="text-sm text-gray-500 dark:text-gray-400">
+            Newest first &middot; {{ $total }} sessions logged
+        </div>
+        <div class="text-xs text-gray-500">auto-refreshes every 10s</div>
+    </div>
+
+    {{-- Scrollable spectate feed (newest first), polled live. --}}
+    <div
+        wire:poll.10s
+        class="overflow-y-auto rounded-xl border border-gray-700 bg-gray-950 divide-y divide-white/5"
+        style="height: 72vh;"
+    >
+        @forelse($rows as $r)
+            <div class="flex items-center gap-3 px-3 py-2.5 hover:bg-white/5">
+                {{-- Map thumbnail --}}
+                <img
+                    src="{{ $r['map_thumb'] ? '/storage/' . $r['map_thumb'] : '/images/unknown.jpg' }}"
+                    onerror="this.onerror=null;this.src='/images/unknown.jpg'"
+                    class="w-20 h-11 rounded object-cover shrink-0 bg-gray-900"
+                    alt=""
+                >
+
+                {{-- Player + map --}}
+                <div class="min-w-0 flex-1">
+                    <div class="font-mono font-semibold truncate text-sm">{!! $r['player_html'] !!}</div>
+                    <div class="flex items-center gap-2 mt-0.5 text-xs text-gray-500">
+                        <span class="truncate">{{ $r['mapname'] ?: 'unknown map' }}</span>
+                        @if($r['user'])
+                            <a href="/profile/{{ $r['user']['id'] }}" target="_blank"
+                               class="text-emerald-400 hover:underline shrink-0">[{{ $r['user']['name'] }}]</a>
+                        @else
+                            <span class="text-gray-600 shrink-0">unmatched</span>
+                        @endif
+                    </div>
+                </div>
+
+                {{-- Time + duration --}}
+                <div class="text-right shrink-0">
+                    <div class="font-mono text-sm text-gray-300 whitespace-nowrap">
+                        {{ $r['from'] }}
+                        <span class="text-gray-600">&rarr;</span>
+                        @if($r['live'])
+                            <span class="inline-flex items-center gap-1 text-red-400 font-bold">
+                                <span class="relative flex h-2 w-2">
+                                    <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75"></span>
+                                    <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500"></span>
+                                </span>
+                                LIVE
+                            </span>
+                        @else
+                            {{ $r['to'] }}
+                        @endif
+                    </div>
+                    <div class="text-xs text-gray-500 mt-0.5">
+                        {{ $r['date'] }} &middot; <span class="text-gray-400 font-semibold">{{ $r['duration'] }}</span>
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="p-12 text-center text-gray-500">
+                Nothing logged yet. The bot's spectate history appears here once it starts watching players.
+            </div>
+        @endforelse
+    </div>
+</x-filament-panels::page>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\DemoReportController;
 use App\Http\Controllers\YoutubeController;
 use App\Http\Controllers\RenderRequestController;
 use App\Http\Controllers\CommunityLeaderboardController;
+use App\Http\Controllers\DefragliveContestController;
 use App\Http\Controllers\CommunityTasksController;
 
 /*
@@ -77,6 +78,9 @@ Route::get('/ranking', [RankingController::class, 'index'])->name('ranking');
 Route::get('/ranking/how-it-works', [RankingController::class, 'howItWorks'])->name('ranking.how-it-works');
 
 Route::get('/community', [CommunityLeaderboardController::class, 'index'])->name('community');
+
+// DefragLive most-watched-player contest (public leaderboard + raffle odds).
+Route::get('/defraglive/contest', [DefragliveContestController::class, 'index'])->name('defraglive.contest');
 Route::get('/community-tasks', [CommunityTasksController::class, 'index'])->middleware(['auth', 'verified'])->name('community.tasks');
 Route::post('/community-tasks/refresh', [CommunityTasksController::class, 'refresh'])->middleware(['auth', 'verified'])->name('community.tasks.refresh');
 Route::post('/community-tasks/vote', [CommunityTasksController::class, 'vote'])->middleware(['auth', 'verified'])->name('community.tasks.vote');


### PR DESCRIPTION
## Summary
Four related changes (see commits):

### DefragLive watch-time contest
Rewards the players the bot spectates most. Watch time accrued from the ingest
serverstate branch into watch sessions; winner drawn by a watch-time-weighted
raffle (1 ticket/min). Public page /defraglive/contest (evergreen intro, live
Twitch card, top-10 leaderboard + your odds, Hall of Fame, "personally funded"
note), Filament "Watch Contests" admin (Draw winner / Mark paid), commands
close-stale-sessions, rollover-contests, draw-contest.

### Spectate log + sitewide banner
Read-only scrollable admin feed of what the bot spectated (player, map, from/to,
duration) over the same watch sessions. Sitewide contest banner (floating + footer
one-liner) via a cached shared Inertia prop — commented out for a quiet soft-launch.

### Demome auto-render/publish tightening
- Field-relative pace gate: a demo is auto-render-eligible only if its time is
  within demome:max_wr_ratio (2.0x) of the map WR, so off-pace runs (a 2-min run
  on a 20-second map) are dropped regardless of rank. Same gate on auto-publish.
- Short runs (< demome:short_demo_ms, 5s) deprioritized in publish, not excluded.
- Daily auto-publish capped server-side at demome:daily_publish_target (8).

### Servers fix
Server-card hover popup ("Logged in as") was painted behind the Connect button
(backdrop-blur stacking-context trap). Lifted the player-list block above it.

## Deploy notes
- New migrations run on deploy (watch sessions + contests).
- Restart Octane after deploy.
- Run `php artisan demos:rebuild-top-ranks` so the pace gate applies to the render
  queue (else it waits for the nightly 04:30 rebuild).
- Create the first contest in admin with status = Active (form defaults to UTC
  now / +14 days). Server runs UTC.
- Contest promo banner stays hidden until the two usages in MainLayout are uncommented.

## Tunable (SiteSetting, live)
- demome:max_wr_ratio (2.0) · demome:daily_publish_target (8) · demome:short_demo_ms (5000)
