### PR TITLE
Add DefragLive map log page

### DIFF
--- a/app/Http/Controllers/DefragliveMapLogController.php
+++ b/app/Http/Controllers/DefragliveMapLogController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DefragliveWatchSession;
+use App\Models\Map;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Inertia\Inertia;
+
+/**
+ * Public map log: what the DefragLive bot has been on, map by map - which map
+ * from when to when, and which players it spectated there (with how long each).
+ *
+ * Built from the same watch sessions as the contest: a "map block" is a maximal
+ * run of consecutive sessions sharing one mapname (the bot stays on a server/map
+ * and spectates various players, then moves on). The still-open session keeps
+ * its block live. It only ever reflects players the bot actually watched, not
+ * the full server roster - that's all the history we keep.
+ */
+class DefragliveMapLogController extends Controller
+{
+    public function index()
+    {
+        // Most recent sessions, oldest-first so we can group in order, then we
+        // present the blocks newest-first.
+        $sessions = DefragliveWatchSession::query()
+            ->orderByDesc('id')
+            ->limit(800)
+            ->get(['id', 'mdd_id', 'user_id', 'player_name', 'player_name_clean', 'mapname', 'seconds', 'started_at', 'ended_at'])
+            ->reverse()
+            ->values();
+
+        $blocks = [];
+        $cur = null;
+        foreach ($sessions as $s) {
+            $map = $s->mapname ?: 'unknown';
+
+            if (!$cur || $cur['map'] !== $map) {
+                if ($cur) {
+                    $blocks[] = $cur;
+                }
+                $cur = [
+                    'map' => $map,
+                    'started_at' => $s->started_at,
+                    'ended_at' => $s->ended_at,
+                    'open' => $s->ended_at === null,
+                    'players' => [],
+                ];
+            }
+
+            // Extend the block to this session's end (live if it's still open).
+            $cur['ended_at'] = $s->ended_at;
+            $cur['open'] = $s->ended_at === null;
+
+            $secs = $s->ended_at
+                ? (int) $s->seconds
+                : max(0, (int) $s->started_at->diffInSeconds(now()));
+
+            $key = $s->mdd_id ? 'mdd:' . (int) $s->mdd_id : 'name:' . $s->player_name_clean;
+            if (!isset($cur['players'][$key])) {
+                $cur['players'][$key] = [
+                    'name' => $s->player_name,
+                    'mdd_id' => $s->mdd_id ? (int) $s->mdd_id : null,
+                    'user_id' => $s->user_id ? (int) $s->user_id : null,
+                    'seconds' => 0,
+                ];
+            }
+            $cur['players'][$key]['seconds'] += $secs;
+            $cur['players'][$key]['name'] = $s->player_name ?: $cur['players'][$key]['name'];
+            if ($s->user_id) {
+                $cur['players'][$key]['user_id'] = (int) $s->user_id;
+            }
+        }
+        if ($cur) {
+            $blocks[] = $cur;
+        }
+
+        // Newest first.
+        $blocks = array_reverse($blocks);
+
+        // Batch-resolve map thumbnails and player users (no N+1).
+        $thumbs = Map::whereIn('name', collect($blocks)->pluck('map')->unique()->values())
+            ->pluck('thumbnail', 'name');
+
+        $userIds = collect($blocks)
+            ->flatMap(fn ($b) => array_column($b['players'], 'user_id'))
+            ->filter()->unique()->values();
+        $users = $userIds->isNotEmpty()
+            ? User::whereIn('id', $userIds)
+                ->get(['id', 'name', 'plain_name', 'profile_photo_path', 'country'])
+                ->keyBy('id')
+            : collect();
+
+        $payload = array_map(function (array $b) use ($thumbs, $users) {
+            $players = array_values($b['players']);
+            usort($players, fn ($a, $c) => $c['seconds'] <=> $a['seconds']);
+
+            return [
+                'map' => $b['map'],
+                'map_thumbnail' => $thumbs[$b['map']] ?? null,
+                'started_at' => optional($b['started_at'])->toIso8601String(),
+                'ended_at' => $b['open'] ? null : optional($b['ended_at'])->toIso8601String(),
+                'live' => $b['open'],
+                'duration' => $b['open']
+                    ? null
+                    : max(0, (int) optional($b['started_at'])->diffInSeconds($b['ended_at'] ?? $b['started_at'])),
+                'players' => array_map(fn ($p) => [
+                    'name' => $p['name'],
+                    'seconds' => $p['seconds'],
+                    'user' => $p['user_id'] && $users->has($p['user_id']) ? [
+                        'id' => $users[$p['user_id']]->id,
+                        'name' => $users[$p['user_id']]->plain_name ?: $users[$p['user_id']]->name,
+                        'profile_photo_path' => $users[$p['user_id']]->profile_photo_path,
+                        'country' => $users[$p['user_id']]->country,
+                    ] : null,
+                ], $players),
+            ];
+        }, $blocks);
+
+        return Inertia::render('DefragliveMapLog', [
+            'blocks' => $payload,
+        ]);
+    }
+}

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -78,6 +78,11 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                             everyone who lets the bot spectate them is the one putting on the show for viewers around the world.
                             The more the bot watches you, the more raffle tickets you earn - but anyone with a ticket can win.
                         </p>
