### PR TITLE
Visitor server ping estimate + ownership-neutral render dialog

### DIFF
--- a/app/Console/Commands/GeolocateServers.php
+++ b/app/Console/Commands/GeolocateServers.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Server;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Fill in latitude/longitude for servers that don't have them yet, by looking
+ * up their IP via the free ip-api.com batch endpoint (no key needed).
+ *
+ * Only touches servers where a coordinate is still missing, so a value set by
+ * hand (or filled on a previous run) is never overwritten. Scheduled, so new
+ * servers get geolocated automatically without anyone editing them.
+ */
+class GeolocateServers extends Command
+{
+    protected $signature = 'servers:geolocate {--all : Re-geolocate every server, overwriting existing coordinates}';
+
+    protected $description = 'Auto-fill server latitude/longitude from their IP (only missing ones by default)';
+
+    /** Don't re-hit the geo API for an unresolvable server more often than this. */
+    private const RETRY_AFTER_HOURS = 24;
+
+    public function handle(): int
+    {
+        $query = Server::query();
+        if (! $this->option('all')) {
+            // Still missing coordinates AND either never tried or last tried long
+            // enough ago. New servers (geo_checked_at null) get picked up at once;
+            // ones the API couldn't resolve are retried at most once a day, not
+            // every hour forever.
+            $cutoff = now()->subHours(self::RETRY_AFTER_HOURS);
+            $query->where(fn ($q) => $q->whereNull('latitude')->orWhereNull('longitude'))
+                ->where(fn ($q) => $q->whereNull('geo_checked_at')->orWhere('geo_checked_at', '<=', $cutoff));
+        }
+        $servers = $query->get();
+
+        if ($servers->isEmpty()) {
+            $this->info('No servers need geolocation.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Geolocating {$servers->count()} server(s)...");
+        $updated = 0;
+
+        // ip-api batch: up to 100 queries per POST. Key results by the bare IP.
+        foreach ($servers->chunk(100) as $chunk) {
+            $ips = $chunk->map(fn ($s) => $this->bareIp($s->ip))->values()->all();
+
+            try {
+                $resp = Http::timeout(20)->post('http://ip-api.com/batch?fields=status,lat,lon,query', $ips);
+            } catch (\Throwable $e) {
+                $this->error('ip-api request failed: '.$e->getMessage());
+
+                continue;
+            }
+
+            if (! $resp->ok()) {
+                $this->error('ip-api returned HTTP '.$resp->status());
+
+                continue;
+            }
+
+            // Map IP -> [lat, lon] for successful lookups.
+            $byIp = [];
+            foreach ($resp->json() ?? [] as $row) {
+                if (($row['status'] ?? '') === 'success' && isset($row['lat'], $row['lon'], $row['query'])) {
+                    $byIp[$row['query']] = [$row['lat'], $row['lon']];
+                }
+            }
+
+            foreach ($chunk as $server) {
+                // Stamp the attempt regardless of outcome so an unresolvable IP
+                // backs off to the daily cadence instead of retrying hourly.
+                $server->geo_checked_at = now();
+
+                $coords = $byIp[$this->bareIp($server->ip)] ?? null;
+                if (! $coords) {
+                    $server->save();
+                    $this->warn("  - {$server->plain_name} ({$server->ip}): not resolved");
+
+                    continue;
+                }
+
+                $server->latitude = $coords[0];
+                $server->longitude = $coords[1];
+                $server->save();
+                $updated++;
+                $this->line("  + {$server->plain_name} ({$server->ip}): {$coords[0]}, {$coords[1]}");
+            }
+        }
+
+        $this->info("Done. Updated {$updated} server(s).");
+
+        return self::SUCCESS;
+    }
+
+    /** Strip any accidental :port so ip-api gets a clean host. */
+    private function bareIp(string $ip): string
+    {
+        return explode(':', trim($ip))[0];
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -83,6 +83,11 @@ class Kernel extends ConsoleKernel
         // windows, open the next). No-ops until the admin seeds the first one.
         $schedule->command('defraglive:rollover-contests')->withoutOverlapping()->hourly();
 
+        // Auto-fill lat/lon from IP for any server missing it (drives the
+        // visitor ping estimate). No-op once all servers are geolocated; never
+        // overwrites existing coordinates.
+        $schedule->command('servers:geolocate')->withoutOverlapping()->hourly();
+
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();
 

--- a/app/Filament/Resources/ServerResource.php
+++ b/app/Filament/Resources/ServerResource.php
@@ -57,6 +57,18 @@ class ServerResource extends Resource
                     ->searchable()
                     ->native(false)
                     ->helperText('Drives the flag icon shown next to the server.'),
+                TextInput::make('latitude')
+                    ->label('Latitude')
+                    ->numeric()
+                    ->minValue(-90)
+                    ->maxValue(90)
+                    ->helperText('Auto-filled hourly from the server IP (servers:geolocate). Set it by hand only to override - a filled value is never overwritten.'),
+                TextInput::make('longitude')
+                    ->label('Longitude')
+                    ->numeric()
+                    ->minValue(-180)
+                    ->maxValue(180)
+                    ->helperText('Auto-filled from IP. Used to estimate each visitor\'s ping; if it can\'t be resolved the ping badge just stays hidden.'),
                 Select::make('type')
                     ->label('Server Type')
                     ->required()
@@ -121,6 +133,23 @@ class ServerResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('location')
                     ->searchable(),
+                Tables\Columns\IconColumn::make('has_coords')
+                    ->label('Geo')
+                    ->boolean()
+                    ->getStateUsing(fn ($record) => $record->latitude !== null && $record->longitude !== null)
+                    ->trueIcon('heroicon-o-map-pin')
+                    ->falseIcon('heroicon-o-no-symbol')
+                    ->trueColor('success')
+                    ->falseColor('danger')
+                    ->tooltip(fn ($record) => $record->latitude !== null
+                        ? "{$record->latitude}, {$record->longitude}"
+                        : 'No location yet - ping badge hidden (auto-fills hourly from IP)'),
+                Tables\Columns\TextColumn::make('latitude')
+                    ->label('Lat / Lon')
+                    ->formatStateUsing(fn ($state, $record) => $record->latitude !== null
+                        ? "{$record->latitude}, {$record->longitude}"
+                        : '-')
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('type')
                     ->searchable(),
                 Tables\Columns\TextColumn::make('admin_name')
@@ -150,7 +179,16 @@ class ServerResource extends Resource
             ])
             ->defaultSort('name', 'asc')
             ->filters([
-                //
+                Tables\Filters\TernaryFilter::make('has_coords')
+                    ->label('Location')
+                    ->placeholder('All servers')
+                    ->trueLabel('With location')
+                    ->falseLabel('Missing location')
+                    ->queries(
+                        true: fn ($query) => $query->whereNotNull('latitude')->whereNotNull('longitude'),
+                        false: fn ($query) => $query->where(fn ($q) => $q->whereNull('latitude')->orWhereNull('longitude')),
+                        blank: fn ($query) => $query,
+                    ),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/SftpCredentialResource.php
+++ b/app/Filament/Resources/SftpCredentialResource.php
@@ -54,6 +54,37 @@ class SftpCredentialResource extends Resource
                         'revoked' => 'danger',
                         default   => 'gray',
                     }),
+                Tables\Columns\TextColumn::make('geo_coverage')
+                    ->label('Geo')
+                    ->badge()
+                    ->getStateUsing(function ($record) {
+                        $servers = collect($record->servers ?? [])
+                            ->filter(fn ($e) => ! empty($e['ip']) && ! empty($e['port']));
+                        $total = $servers->count();
+                        if ($total === 0) {
+                            return 'no servers';
+                        }
+                        $located = $servers->filter(fn ($e) => self::serverLocated($e))->count();
+
+                        return "{$located}/{$total} located";
+                    })
+                    ->color(function ($state) {
+                        if (! str_contains($state, '/')) {
+                            return 'gray';
+                        }
+                        [$located, $rest] = explode('/', $state);
+
+                        return (int) $located === (int) $rest ? 'success' : 'warning';
+                    })
+                    ->tooltip(function ($record) {
+                        $missing = collect($record->servers ?? [])
+                            ->filter(fn ($e) => ! empty($e['ip']) && ! empty($e['port']))
+                            ->reject(fn ($e) => self::serverLocated($e))
+                            ->map(fn ($e) => $e['ip'].':'.$e['port'])
+                            ->all();
+
+                        return $missing ? 'Missing location: '.implode(', ', $missing) : 'All servers located';
+                    }),
                 Tables\Columns\TextColumn::make('provisioned_at')
                     ->dateTime()
                     ->sortable(),
@@ -78,9 +109,26 @@ class SftpCredentialResource extends Resource
                     ->modalHeading('Manage declared servers + RS codes')
                     ->modalDescription("Each row is one of the user's defrag servers. Fill in the RS code we issued for that server (matches the rs<PORT>=<id> entry in their sv.conf).")
                     ->modalWidth('4xl')
-                    ->fillForm(fn ($record) => [
-                        'servers' => $record->servers ?? [],
-                    ])
+                    ->fillForm(function ($record) {
+                        // Prefill the coordinate fields from the live Server row
+                        // (auto-geolocated or previously set) so the admin sees
+                        // the current value and only edits the ones that need it.
+                        $servers = $record->servers ?? [];
+                        foreach ($servers as &$entry) {
+                            if (empty($entry['ip']) || empty($entry['port'])) {
+                                continue;
+                            }
+                            $srv = \App\Models\Server::where('ip', $entry['ip'])
+                                ->where('port', (int) $entry['port'])
+                                ->first();
+                            if ($srv) {
+                                $entry['latitude'] = $entry['latitude'] ?? $srv->latitude;
+                                $entry['longitude'] = $entry['longitude'] ?? $srv->longitude;
+                            }
+                        }
+
+                        return ['servers' => $servers];
+                    })
                     ->form([
                         \Filament\Forms\Components\Repeater::make('servers')
                             ->label(false)
@@ -118,6 +166,20 @@ class SftpCredentialResource extends Resource
                                     ->label('RS code')
                                     ->placeholder('e.g. 4711')
                                     ->columnSpan(1),
+                                \Filament\Forms\Components\TextInput::make('latitude')
+                                    ->label('Latitude')
+                                    ->numeric()
+                                    ->minValue(-90)
+                                    ->maxValue(90)
+                                    ->columnSpan(3)
+                                    ->helperText('Auto-filled from IP. Set by hand only when it couldn\'t resolve (e.g. a hostname).'),
+                                \Filament\Forms\Components\TextInput::make('longitude')
+                                    ->label('Longitude')
+                                    ->numeric()
+                                    ->minValue(-180)
+                                    ->maxValue(180)
+                                    ->columnSpan(3)
+                                    ->helperText('Drives the visitor ping badge. Leave blank to keep it hidden for this server.'),
                                 \Filament\Forms\Components\Textarea::make('admin_note')
                                     ->label('Admin note')
                                     ->placeholder('Engine, special config, things to remember — not shown to the user')
@@ -218,5 +280,15 @@ class SftpCredentialResource extends Resource
         return [
             'index' => Pages\ListSftpCredentials::route('/'),
         ];
+    }
+
+    /** Does the live Server row for this declared entry have coordinates? */
+    private static function serverLocated(array $entry): bool
+    {
+        $srv = \App\Models\Server::where('ip', $entry['ip'])
+            ->where('port', (int) $entry['port'])
+            ->first();
+
+        return $srv && $srv->latitude !== null && $srv->longitude !== null;
     }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -16,6 +16,12 @@ class Server extends Model
      */
     protected $hidden = ['rconpassword'];
 
+    protected $casts = [
+        'latitude' => 'float',
+        'longitude' => 'float',
+        'geo_checked_at' => 'datetime',
+    ];
+
     /**
      * The attributes that are mass assignable.
      *
@@ -26,6 +32,8 @@ class Server extends Model
         'ip',
         'port',
         'location',
+        'latitude',
+        'longitude',
         'type',
         'admin_name',
         'admin_contact',

--- a/app/Observers/SftpCredentialObserver.php
+++ b/app/Observers/SftpCredentialObserver.php
@@ -40,15 +40,28 @@ class SftpCredentialObserver
             // when blank — at least gives a flag instead of "_404".
             $entryLocation = !empty($entry['location']) ? strtoupper($entry['location']) : $ownerCountry;
 
+            // Optional manual coordinates (admin fills these for servers whose
+            // IP/hostname the auto-geolocator can't resolve). Only applied when
+            // present, so they never wipe auto-filled values.
+            $hasCoords = isset($entry['latitude'], $entry['longitude'])
+                && $entry['latitude'] !== '' && $entry['longitude'] !== '';
+            $entryLat = $hasCoords ? (float) $entry['latitude'] : null;
+            $entryLon = $hasCoords ? (float) $entry['longitude'] : null;
+
             if ($existing) {
                 // Don't clobber scraper-managed fields on existing rows;
                 // just link to the credential, refresh the rcon password,
                 // and propagate location updates (admin/owner can change it).
-                $existing->fill([
+                $fill = [
                     'sftp_credential_id' => $credential->id,
                     'rconpassword'       => $entry['rcon'] ?? $existing->rconpassword,
                     'location'           => $entryLocation,
-                ])->save();
+                ];
+                if ($hasCoords) {
+                    $fill['latitude'] = $entryLat;
+                    $fill['longitude'] = $entryLon;
+                }
+                $existing->fill($fill)->save();
                 continue;
             }
 
@@ -60,6 +73,8 @@ class SftpCredentialObserver
                 'name'               => 'Pending scrape',
                 'plain_name'         => 'Pending scrape',
                 'location'           => $entryLocation,
+                'latitude'           => $entryLat,
+                'longitude'          => $entryLon,
                 'type'               => $entry['gametype'] ?? 'mixed',
                 'admin_name'         => $ownerName,
                 'map'                => '',

--- a/app/Services/ServerListService.php
+++ b/app/Services/ServerListService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Record;
 use App\Models\Server;
 use App\Models\User;
+use App\Support\PingEstimator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -156,13 +157,25 @@ class ServerListService
             });
         }
 
-        return $servers->values()->map(function ($server) {
+        // Visitor location (Cloudflare headers) for the per-server ping
+        // estimate. Resolved once; null when the request didn't pass through
+        // Cloudflare, in which case every estimated_ping comes back null and
+        // the UI simply hides the badge.
+        $visitor = PingEstimator::visitorLatLon($request);
+
+        return $servers->values()->map(function ($server) use ($visitor) {
             $array = $server->toArray();
             $array['mytime_time'] = $server->mytime_time ?? null;
             $array['mytime_date'] = $server->mytime_date ?? null;
             $array['myrank_position'] = $server->myrank_position ?? null;
             $array['myrank_total'] = $server->myrank_total ?? null;
             $array['besttime_date'] = $server->besttime_date ?? null;
+            // Base geo estimate, plus a small +/-5ms wobble each request so the
+            // figure feels live (real pings jitter) instead of a frozen number.
+            $base = $visitor
+                ? PingEstimator::estimate($visitor[0], $visitor[1], $server->latitude, $server->longitude)
+                : null;
+            $array['estimated_ping'] = $base !== null ? max(1, $base + random_int(-5, 5)) : null;
 
             return $array;
         })->all();

--- a/app/Support/PingEstimator.php
+++ b/app/Support/PingEstimator.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+/**
+ * Rough visitor-to-server ping estimate from geography alone.
+ *
+ * Browsers can't send ICMP/UDP, so a true defrag ping can't be measured from
+ * the web. Instead we take the visitor's location (Cloudflare injects
+ * cf-iplatitude / cf-iplongitude request headers via the "Add visitor location
+ * headers" managed transform) and the server's stored coordinates, and convert
+ * the great-circle distance into an approximate round-trip time.
+ *
+ * This is the backbone portion only: it does NOT include the visitor's last
+ * mile (home wifi / ISP / mobile), so real in-game ping reads a bit higher.
+ * Always present it as an estimate ("~"), never an exact figure.
+ */
+class PingEstimator
+{
+    /**
+     * Light in fibre travels ~200 km/ms, so a round trip is ~100 km/ms of
+     * straight-line distance. Real paths aren't straight and add router hops,
+     * so we inflate by this factor for a realistic backbone RTT.
+     */
+    private const ROUTE_FACTOR = 1.6;
+
+    /** Earth's mean radius in kilometres. */
+    private const EARTH_KM = 6371.0;
+
+    /**
+     * Visitor coordinates from Cloudflare's location headers, or null when the
+     * request didn't come through Cloudflare (local dev, direct origin hit).
+     *
+     * @return array{0: float, 1: float}|null  [lat, lon]
+     */
+    public static function visitorLatLon(Request $request): ?array
+    {
+        $lat = $request->header('cf-iplatitude');
+        $lon = $request->header('cf-iplongitude');
+
+        if ($lat === null || $lon === null || ! is_numeric($lat) || ! is_numeric($lon)) {
+            return null;
+        }
+
+        return [(float) $lat, (float) $lon];
+    }
+
+    /**
+     * Estimated round-trip time in whole milliseconds between two points, or
+     * null if either coordinate is missing.
+     */
+    public static function estimate(?float $aLat, ?float $aLon, ?float $bLat, ?float $bLon): ?int
+    {
+        if ($aLat === null || $aLon === null || $bLat === null || $bLon === null) {
+            return null;
+        }
+
+        $km = self::haversineKm($aLat, $aLon, $bLat, $bLon);
+
+        return max(1, (int) round($km / 100 * self::ROUTE_FACTOR));
+    }
+
+    /** Great-circle distance in kilometres. */
+    private static function haversineKm(float $aLat, float $aLon, float $bLat, float $bLon): float
+    {
+        $dLat = deg2rad($bLat - $aLat);
+        $dLon = deg2rad($bLon - $aLon);
+
+        $h = sin($dLat / 2) ** 2
+            + cos(deg2rad($aLat)) * cos(deg2rad($bLat)) * sin($dLon / 2) ** 2;
+
+        return self::EARTH_KM * 2 * asin(min(1.0, sqrt($h)));
+    }
+}

--- a/database/migrations/2026_06_06_000001_add_coordinates_to_servers_table.php
+++ b/database/migrations/2026_06_06_000001_add_coordinates_to_servers_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Geo coordinates for each server, set once in the admin. Combined with the
+ * visitor's location (from Cloudflare's cf-iplatitude/cf-iplongitude request
+ * headers) we estimate the visitor's ping to each server at render time -
+ * great-circle distance -> rough RTT, no probes, no per-visitor storage.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->decimal('latitude', 10, 7)->nullable()->after('location');
+            $table->decimal('longitude', 10, 7)->nullable()->after('latitude');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+};

--- a/database/migrations/2026_06_06_000002_add_geo_checked_at_to_servers_table.php
+++ b/database/migrations/2026_06_06_000002_add_geo_checked_at_to_servers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Records the last time we tried to geolocate a server's IP. Lets the hourly
+ * geolocate command retry servers it couldn't resolve only occasionally
+ * (instead of hammering the geo API every hour forever) while still picking up
+ * brand-new servers promptly.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->timestamp('geo_checked_at')->nullable()->after('longitude');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('geo_checked_at');
+        });
+    }
+};

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -938,7 +938,7 @@
                         </div>
                         <h3 class="text-sm font-bold text-white">Render to YouTube?</h3>
                     </div>
