### PR TITLE
Run server geolocate daily, not hourly

### DIFF
--- a/app/Console/Commands/GeolocateServers.php
+++ b/app/Console/Commands/GeolocateServers.php
@@ -20,8 +20,12 @@ class GeolocateServers extends Command
 
     protected $description = 'Auto-fill server latitude/longitude from their IP (only missing ones by default)';
 
-    /** Don't re-hit the geo API for an unresolvable server more often than this. */
-    private const RETRY_AFTER_HOURS = 24;
+    /**
+     * Don't re-hit the geo API for an unresolvable server more often than this.
+     * Below the daily schedule interval so the once-a-day run always retries
+     * failures (rather than skipping a day on timing drift).
+     */
+    private const RETRY_AFTER_HOURS = 12;
 
     public function handle(): int
     {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -84,9 +84,11 @@ class Kernel extends ConsoleKernel
         $schedule->command('defraglive:rollover-contests')->withoutOverlapping()->hourly();
 
         // Auto-fill lat/lon from IP for any server missing it (drives the
-        // visitor ping estimate). No-op once all servers are geolocated; never
+        // visitor ping estimate). Daily is plenty - new servers are rare and a
+        // ping badge appearing within a day is fine. No-op once all servers are
+        // geolocated (a cheap "WHERE latitude IS NULL" returning nothing); never
         // overwrites existing coordinates.
-        $schedule->command('servers:geolocate')->withoutOverlapping()->hourly();
+        $schedule->command('servers:geolocate')->withoutOverlapping()->daily();
 
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();


### PR DESCRIPTION
New servers are rare and a ping badge appearing within a day is fine, so drop the schedule from hourly to daily; it's a no-op when nothing is missing. Lower the unresolvable-retry backoff to 12h so the daily run always retries failures instead of skipping a day on timing drift.