+                        <p>
+                            Curious what's been on? Browse the
+                            <Link href="/defraglive/maps" class="text-[#a970ff] hover:text-[#bf94ff] font-semibold hover:underline">full map log</Link>
+                            - every map the bot streamed, from when to when, and who it spectated.
+                        </p>
                     </div>
                     <div class="mt-3 flex items-start gap-2 text-sm text-amber-100 bg-amber-500/20 border border-amber-400/40 rounded-lg px-3.5 py-2.5">
                         <svg class="w-5 h-5 shrink-0 mt-px text-amber-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -168,16 +168,16 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                         <div class="text-3xl md:text-4xl font-black text-emerald-400">
                             {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ contest.prize_amount }}{{ contest.prize_currency !== 'USD' ? ' ' + contest.prize_currency : '' }}
                         </div>
-                        <div class="text-xs uppercase tracking-wide text-gray-500">prize</div>
+                        <div class="text-sm font-bold uppercase tracking-widest text-gray-300">prize</div>
                     </div>
-                    <div v-if="timeLeft && !timeLeft.ended" class="flex gap-2 font-mono">
+                    <div v-if="timeLeft && !timeLeft.ended" class="flex gap-2.5 font-mono">
                         <div v-for="part in [['d', timeLeft.d], ['h', timeLeft.h], ['m', timeLeft.m], ['s', timeLeft.s]]" :key="part[0]"
-                            class="bg-black/40 rounded-lg px-2.5 py-1 text-center min-w-[44px]">
-                            <div class="text-xl font-bold text-white">{{ String(part[1]).padStart(2, '0') }}</div>
-                            <div class="text-[10px] uppercase text-gray-500">{{ part[0] }}</div>
+                            class="bg-black/40 rounded-xl px-3.5 py-2 text-center min-w-[60px]">
+                            <div class="text-3xl md:text-4xl font-black text-white tabular-nums leading-none">{{ String(part[1]).padStart(2, '0') }}</div>
+                            <div class="text-sm font-bold uppercase tracking-widest text-gray-300 mt-1">{{ part[0] }}</div>
                         </div>
                     </div>
-                    <div v-else-if="timeLeft" class="text-sm text-amber-400 font-semibold">Period ended<br>awaiting draw</div>
+                    <div v-else-if="timeLeft" class="text-base text-amber-400 font-semibold">Period ended<br>awaiting draw</div>
                 </div>
             </div>
 