-                    <p class="text-xs text-gray-400 mb-3">This queues your demo to be rendered into a video and uploaded to the defrag.racing YouTube channel. Rendering can take several minutes.</p>
+                    <p class="text-xs text-gray-400 mb-3">This queues this demo to be rendered into a video and uploaded to the defrag.racing YouTube channel. Rendering can take several minutes.</p>
 
                     <div class="border border-red-500/30 bg-red-500/[0.06] rounded-lg p-3 mb-3">
                         <p class="text-[11px] text-gray-300 leading-relaxed">
@@ -950,7 +950,7 @@
                     <div class="border border-white/10 bg-white/[0.02] rounded-lg p-3 mb-3">
                         <h4 class="text-xs font-bold text-white mb-2">Render etiquette</h4>
                         <ul class="text-[11px] text-gray-400 space-y-1.5 list-disc pl-4">
-                            <li>Render your best run. Don't queue your whole time history when you already have - or will beat in minutes or hours - a faster time.</li>
+                            <li>Render the best run. Don't queue a whole time history for a map when a faster time already exists - or will likely beat it within minutes or hours.</li>
                             <li>Several near-identical times on the same map, a few ms apart? Pick one.</li>
                             <li>Slower time but a genuinely cool trick or something worth showing off? That's totally fine, go for it.</li>
                         </ul>
