### PR TITLE
Expose weapons/items/functions in launcher maps API

### DIFF
--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -370,7 +370,7 @@ class LauncherController extends Controller
         $perPage = 50;
 
         $query = Map::query()
-            ->select('id', 'name', 'author', 'thumbnail', 'physics', 'gametype', 'is_nsfw', 'date_added', 'pk3')
+            ->select('id', 'name', 'author', 'thumbnail', 'physics', 'gametype', 'is_nsfw', 'date_added', 'pk3', 'weapons', 'items', 'functions')
             ->orderBy('date_added', 'DESC')
             ->orderBy('id', 'DESC');
 


### PR DESCRIPTION
## What
Adds `weapons`, `items` and `functions` (comma-separated codes) to the `/api/launcher/maps` response.

## Why
The desktop launcher's Maps tab now renders weapon/item/function icons over each map thumbnail, the same way the website does. It needs these per-map fields to know which icons to show. Icons themselves are bundled in the launcher; this just supplies the data.

## Change
- `Api/LauncherController@maps`: add `weapons`, `items`, `functions` to the `select(...)`.

Additive, no behaviour change for existing consumers. Pairs with launcher v0.1.32.
