### PR TITLE
Launcher: make .exe the recommended Windows download + re-enable launcher promo

### DIFF
--- a/app/Http/Controllers/LauncherController.php
+++ b/app/Http/Controllers/LauncherController.php
@@ -106,9 +106,14 @@ class LauncherController extends Controller
             ];
 
             if (str_ends_with($name, '.msi')) {
-                $by['windows'][] = $entry + ['kind' => 'msi', 'label' => 'Installer (.msi)', 'recommended' => true];
+                // Legacy: we stopped shipping the per-machine MSI from
+                // launcher 0.1.17 on (it forced a UAC prompt on every
+                // auto-update). Kept here so older releases still render.
+                $by['windows'][] = $entry + ['kind' => 'msi', 'label' => 'Installer (.msi)', 'recommended' => false];
             } elseif (str_ends_with($name, '.exe')) {
-                $by['windows'][] = $entry + ['kind' => 'exe', 'label' => 'Setup (.exe)', 'recommended' => false];
+                // The per-user NSIS installer - now the primary Windows
+                // download (no admin prompt, silent auto-updates).
+                $by['windows'][] = $entry + ['kind' => 'exe', 'label' => 'Installer (.exe)', 'recommended' => true];
             } elseif (str_ends_with($name, '.dmg')) {
                 $isArm = str_contains($name, 'aarch64') || str_contains($name, 'arm64');
                 $by['macos'][] = $entry + [

--- a/resources/js/Pages/Demos/Index.vue
+++ b/resources/js/Pages/Demos/Index.vue
@@ -1344,7 +1344,6 @@ watch(selectedPhysics, () => {
                         </p>
                     </div>
 
-                    <!-- TEMP hidden: launcher header chip (re-enable once render is confirmed working)
                     <Link :href="route('launcher')"
                           class="flex items-center gap-2 bg-gradient-to-r from-blue-600/30 to-blue-500/15 hover:from-blue-600/40 hover:to-blue-500/25 backdrop-blur-sm px-3 py-2 rounded-lg border border-blue-400/40 hover:border-blue-300/60 transition-colors text-sm">
                         <svg class="w-5 h-5 text-blue-300 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -1355,7 +1354,6 @@ watch(selectedPhysics, () => {
                         <span class="font-bold text-white whitespace-nowrap">Get the launcher</span>
                         <span class="hidden sm:inline text-blue-200/80 font-semibold text-xs">auto backup demos + many more features</span>
                     </Link>
-                    -->
 
                     <!-- Limits Info (Right Side) -->
                     <div class="flex flex-col gap-2">
@@ -1414,9 +1412,7 @@ watch(selectedPhysics, () => {
         <div class="overflow-x-hidden">
             <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12">
 
-                <!-- TEMP hidden: dismissible launcher banner (re-enable once render is confirmed working)
                 <LauncherBanner variant="demos" />
-                -->
 
                 <!-- Upload Section (visible to all users; guests will have restricted actions) -->
                 <div class="bg-black/40 backdrop-blur-sm rounded-xl p-3 mb-4 shadow-2xl border border-white/5">

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -388,7 +388,6 @@ const getFunctionName = (abbr) => {
                         Live Servers
                     </h1>
 
-                    <!-- TEMP hidden: launcher header chip (re-enable once render is confirmed working)
                     <Link :href="route('launcher')"
                           class="flex items-center gap-2 bg-gradient-to-r from-blue-600/30 to-blue-500/15 hover:from-blue-600/40 hover:to-blue-500/25 backdrop-blur-sm px-3 py-2 rounded-lg border border-blue-400/40 hover:border-blue-300/60 transition-colors text-sm">
                         <svg class="w-5 h-5 text-blue-300 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -399,7 +398,6 @@ const getFunctionName = (abbr) => {
                         <span class="font-bold text-white whitespace-nowrap">Get the launcher</span>
                         <span class="hidden sm:inline text-blue-200/80 font-semibold text-xs">connect to servers in 1 click + many more features</span>
                     </Link>
-                    -->
 
                     <div class="flex items-center gap-3 text-sm">
                         <div class="flex items-center gap-2 bg-black/40 backdrop-blur-sm px-3 py-2 rounded-lg border border-blue-400/30">
@@ -512,9 +510,7 @@ const getFunctionName = (abbr) => {
 
         <!-- Servers Grid/List -->
         <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12" style="margin-top: -22rem;">
-            <!-- TEMP hidden: dismissible launcher banner (re-enable once render is confirmed working)
             <LauncherBanner variant="servers" />
-            -->
             <!-- Loading skeleton while deferred data loads -->
             <div v-if="!serversLoaded" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <div v-for="i in 6" :key="i" class="bg-black/40 backdrop-blur-sm rounded-2xl border border-white/10 overflow-hidden animate-pulse">


### PR DESCRIPTION
## What
- **Download page (`LauncherController`)**: the per-user `.exe` is now the recommended Windows asset (it gets the "Best" badge); the `.msi` is kept as a non-recommended legacy entry.
- **Servers + Demos pages**: re-enabled the "Get the launcher" header chip and the dismissible launcher banner.

## Why
The launcher stopped shipping the per-machine `.msi` from **0.1.17** on - it forced a Windows UAC prompt on every auto-update (and the prompt wouldn't even come to the foreground). It now installs per-user via the `.exe`, so updates apply silently.

As a side effect the download page lost its "Best" badge (the badge was tied to the MSI) and the `.exe` looked like an afterthought. This flips the recommendation to the `.exe`.

The promo chip + banner were hidden behind a "re-enable once render is confirmed working" note - render works now, so they're back on.