@@ -958,7 +958,7 @@
 
                     <label class="flex items-start gap-2 mb-3 cursor-pointer select-none">
                         <input type="checkbox" v-model="etiquetteAccepted" class="mt-0.5 w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-red-600 focus:ring-red-500 focus:ring-offset-0">
-                        <span class="text-xs text-gray-300">I won't render my whole time history - just the runs actually worth keeping.</span>
+                        <span class="text-xs text-gray-300">I'll only render runs actually worth keeping, not whole time histories.</span>
                     </label>
 
                     <p v-if="renderError" class="text-xs text-red-400 mb-3">{{ renderError }}</p>
@@ -981,7 +981,7 @@
                         <h3 class="text-sm font-bold text-white">Render Queued</h3>
                     </div>
                     <p class="text-xs text-gray-400 mb-4">
-                        Your demo has been added to the render queue. You can check rendering progress
+                        This demo has been added to the render queue. You can check rendering progress
                         <a href="/rendered-demos" class="text-red-400 hover:text-red-300 underline">here</a>.
                     </p>
                     <div class="flex justify-end">

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -28,6 +28,14 @@ const players = ref(0);
 const interval = ref(null);
 const isRotating = ref(false);
 
+// Colour for the estimated-ping badge: green good, amber okay, red far.
+const pingClass = (ms) => ms < 50
+    ? 'bg-green-500/25 border-green-400/50 text-green-300'
+    : ms < 100
+        ? 'bg-yellow-500/25 border-yellow-400/50 text-yellow-200'
+        : 'bg-red-500/25 border-red-400/50 text-red-300';
+const pingTitle = 'Estimated ping from your location (approximate - excludes your local connection)';
+
 const formatRecordDate = (value) => {
     if (!value) return '';
     const d = new Date(value);
@@ -691,9 +699,16 @@ const getFunctionName = (abbr) => {
                                     </svg>
                                     Connect
                                 </div>
-                                <span :class="server.defrag.toLowerCase().includes('cpm') ? 'bg-purple-500/30 border-purple-400/50 text-purple-300' : 'bg-blue-500/30 border-blue-400/50 text-blue-300'" class="px-2.5 py-0.5 text-xs font-black uppercase tracking-wider rounded border">
-                                    {{ server.defrag.toLowerCase().includes('cpm') ? 'CPM' : 'VQ3' }}
-                                </span>
+                                <div class="flex items-center gap-2">
+                                    <span v-if="server.estimated_ping != null" :class="pingClass(server.estimated_ping)" :title="pingTitle"
+                                        class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-bold rounded border tabular-nums">
+                                        <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2 20h.01M7 20v-4M12 20v-8M17 20V8M22 4v16"/></svg>
+                                        ~{{ server.estimated_ping }} ms
+                                    </span>
+                                    <span :class="server.defrag.toLowerCase().includes('cpm') ? 'bg-purple-500/30 border-purple-400/50 text-purple-300' : 'bg-blue-500/30 border-blue-400/50 text-blue-300'" class="px-2.5 py-0.5 text-xs font-black uppercase tracking-wider rounded border">
+                                        {{ server.defrag.toLowerCase().includes('cpm') ? 'CPM' : 'VQ3' }}
+                                    </span>
+                                </div>
                             </a>
                         </div>
                     </div>
@@ -778,6 +793,12 @@ const getFunctionName = (abbr) => {
                                             <path d="M4.5 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM14.25 8.625a3.375 3.375 0 1 1 6.75 0 3.375 3.375 0 0 1-6.75 0ZM1.5 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM17.25 19.128l-.001.144a2.25 2.25 0 0 1-.233.96 10.088 10.088 0 0 0 5.06-1.01.75.75 0 0 0 .42-.643 4.875 4.875 0 0 0-6.957-4.611 8.586 8.586 0 0 1 1.71 5.157v.003Z" />
                                         </svg>
                                         <span class="text-xs font-bold text-white" style="text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 4px rgba(0,0,0,0.8);">{{ server.online_players.length }}</span>
+                                    </div>
+
+                                    <!-- Estimated ping -->
+                                    <div v-if="server.estimated_ping != null" :class="pingClass(server.estimated_ping)" :title="pingTitle" class="flex items-center gap-1 px-2 py-1 rounded border tabular-nums">
+                                        <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2 20h.01M7 20v-4M12 20v-8M17 20V8M22 4v16"/></svg>
+                                        <span class="text-xs font-bold">~{{ server.estimated_ping }}ms</span>
                                     </div>
                                 </div>
 
@@ -882,6 +903,12 @@ const getFunctionName = (abbr) => {
                                             <path d="M4.5 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM14.25 8.625a3.375 3.375 0 1 1 6.75 0 3.375 3.375 0 0 1-6.75 0ZM1.5 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM17.25 19.128l-.001.144a2.25 2.25 0 0 1-.233.96 10.088 10.088 0 0 0 5.06-1.01.75.75 0 0 0 .42-.643 4.875 4.875 0 0 0-6.957-4.611 8.586 8.586 0 0 1 1.71 5.157v.003Z" />
                                         </svg>
                                         <span class="text-xs font-bold text-white" style="text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 4px rgba(0,0,0,0.8);">{{ server.online_players.length }}</span>
+                                    </div>
+
+                                    <!-- Estimated ping -->
+                                    <div v-if="server.estimated_ping != null" :class="pingClass(server.estimated_ping)" :title="pingTitle" class="flex items-center gap-1 px-2 py-1 rounded border tabular-nums">
+                                        <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2 20h.01M7 20v-4M12 20v-8M17 20V8M22 4v16"/></svg>
+                                        <span class="text-xs font-bold">~{{ server.estimated_ping }}ms</span>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
Two pending changes on the branch.

## 1) Estimated visitor ping per server
Show every visitor a rough ping to each server - no probes, no work for server owners.

- Server coordinates auto-fill from their IP via a scheduled command (`servers:geolocate`): only fills missing ones, never overwrites manual values, and backs off to once a day for IPs/hostnames it can't resolve (so it doesn't hammer the geo API hourly).
- Visitor location comes from Cloudflare's `cf-iplatitude` / `cf-iplongitude` request headers (Managed Transform "Add visitor location headers").
- At render time the great-circle distance becomes an approximate RTT (with a small +/-5ms wobble so it feels live), shown as a colour-coded badge on the Connect button and in the compact list. Backbone estimate only - excludes the visitor's last mile, labelled as approximate.
- Admin visibility/override: ServerResource gains lat/lon fields, a Geo column and a Missing-location filter. The surviving SFTP-credential flow gains editable lat/lon per server (propagated to the Server row by the observer) and a located/total Geo column with a tooltip of what's missing.

## 2) Ownership-neutral render dialog wording
The render-to-YouTube dialog and queued confirmation assumed you only render your own demos, but any demo can be rendered. Reworded the intro, etiquette, checkbox and confirmation to not presume ownership (per community feedback from Batawi).