--- a/resources/js/Pages/DefragliveMapLog.vue
+++ b/resources/js/Pages/DefragliveMapLog.vue
@@ -1,0 +1,141 @@
+<script setup>
+import { Head, Link } from '@inertiajs/vue3';
+import { ref, computed, onMounted, onUnmounted, getCurrentInstance } from 'vue';
+
+const props = defineProps({
+    blocks: Array,
+});
+
+const { proxy } = getCurrentInstance();
+const q3tohtml = proxy.q3tohtml;
+
+// Tick so the open (live) block's duration keeps counting up.
+const now = ref(Date.now());
+let timer = null;
+onMounted(() => { timer = setInterval(() => { now.value = Date.now(); }, 1000); });
+onUnmounted(() => { if (timer) clearInterval(timer); });
+
+const photo = (u) => u?.profile_photo_path ? '/storage/' + u.profile_photo_path : '/images/null.jpg';
+
+const fmtDur = (seconds) => {
+    const s = Math.max(0, Math.floor(seconds || 0));
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m ${s % 60}s`;
+    return `${s}s`;
+};
+
+const time = (iso) => iso ? new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+const day = (iso) => iso ? new Date(iso).toLocaleDateString([], { month: 'short', day: 'numeric' }) : '';
+
+const liveDur = (b) => b.live
+    ? Math.max(0, Math.floor((now.value - new Date(b.started_at).getTime()) / 1000))
+    : b.duration;
+
+// Group blocks under day headers for a cleaner timeline.
+const byDay = computed(() => {
+    const out = [];
+    let cur = null;
+    for (const b of props.blocks || []) {
+        const d = day(b.started_at);
+        if (!cur || cur.day !== d) {
+            cur = { day: d, blocks: [] };
+            out.push(cur);
+        }
+        cur.blocks.push(b);
+    }
+    return out;
+});
+</script>
+
+<template>
+    <Head title="DefragLive Map Log" />
+
+    <div class="max-w-5xl mx-auto px-4 md:px-6 py-8">
+        <!-- Header -->
+        <div class="mb-6">
+            <div class="text-xs uppercase tracking-widest text-purple-300/80 font-semibold mb-1">DefragLive</div>
+            <h1 class="text-3xl md:text-4xl font-black text-white">Map log</h1>
+            <p class="text-gray-400 mt-2 text-sm leading-relaxed max-w-2xl">
+                What the bot has been streaming, map by map - which map ran from when to when,
+                and the players it spectated along the way. Each block is one continuous stretch on a map.
+            </p>
+            <Link href="/defraglive/contest"
+                class="inline-flex items-center gap-1.5 mt-3 text-sm font-semibold text-[#a970ff] hover:text-[#bf94ff] hover:underline">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
+                Back to the Watch Contest
+            </Link>
+        </div>
+
+        <div v-if="!blocks || blocks.length === 0"
+            class="rounded-2xl border border-white/10 bg-black/40 backdrop-blur-sm p-10 text-center text-gray-500">
+            Nothing logged yet.
+        </div>
+
+        <div v-else class="space-y-8">
+            <div v-for="grp in byDay" :key="grp.day">
+                <div class="text-xs font-bold uppercase tracking-widest text-gray-500 mb-3 pl-1">{{ grp.day }}</div>
+
+                <div class="space-y-3">
+                    <div v-for="(b, i) in grp.blocks" :key="grp.day + '-' + i"
+                        class="rounded-xl border border-white/10 bg-black/40 backdrop-blur-sm overflow-hidden shadow-lg hover:border-white/20 transition-colors">
+                        <div class="flex flex-col sm:flex-row">
+                            <!-- Map thumbnail -->
+                            <div class="relative sm:w-56 shrink-0 aspect-video sm:aspect-auto bg-gray-950">
+                                <img :src="b.map_thumbnail ? `/storage/${b.map_thumbnail}` : '/images/unknown.jpg'"
+                                    class="absolute inset-0 w-full h-full object-cover opacity-80"
+                                    onerror="this.onerror=null;this.src='/images/unknown.jpg'" alt="">
+                                <div class="absolute inset-0 bg-gradient-to-t sm:bg-gradient-to-r from-black/80 via-black/20 to-transparent"></div>
+                                <div v-if="b.live"
+                                    class="absolute top-2 left-2 inline-flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-red-400 bg-black/60 rounded px-1.5 py-0.5">
+                                    <span class="relative flex h-2 w-2">
+                                        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75"></span>
+                                        <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500"></span>
+                                    </span>
+                                    Live
+                                </div>
+                                <div class="absolute bottom-2 left-3 right-3 sm:hidden">
+                                    <div class="font-bold text-white truncate drop-shadow">{{ b.map }}</div>
+                                </div>
+                            </div>
+
+                            <!-- Detail -->
+                            <div class="flex-1 p-4 min-w-0">
+                                <div class="flex items-start justify-between gap-3 mb-3">
+                                    <div class="min-w-0">
+                                        <a :href="`/maps/${b.map}`"
+                                            class="hidden sm:block font-bold text-white hover:text-[#a970ff] truncate transition-colors">{{ b.map }}</a>
+                                        <div class="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
+                                            <span>{{ time(b.started_at) }}</span>
+                                            <span class="text-gray-600">&rarr;</span>
+                                            <span v-if="b.live" class="text-red-400 font-semibold">now</span>
+                                            <span v-else>{{ time(b.ended_at) }}</span>
+                                        </div>
+                                    </div>
+                                    <div class="shrink-0 text-right">
+                                        <div class="text-sm font-bold text-white tabular-nums">{{ fmtDur(liveDur(b)) }}</div>
+                                        <div class="text-[10px] uppercase tracking-wider text-gray-500">{{ b.players.length }} player{{ b.players.length === 1 ? '' : 's' }}</div>
+                                    </div>
+                                </div>
+
+                                <!-- Players the bot spectated on this map -->
+                                <div class="flex flex-wrap gap-1.5">
+                                    <component :is="p.user ? Link : 'span'" v-for="(p, pi) in b.players" :key="pi"
+                                        :href="p.user ? `/profile/${p.user.id}` : undefined"
+                                        class="inline-flex items-center gap-1.5 rounded-full bg-white/5 border border-white/10 pl-1.5 pr-2.5 py-1 text-sm"
+                                        :class="p.user ? 'hover:bg-white/10 hover:border-white/20 transition-colors' : ''">
+                                        <img v-if="p.user" :src="photo(p.user)" class="w-5 h-5 rounded-full object-cover" alt="">
+                                        <img v-if="p.user?.country" :src="`/images/flags/${p.user.country}.png`" class="w-4 h-3 shrink-0" onerror="this.style.display='none'">
+                                        <span v-html="q3tohtml(p.name)"></span>
+                                        <span class="text-xs text-gray-500 tabular-nums">{{ fmtDur(p.seconds) }}</span>
+                                    </component>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/DefragliveMapLog.vue
+++ b/resources/js/Pages/DefragliveMapLog.vue
@@ -52,9 +52,9 @@ const byDay = computed(() => {
 <template>
     <Head title="DefragLive Map Log" />
 
-    <div class="max-w-5xl mx-auto px-4 md:px-6 py-8">
+    <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-8">
         <!-- Header -->
-        <div class="mb-6">
+        <div class="rounded-2xl border border-purple-500/20 bg-black/40 backdrop-blur-sm p-6 md:p-8 mb-6 shadow-2xl">
             <div class="text-xs uppercase tracking-widest text-purple-300/80 font-semibold mb-1">DefragLive</div>
             <h1 class="text-3xl md:text-4xl font-black text-white">Map log</h1>
             <p class="text-gray-400 mt-2 text-sm leading-relaxed max-w-2xl">
@@ -75,7 +75,10 @@ const byDay = computed(() => {
 
         <div v-else class="space-y-8">
             <div v-for="grp in byDay" :key="grp.day">
-                <div class="text-xs font-bold uppercase tracking-widest text-gray-500 mb-3 pl-1">{{ grp.day }}</div>
+                <div class="flex items-center gap-3 mb-4">
+                    <h2 class="text-xl md:text-2xl font-black text-white tracking-tight">{{ grp.day }}</h2>
+                    <div class="flex-1 h-px bg-white/10"></div>
+                </div>
 
                 <div class="space-y-3">
                     <div v-for="(b, i) in grp.blocks" :key="grp.day + '-' + i"

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\YoutubeController;
 use App\Http\Controllers\RenderRequestController;
 use App\Http\Controllers\CommunityLeaderboardController;
 use App\Http\Controllers\DefragliveContestController;
+use App\Http\Controllers\DefragliveMapLogController;
 use App\Http\Controllers\CommunityTasksController;
 
 /*
@@ -81,6 +82,7 @@ Route::get('/community', [CommunityLeaderboardController::class, 'index'])->name
 
 // DefragLive most-watched-player contest (public leaderboard + raffle odds).
 Route::get('/defraglive/contest', [DefragliveContestController::class, 'index'])->name('defraglive.contest');
+Route::get('/defraglive/maps', [DefragliveMapLogController::class, 'index'])->name('defraglive.maps');
 Route::get('/community-tasks', [CommunityTasksController::class, 'index'])->middleware(['auth', 'verified'])->name('community.tasks');
 Route::post('/community-tasks/refresh', [CommunityTasksController::class, 'refresh'])->middleware(['auth', 'verified'])->name('community.tasks.refresh');
 Route::post('/community-tasks/vote', [CommunityTasksController::class, 'vote'])->middleware(['auth', 'verified'])->name('community.tasks.vote');


### PR DESCRIPTION
## What
A new public page at `/defraglive/maps`: a map-by-map timeline of what the DefragLive bot has been streaming, plus some visual polish on the contest page.

## Map log
- Each block is one continuous stretch on a single map: thumbnail, name, from -> to, duration
- Lists the players the bot spectated on that map with how long each, avatar + flag + colored name, linking to the player's profile when resolved
- Blocks grouped under prominent day headers, newest first; the still-running map stays live and ticks
- Built from the existing `defraglive_watch_sessions` (grouped by consecutive mapname) - no new data source, no bot change
- Full page width, intro in a glass panel matching the contest
- Linked from the Watch Contest intro as a text link; final placement to be decided later

## Contest tweaks
- Bigger, clearer countdown tiles with larger, brighter PRIZE and D/H/M/S labels

## Notes
Reflects only players the bot actually spectated (that's all the history we keep), not the full server roster.
