### PR TITLE
DefragLive contest overhaul + Donations page redesign

### DIFF
--- a/app/Filament/Resources/DefragliveContestResource.php
+++ b/app/Filament/Resources/DefragliveContestResource.php
@@ -179,13 +179,19 @@ class DefragliveContestResource extends Resource
                             }
                             // Credit the prize back as a real site donation so it
                             // shows up in the donations progress right away.
+                            // donor_email matters: isDonor()/getDonationTotal()
+                            // aggregate a user's donations by email match, so
+                            // without it the prize wouldn't count toward the
+                            // winner's donor stats.
                             \App\Models\SiteDonation::create([
                                 'user_id' => $record->winner_user_id,
+                                'donor_email' => $record->winner?->email,
                                 'donor_name' => $plainWinner ?: 'DefragLive contest winner',
                                 'amount' => $record->prize_amount,
                                 'currency' => $record->prize_currency,
                                 'donation_date' => now()->toDateString(),
-                                'note' => "DefragLive contest prize donated back ({$record->title})",
+                                'note' => "DefragLive contest prize donated back ({$record->title}) - "
+                                    . url('/defraglive/contest'),
                                 'status' => 'approved',
                             ]);
                             Notification::make()->title('Marked as donated')

--- a/app/Filament/Resources/DefragliveContestResource.php
+++ b/app/Filament/Resources/DefragliveContestResource.php
@@ -61,6 +61,8 @@ class DefragliveContestResource extends Resource
                         DefragliveContest::STATUS_ACTIVE => 'Active',
                         DefragliveContest::STATUS_CLOSED => 'Closed',
                         DefragliveContest::STATUS_PAID => 'Paid',
+                        DefragliveContest::STATUS_DONATED => 'Donated to the site',
+                        DefragliveContest::STATUS_FORWARDED => 'Forwarded to the next winner',
                     ])
                     ->default(DefragliveContest::STATUS_DRAFT)
                     ->required(),
@@ -100,6 +102,8 @@ class DefragliveContestResource extends Resource
                         DefragliveContest::STATUS_ACTIVE => 'success',
                         DefragliveContest::STATUS_CLOSED => 'warning',
                         DefragliveContest::STATUS_PAID => 'info',
+                        DefragliveContest::STATUS_DONATED => 'success',
+                        DefragliveContest::STATUS_FORWARDED => 'info',
                         default => 'gray',
                     }),
                 Tables\Columns\TextColumn::make('winner_name')
@@ -132,15 +136,97 @@ class DefragliveContestResource extends Resource
                             ->success()->send();
                     }),
 
-                // Mark a drawn contest as paid out.
-                Tables\Actions\Action::make('markPaid')
-                    ->label('Mark paid')
+                // Settle a drawn contest's prize: paid out, donated back to the
+                // site by the winner, or rolled over into the next contest's
+                // prize pool (bump that contest's prize_amount manually).
+                Tables\Actions\Action::make('resolvePrize')
+                    ->label('Resolve prize')
                     ->icon('heroicon-o-banknotes')
                     ->color('success')
-                    ->requiresConfirmation()
-                    ->visible(fn (DefragliveContest $r) => $r->winner_name !== null && $r->status !== DefragliveContest::STATUS_PAID)
-                    ->action(function (DefragliveContest $record) {
-                        $record->update(['status' => DefragliveContest::STATUS_PAID]);
+                    ->form([
+                        Forms\Components\Radio::make('resolution')
+                            ->label('How was the prize settled?')
+                            ->options([
+                                DefragliveContest::STATUS_PAID => 'Paid to the winner',
+                                DefragliveContest::STATUS_DONATED => 'Donated to the site',
+                                DefragliveContest::STATUS_FORWARDED => 'Forwarded to the next winner',
+                            ])
+                            ->descriptions([
+                                DefragliveContest::STATUS_FORWARDED => 'Adds this prize to the next upcoming contest\'s pool, shown publicly as "carried over from previous winners".',
+                            ])
+                            ->default(DefragliveContest::STATUS_PAID)
+                            ->required()
+                            ->live(),
+                        Forms\Components\Checkbox::make('create_donation')
+                            ->label('Create a site donation record in the winner\'s name')
+                            ->helperText('Shows up immediately in the site donations progress as approved.')
+                            ->default(true)
+                            ->visible(fn (Forms\Get $get) => $get('resolution') === DefragliveContest::STATUS_DONATED),
+                    ])
+                    ->visible(fn (DefragliveContest $r) => $r->winner_name !== null
+                        && ! in_array($r->status, DefragliveContest::RESOLVED_STATUSES, true))
+                    ->action(function (DefragliveContest $record, array $data) {
+                        $record->update(['status' => $data['resolution']]);
+                        $plainWinner = trim(preg_replace('/\^[0-9A-Za-z]/', '', (string) $record->winner_name));
+
+                        if ($data['resolution'] === DefragliveContest::STATUS_DONATED) {
+                            if (empty($data['create_donation'])) {
+                                Notification::make()->title('Marked as donated')
+                                    ->body('No donation record created (checkbox was off).')
+                                    ->success()->send();
+
+                                return;
+                            }
+                            // Credit the prize back as a real site donation so it
+                            // shows up in the donations progress right away.
+                            \App\Models\SiteDonation::create([
+                                'user_id' => $record->winner_user_id,
+                                'donor_name' => $plainWinner ?: 'DefragLive contest winner',
+                                'amount' => $record->prize_amount,
+                                'currency' => $record->prize_currency,
+                                'donation_date' => now()->toDateString(),
+                                'note' => "DefragLive contest prize donated back ({$record->title})",
+                                'status' => 'approved',
+                            ]);
+                            Notification::make()->title('Marked as donated')
+                                ->body("Site donation of {$record->prize_amount} {$record->prize_currency} recorded for {$plainWinner}.")
+                                ->success()->send();
+
+                            return;
+                        }
+
+                        if ($data['resolution'] === DefragliveContest::STATUS_FORWARDED) {
+                            // Roll the prize into the next contest (same currency,
+                            // starting after this one; draft or active).
+                            $next = DefragliveContest::query()
+                                ->whereNull('winner_name')
+                                ->whereKeyNot($record->getKey())
+                                ->where('prize_currency', $record->prize_currency)
+                                ->whereIn('status', [DefragliveContest::STATUS_DRAFT, DefragliveContest::STATUS_ACTIVE])
+                                ->where('starts_at', '>=', $record->starts_at)
+                                ->orderBy('starts_at')
+                                ->first();
+
+                            if ($next) {
+                                $next->update([
+                                    'prize_amount' => $next->prize_amount + $record->prize_amount,
+                                    // Tracked separately so the public page can
+                                    // show "base + carried over from previous
+                                    // winners" instead of one opaque number.
+                                    'carried_over_amount' => $next->carried_over_amount + $record->prize_amount,
+                                ]);
+                                Notification::make()->title('Marked as forwarded')
+                                    ->body("Prize added to \"{$next->title}\" - its pool is now {$next->fresh()->prize_amount} {$next->prize_currency} (of which {$next->fresh()->carried_over_amount} carried over).")
+                                    ->success()->send();
+                            } else {
+                                Notification::make()->title('Marked as forwarded - but no upcoming contest found')
+                                    ->body('Create the next contest and raise its prize manually by this amount.')
+                                    ->warning()->send();
+                            }
+
+                            return;
+                        }
+
                         Notification::make()->title('Marked as paid')->success()->send();
                     }),
 

--- a/app/Http/Controllers/DefragliveContestController.php
+++ b/app/Http/Controllers/DefragliveContestController.php
@@ -19,6 +19,10 @@ class DefragliveContestController extends Controller
     public function index(Request $request, DefragliveWatchService $service)
     {
         $contest = DefragliveContest::current()->first();
+        $open = DefragliveWatchSession::open()
+            ->where('last_seen_at', '>=', now()->subSeconds(DefragliveWatchService::LIVE_WINDOW))
+            ->orderByDesc('id')
+            ->first();
 
         $leaderboard = [];
         $totalTickets = 0;
@@ -42,18 +46,17 @@ class DefragliveContestController extends Controller
                         'seconds' => $e['seconds'],
                         'tickets' => $e['tickets'],
                         'odds' => $totalTickets > 0 ? round($e['tickets'] / $totalTickets * 100, 1) : 0,
+                        'is_current' => $this->isCurrent($e, $open),
                     ];
                     break;
                 }
             }
 
-            $leaderboard = array_map($this->present(...), array_slice($all, 0, 10));
+            $leaderboard = array_map(
+                fn (array $entry) => $this->present($entry, $open),
+                array_slice($all, 0, 10)
+            );
         }
-
-        $open = DefragliveWatchSession::open()
-            ->where('started_at', '>=', now()->subHours(DefragliveWatchService::ORPHAN_HOURS))
-            ->orderByDesc('id')
-            ->first();
 
         return Inertia::render('DefragliveContest', [
             'contest' => $contest ? [
@@ -61,6 +64,8 @@ class DefragliveContestController extends Controller
                 'title' => $contest->title,
                 'prize_amount' => $contest->prize_amount,
                 'prize_currency' => $contest->prize_currency,
+                // Forwarded in by previous winners; base = amount - carried.
+                'carried_over_amount' => (float) $contest->carried_over_amount,
                 'starts_at' => $contest->starts_at?->toIso8601String(),
                 'ends_at' => $contest->ends_at?->toIso8601String(),
             ] : null,
@@ -70,6 +75,7 @@ class DefragliveContestController extends Controller
             'nowWatching' => $open ? [
                 'name' => $open->player_name,
                 'mapname' => $open->mapname,
+                'seconds' => (int) ($open->started_at?->diffInSeconds(now()) ?? $open->seconds),
                 'map_thumbnail' => $open->mapname
                     ? \App\Models\Map::where('name', $open->mapname)->value('thumbnail')
                     : null,
@@ -84,10 +90,23 @@ class DefragliveContestController extends Controller
                     'winner_user_id' => $c->winner_user_id,
                     'prize_amount' => $c->prize_amount,
                     'prize_currency' => $c->prize_currency,
+                    'carried_over_amount' => (float) $c->carried_over_amount,
                     'drawn_at' => $c->drawn_at?->toDateString(),
                     'status' => $c->status,
+                    'winner_seconds' => (int) $c->winner_seconds,
+                    'winner_tickets' => (int) $c->winner_tickets,
+                    'total_tickets' => (int) $c->total_tickets,
                 ]),
             'hallOfFame' => $this->hallOfFame($service),
+            // Loaded on demand (Inertia lazy prop): the page requests it via a
+            // partial reload when the visitor expands the all-time stats view,
+            // growing watchers_limit in steps of 40 as the visitor scrolls.
+            'allTimeWatchers' => Inertia::lazy(fn () => $service->allTimeLeaderboard(
+                // Hard cap: the list grows 40 at a time as the visitor scrolls,
+                // and past rank 400 an all-time list stops being interesting -
+                // this also bounds the largest partial-reload payload.
+                max(1, min(400, (int) $request->input('watchers_limit', 40)))
+            )),
         ]);
     }
 
@@ -98,25 +117,27 @@ class DefragliveContestController extends Controller
     private function hallOfFame(DefragliveWatchService $service): array
     {
         $won = DefragliveContest::whereNotNull('winner_name')
-            ->get(['winner_user_id', 'winner_mdd_id', 'winner_name', 'prize_amount', 'prize_currency']);
+            ->get(['winner_user_id', 'winner_mdd_id', 'winner_name', 'prize_amount', 'prize_currency', 'winner_seconds']);
 
         $groups = [];
         foreach ($won as $c) {
             $key = $c->winner_user_id
-                ? 'u:' . $c->winner_user_id
-                : 'n:' . $service->cleanName((string) $c->winner_name);
+                ? 'u:'.$c->winner_user_id
+                : 'n:'.$service->cleanName((string) $c->winner_name);
 
-            if (!isset($groups[$key])) {
+            if (! isset($groups[$key])) {
                 $groups[$key] = [
                     'winner_user_id' => $c->winner_user_id,
                     'name' => $c->winner_name,
                     'wins' => 0,
                     'total' => 0.0,
                     'currency' => $c->prize_currency,
+                    'seconds' => 0,
                 ];
             }
             $groups[$key]['wins']++;
             $groups[$key]['total'] += (float) $c->prize_amount;
+            $groups[$key]['seconds'] += (int) $c->winner_seconds;
             $groups[$key]['name'] = $c->winner_name ?: $groups[$key]['name'];
         }
 
@@ -144,13 +165,14 @@ class DefragliveContestController extends Controller
     }
 
     /** Shape one leaderboard entry for the page (colored name + resolved user). */
-    private function present(array $e): array
+    private function present(array $e, ?DefragliveWatchSession $open = null): array
     {
         return [
             'name' => $e['name'],
             'seconds' => $e['seconds'],
             'tickets' => $e['tickets'],
             'mdd_id' => $e['mdd_id'],
+            'is_current' => $this->isCurrent($e, $open),
             'user' => $e['user'] ? [
                 'id' => $e['user']->id,
                 'name' => $e['user']->name,
@@ -158,5 +180,20 @@ class DefragliveContestController extends Controller
                 'country' => $e['user']->country,
             ] : null,
         ];
+    }
+
+    private function isCurrent(array $entry, ?DefragliveWatchSession $open): bool
+    {
+        if (! $open) {
+            return false;
+        }
+
+        if ($entry['mdd_id'] && $open->mdd_id) {
+            return (int) $entry['mdd_id'] === (int) $open->mdd_id;
+        }
+
+        return $entry['name_clean'] !== null
+            && $open->player_name_clean !== null
+            && (string) $entry['name_clean'] === (string) $open->player_name_clean;
     }
 }

--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -16,8 +16,12 @@ class DonationController extends Controller
     {
         $currentYear = now()->year;
 
-        // Get only approved donations and self-raised money
-        $donations = SiteDonation::approved()->orderBy('donation_date', 'desc')->get();
+        // Get only approved donations and self-raised money. The linked user
+        // (if any) drives the avatar + profile link on the donation card.
+        $donations = SiteDonation::approved()
+            ->with('user:id,name,profile_photo_path')
+            ->orderBy('donation_date', 'desc')
+            ->get();
         $selfRaisedMoney = SelfRaisedMoney::orderBy('earned_date', 'desc')->get();
         $goal = DonationGoal::where('year', $currentYear)->first();
         $allGoals = DonationGoal::all()->keyBy('year'); // Get all goals indexed by year

--- a/app/Models/DefragliveContest.php
+++ b/app/Models/DefragliveContest.php
@@ -18,6 +18,17 @@ class DefragliveContest extends Model
     public const STATUS_ACTIVE = 'active';
     public const STATUS_CLOSED = 'closed';
     public const STATUS_PAID = 'paid';
+    // Prize resolutions other than a payout: the winner donated it back to the
+    // site, or it rolled over into the next contest's prize pool.
+    public const STATUS_DONATED = 'donated';
+    public const STATUS_FORWARDED = 'forwarded';
+
+    /** Statuses meaning the prize is settled (nothing owed to the winner). */
+    public const RESOLVED_STATUSES = [
+        self::STATUS_PAID,
+        self::STATUS_DONATED,
+        self::STATUS_FORWARDED,
+    ];
 
     protected $fillable = [
         'title',
@@ -25,6 +36,7 @@ class DefragliveContest extends Model
         'ends_at',
         'prize_amount',
         'prize_currency',
+        'carried_over_amount',
         'status',
         'winner_mdd_id',
         'winner_user_id',
@@ -42,6 +54,7 @@ class DefragliveContest extends Model
         'ends_at' => 'datetime',
         'drawn_at' => 'datetime',
         'prize_amount' => 'decimal:2',
+        'carried_over_amount' => 'decimal:2',
         'winner_seconds' => 'integer',
         'winner_tickets' => 'integer',
         'total_tickets' => 'integer',

--- a/app/Services/DefragliveWatchService.php
+++ b/app/Services/DefragliveWatchService.php
@@ -8,7 +8,6 @@ use App\Models\OnlinePlayer;
 use App\Models\Server;
 use App\Models\User;
 use App\Models\UserAlias;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -61,7 +60,7 @@ class DefragliveWatchService
 
         // No one being spectated, or the bot is watching itself (idle) -> the
         // current watch stretch is over; close it and credit nobody.
-        if (!is_array($current) || $this->isBot($current, $serverstate)) {
+        if (! is_array($current) || $this->isBot($current, $serverstate)) {
             $this->closeOpenSession();
 
             return;
@@ -91,7 +90,7 @@ class DefragliveWatchService
                     $open->seconds = $this->span($open->started_at, now());
                     $open->last_seen_at = now();
                     $open->mapname = $mapname ?: $open->mapname;
-                    if (!$open->mdd_id && $identity['mdd_id']) {
+                    if (! $open->mdd_id && $identity['mdd_id']) {
                         $open->mdd_id = $identity['mdd_id'];
                         $open->user_id = $identity['user_id'];
                     }
@@ -120,7 +119,7 @@ class DefragliveWatchService
     {
         DB::transaction(function () {
             $open = DefragliveWatchSession::open()->lockForUpdate()->first();
-            if (!$open) {
+            if (! $open) {
                 return;
             }
 
@@ -155,7 +154,7 @@ class DefragliveWatchService
     /** Whole seconds between two timestamps (>= 0). */
     private function span($start, $end): int
     {
-        if (!$start || !$end) {
+        if (! $start || ! $end) {
             return 0;
         }
 
@@ -204,7 +203,7 @@ class DefragliveWatchService
         }
 
         // 2) Clean-name match against the live player map.
-        if (!$mddId && $clean !== '') {
+        if (! $mddId && $clean !== '') {
             $op = OnlinePlayer::whereNotNull('mdd_id')
                 ->get(['name', 'mdd_id'])
                 ->first(fn ($p) => $this->cleanName((string) $p->name) === $clean);
@@ -214,7 +213,7 @@ class DefragliveWatchService
         }
 
         // 3) Approved alias history.
-        if (!$mddId && $clean !== '') {
+        if (! $mddId && $clean !== '') {
             $alias = UserAlias::query()
                 ->whereNotNull('mdd_id')
                 ->get(['mdd_id', 'alias'])
@@ -236,16 +235,26 @@ class DefragliveWatchService
      */
     public function leaderboard(DefragliveContest $contest, ?int $limit = 10): array
     {
+        $periodStart = $contest->starts_at->copy();
+        $periodEnd = $contest->ends_at->copy();
+        $now = now();
+        $windowEnd = $now->lessThan($periodEnd) ? $now : $periodEnd;
+
         $rows = DefragliveWatchSession::query()
-            ->where('started_at', '>=', $contest->starts_at)
-            ->where('started_at', '<=', $contest->ends_at)
+            // Include every session that overlaps the contest. A continuous
+            // watch can start in the previous period or end in the next one.
+            ->where('started_at', '<', $periodEnd)
+            ->where(function ($query) use ($periodStart) {
+                $query->whereNull('ended_at')
+                    ->orWhere('ended_at', '>', $periodStart);
+            })
             ->orderBy('id')
             ->get(['mdd_id', 'user_id', 'player_name', 'player_name_clean', 'seconds', 'started_at', 'ended_at']);
 
         $groups = [];
         foreach ($rows as $r) {
             $key = $this->keyFor($r->mdd_id, $r->player_name_clean);
-            if (!isset($groups[$key])) {
+            if (! isset($groups[$key])) {
                 $groups[$key] = [
                     'mdd_id' => $r->mdd_id ? (int) $r->mdd_id : null,
                     'user_id' => $r->user_id ? (int) $r->user_id : null,
@@ -254,11 +263,18 @@ class DefragliveWatchService
                     'seconds' => 0,
                 ];
             }
-            // Still-open session = currently being watched; count it live to now
-            // (its stored seconds only updates on an emit, which may be silent).
-            $groups[$key]['seconds'] += $r->ended_at
-                ? (int) $r->seconds
-                : $this->span($r->started_at, now());
+            // Count only the part inside this contest. Using the timestamps
+            // avoids credit leaking across rollover boundaries, including for
+            // an open session whose stored seconds updates only on an emit.
+            $sessionStart = $r->started_at->lessThan($periodStart)
+                ? $periodStart
+                : $r->started_at;
+            $rawEnd = $r->ended_at ?? $windowEnd;
+            $sessionEnd = $rawEnd->greaterThan($windowEnd)
+                ? $windowEnd
+                : $rawEnd;
+
+            $groups[$key]['seconds'] += $this->span($sessionStart, $sessionEnd);
             // Keep the latest seen colored name / resolved identity.
             $groups[$key]['name'] = $r->player_name ?: $groups[$key]['name'];
             if ($r->mdd_id) {
@@ -287,6 +303,69 @@ class DefragliveWatchService
         foreach ($entries as &$e) {
             $e['tickets'] = intdiv($e['seconds'], self::SECONDS_PER_TICKET);
             $e['user'] = $e['user_id'] ? $users->get($e['user_id']) : null;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * All-time watch totals across EVERY recorded session (no contest window),
+     * grouped by the same identity rules as leaderboard(). Powers the public
+     * page's expandable "all-time stats" view; $limit = null returns everyone.
+     */
+    public function allTimeLeaderboard(?int $limit = null): array
+    {
+        $rows = DefragliveWatchSession::query()
+            ->orderBy('id')
+            ->get(['mdd_id', 'user_id', 'player_name', 'player_name_clean', 'seconds', 'started_at', 'ended_at']);
+
+        $groups = [];
+        foreach ($rows as $r) {
+            $key = $this->keyFor($r->mdd_id, $r->player_name_clean);
+            if (! isset($groups[$key])) {
+                $groups[$key] = [
+                    'mdd_id' => $r->mdd_id ? (int) $r->mdd_id : null,
+                    'user_id' => $r->user_id ? (int) $r->user_id : null,
+                    'name' => $r->player_name,
+                    'seconds' => 0,
+                    'sessions' => 0,
+                ];
+            }
+            // An open session is being watched right now - count it live.
+            $groups[$key]['seconds'] += $r->ended_at
+                ? (int) $r->seconds
+                : $this->span($r->started_at, now());
+            $groups[$key]['sessions']++;
+            $groups[$key]['name'] = $r->player_name ?: $groups[$key]['name'];
+            if ($r->mdd_id) {
+                $groups[$key]['mdd_id'] = (int) $r->mdd_id;
+            }
+            if ($r->user_id) {
+                $groups[$key]['user_id'] = (int) $r->user_id;
+            }
+        }
+
+        $entries = array_values($groups);
+        usort($entries, fn ($a, $b) => $b['seconds'] <=> $a['seconds']);
+
+        if ($limit !== null) {
+            $entries = array_slice($entries, 0, $limit);
+        }
+
+        $userIds = array_values(array_filter(array_column($entries, 'user_id')));
+        $users = $userIds
+            ? User::whereIn('id', $userIds)
+                ->get(['id', 'name', 'plain_name', 'profile_photo_path', 'country', 'mdd_id'])
+                ->keyBy('id')
+            : collect();
+
+        foreach ($entries as &$e) {
+            $u = $e['user_id'] ? $users->get($e['user_id']) : null;
+            $e['user'] = $u ? [
+                'id' => $u->id,
+                'profile_photo_path' => $u->profile_photo_path,
+                'country' => $u->country,
+            ] : null;
         }
 
         return $entries;
@@ -348,7 +427,7 @@ class DefragliveWatchService
 
     private function keyFor($mddId, ?string $clean): string
     {
-        return $mddId ? 'mdd:' . (int) $mddId : 'name:' . (string) $clean;
+        return $mddId ? 'mdd:'.(int) $mddId : 'name:'.(string) $clean;
     }
 
     /** Is the "current player" actually the bot self-spectating (idle)? */

--- a/database/migrations/2026_07_10_205136_add_carried_over_amount_to_defraglive_contests.php
+++ b/database/migrations/2026_07_10_205136_add_carried_over_amount_to_defraglive_contests.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('defraglive_contests', function (Blueprint $table) {
+            // Portion of prize_amount that was forwarded in by previous
+            // winners ("Resolve prize -> forwarded"). Kept separately so the
+            // public page can show "base prize + carried over" transparently.
+            $table->decimal('carried_over_amount', 8, 2)->default(0)->after('prize_currency');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('defraglive_contests', function (Blueprint $table) {
+            $table->dropColumn('carried_over_amount');
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="mysql" force="true"/>
+        <env name="DB_DATABASE" value="testing" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { Head, Link } from '@inertiajs/vue3';
-import { ref, computed, onMounted, onUnmounted, getCurrentInstance } from 'vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { ref, computed, onMounted, onUnmounted, getCurrentInstance, watch } from 'vue';
 
 const props = defineProps({
     contest: Object,
@@ -10,6 +10,7 @@ const props = defineProps({
     nowWatching: Object,
     pastWinners: Array,
     hallOfFame: Array,
+    allTimeWatchers: Array,
 });
 
 const { proxy } = getCurrentInstance();
@@ -19,9 +20,24 @@ const TWITCH_CHANNEL = 'defraglive';
 
 // Live countdown to the end of the period.
 const now = ref(Date.now());
+const receivedAt = ref(Date.now());
 let timer = null;
-onMounted(() => { timer = setInterval(() => { now.value = Date.now(); }, 1000); });
-onUnmounted(() => { if (timer) clearInterval(timer); });
+let refreshTimer = null;
+onMounted(() => {
+    timer = setInterval(() => { now.value = Date.now(); }, 1000);
+    refreshTimer = setInterval(() => {
+        router.reload({
+            only: ['leaderboard', 'totalTickets', 'myEntry', 'nowWatching'],
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, 30000);
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+    if (refreshTimer) clearInterval(refreshTimer);
+});
+watch(() => props.nowWatching, () => { receivedAt.value = Date.now(); });
 
 const timeLeft = computed(() => {
     if (!props.contest?.ends_at) return null;
@@ -46,10 +62,70 @@ const fmtWatch = (seconds) => {
     return `${s}s`;
 };
 
-const maxSeconds = computed(() => Math.max(1, ...(props.leaderboard || []).map(e => e.seconds || 0)));
+const liveDelta = computed(() => Math.max(0, Math.floor((now.value - receivedAt.value) / 1000)));
+const entrySeconds = (entry) => Math.max(0, Number(entry?.seconds || 0)) + (entry?.is_current ? liveDelta.value : 0);
+const currentWatchSeconds = computed(() => props.nowWatching ? entrySeconds({
+    seconds: props.nowWatching.seconds,
+    is_current: true,
+}) : 0);
+const maxSeconds = computed(() => Math.max(1, ...(props.leaderboard || []).map(entrySeconds)));
 const odds = (tickets) => props.totalTickets > 0 ? (tickets / props.totalTickets * 100) : 0;
 const photo = (u) => u?.profile_photo_path ? '/storage/' + u.profile_photo_path : '/images/null.jpg';
 const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300' : i === 2 ? 'text-amber-600' : 'text-gray-500';
+
+// All-time watch stats: lazy Inertia prop, fetched when the view is expanded.
+// Loads 40 rows at a time; scrolling near the bottom of the list fetches the
+// next 40 (the server just re-slices with a bigger limit).
+const WATCHERS_PAGE = 40;
+const showAllTime = ref(false);
+const allTimeLoading = ref(false);
+const watchersLimit = ref(0); // last limit actually requested
+const watchersDone = computed(() =>
+    watchersLimit.value > 0 && (props.allTimeWatchers?.length ?? 0) < watchersLimit.value);
+
+const fetchWatchers = (limit, onDone) => {
+    allTimeLoading.value = true;
+    router.reload({
+        only: ['allTimeWatchers'],
+        data: { watchers_limit: limit },
+        preserveScroll: true,
+        preserveState: true,
+        onFinish: () => { allTimeLoading.value = false; watchersLimit.value = limit; onDone?.(); },
+    });
+};
+const toggleAllTime = () => {
+    if (showAllTime.value) { showAllTime.value = false; return; }
+    if (props.allTimeWatchers) { showAllTime.value = true; return; }
+    fetchWatchers(WATCHERS_PAGE, () => { showAllTime.value = true; });
+};
+const onWatchersScroll = (e) => {
+    const el = e.target;
+    if (allTimeLoading.value || watchersDone.value) return;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+        fetchWatchers(watchersLimit.value + WATCHERS_PAGE);
+    }
+};
+
+// Long durations read better with days: "3d 7h", then "5h 12m", then "42m".
+const fmtLong = (seconds) => {
+    const s = Math.max(0, Math.floor(seconds || 0));
+    const d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600), m = Math.floor((s % 3600) / 60);
+    if (d) return `${d}d ${h}h`;
+    if (h) return `${h}h ${m}m`;
+    return `${m}m`;
+};
+
+// How a past contest's prize was settled (see DefragliveContest statuses).
+const statusLabel = (s) => ({
+    paid: 'paid',
+    donated: 'donated to the site',
+    forwarded: 'forwarded to next winner',
+}[s] || 'payout pending');
+const statusColor = (s) => ({
+    paid: 'text-emerald-500',
+    donated: 'text-sky-400',
+    forwarded: 'text-indigo-400',
+}[s] || 'text-amber-500');
 </script>
 
 <template>
@@ -127,6 +203,7 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                                 <div class="text-[11px] uppercase tracking-wide text-gray-300">Now spectating</div>
                                 <div class="text-2xl md:text-3xl font-black leading-tight" v-html="q3tohtml(nowWatching.name)"></div>
                                 <div v-if="nowWatching.mapname" class="text-sm text-gray-300 mt-0.5">on <span class="font-semibold text-white">{{ nowWatching.mapname }}</span></div>
+                                <div class="text-xs text-purple-200 mt-1">Watched for {{ fmtWatch(currentWatchSeconds) }}</div>
                             </template>
                             <template v-else>
                                 <div class="text-xl font-black text-white">DefragLive</div>
@@ -160,6 +237,7 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                         <span class="text-gray-400">Now spectating</span>
                         <span class="font-bold" v-html="q3tohtml(nowWatching.name)"></span>
                         <span v-if="nowWatching.mapname" class="text-gray-500">on {{ nowWatching.mapname }}</span>
+                        <span class="text-purple-300 font-semibold">for {{ fmtWatch(currentWatchSeconds) }}</span>
                     </div>
                 </div>
 
@@ -169,6 +247,12 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                             {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ contest.prize_amount }}{{ contest.prize_currency !== 'USD' ? ' ' + contest.prize_currency : '' }}
                         </div>
                         <div class="text-sm font-bold uppercase tracking-widest text-gray-300">prize</div>
+                        <!-- Pool transparency: base prize vs what previous winners forwarded in -->
+                        <div v-if="contest.carried_over_amount > 0" class="text-[11px] text-purple-200/90 mt-1 leading-snug">
+                            {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ (contest.prize_amount - contest.carried_over_amount).toFixed(2) }} base
+                            + {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ contest.carried_over_amount.toFixed(2) }}
+                            carried over from previous winners
+                        </div>
                     </div>
                     <div v-if="timeLeft && !timeLeft.ended" class="flex gap-2.5 font-mono">
                         <div v-for="part in [['d', timeLeft.d], ['h', timeLeft.h], ['m', timeLeft.m], ['s', timeLeft.s]]" :key="part[0]"
@@ -195,7 +279,7 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
             </div>
             <div>
                 <div class="text-xs uppercase text-gray-500">Watched</div>
-                <div class="text-2xl font-black text-white">{{ fmtWatch(myEntry.seconds) }}</div>
+                <div class="text-2xl font-black text-white">{{ fmtWatch(entrySeconds(myEntry)) }}</div>
             </div>
             <div>
                 <div class="text-xs uppercase text-gray-500">Tickets</div>
@@ -225,15 +309,16 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                         <component :is="e.user ? Link : 'span'" :href="e.user ? `/profile/${e.user.id}` : undefined"
                             class="font-semibold truncate block" :class="e.user ? 'hover:underline' : ''">
                             <span v-html="q3tohtml(e.name)"></span>
+                            <span v-if="e.is_current" class="ml-2 text-[10px] uppercase tracking-wider text-red-400">Live</span>
                         </component>
                         <div class="mt-1 h-1.5 rounded-full bg-gray-800 overflow-hidden">
                             <div class="h-full rounded-full bg-gradient-to-r from-purple-500 to-emerald-400"
-                                :style="{ width: Math.max(3, (e.seconds / maxSeconds) * 100) + '%' }"></div>
+                                :style="{ width: Math.max(3, (entrySeconds(e) / maxSeconds) * 100) + '%' }"></div>
                         </div>
                     </div>
 
                     <div class="text-right shrink-0">
-                        <div class="font-bold text-white tabular-nums">{{ fmtWatch(e.seconds) }}</div>
+                        <div class="font-bold text-white tabular-nums">{{ fmtWatch(entrySeconds(e)) }}</div>
                         <div class="text-xs text-gray-500">{{ e.tickets }} tickets &middot; {{ odds(e.tickets).toFixed(1) }}%</div>
                     </div>
                 </div>
@@ -244,22 +329,42 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
             </div>
         </div>
 
-        <!-- Past winners -->
+        <!-- Past winners - vertical timeline: center line, cards alternating
+             left/right, newest draw at the top. Collapses to a single left-lined
+             column on mobile. -->
         <div v-if="pastWinners.length">
-            <h2 class="font-bold text-gray-300 mb-3">Past winners</h2>
-            <div class="grid gap-2 sm:grid-cols-2">
+            <h2 class="font-bold text-gray-300 mb-4">Past winners</h2>
+            <div class="relative">
+                <div class="absolute top-1 bottom-1 left-4 sm:left-1/2 w-px bg-gradient-to-b from-purple-400/70 via-white/20 to-transparent"></div>
                 <div v-for="(w, i) in pastWinners" :key="i"
-                    class="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/40 backdrop-blur-sm px-4 py-3">
-                    <div class="min-w-0">
-                        <component :is="w.winner_user_id ? Link : 'span'" :href="w.winner_user_id ? `/profile/${w.winner_user_id}` : undefined"
-                            class="font-semibold truncate block">
-                            <span v-html="q3tohtml(w.winner_name)"></span>
-                        </component>
-                        <div class="text-xs text-gray-500 truncate">{{ w.title }}</div>
-                    </div>
-                    <div class="text-right shrink-0">
-                        <div class="font-bold text-emerald-400">{{ w.prize_currency === 'USD' ? '$' : '' }}{{ w.prize_amount }}</div>
-                        <div class="text-[11px] uppercase" :class="w.status === 'paid' ? 'text-emerald-500' : 'text-amber-500'">{{ w.status }}</div>
+                    class="relative pl-10 pb-6 sm:pl-0 sm:pb-8 sm:w-[calc(50%-1.5rem)]"
+                    :class="[i % 2 === 0 ? 'sm:mr-auto' : 'sm:ml-auto', i > 0 ? 'sm:-mt-[4.5rem]' : '']">
+                    <!-- node on the line -->
+                    <div class="absolute top-5 left-4 -translate-x-1/2 w-2.5 h-2.5 rounded-full bg-purple-400 ring-4 ring-purple-400/20"
+                        :class="i % 2 === 0 ? 'sm:left-auto sm:-right-6 sm:translate-x-1/2' : 'sm:-left-6 sm:-translate-x-1/2'"></div>
+                    <!-- connector from card to the line -->
+                    <div class="hidden sm:block absolute top-[1.35rem] w-6 h-px bg-white/15"
+                        :class="i % 2 === 0 ? '-right-6' : '-left-6'"></div>
+                    <div class="text-[11px] text-gray-500 mb-1" :class="i % 2 === 0 ? 'sm:text-right' : ''">{{ w.drawn_at }}</div>
+                    <div class="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/40 backdrop-blur-sm px-4 py-3">
+                        <div class="min-w-0">
+                            <component :is="w.winner_user_id ? Link : 'span'" :href="w.winner_user_id ? `/profile/${w.winner_user_id}` : undefined"
+                                class="font-semibold truncate block">
+                                <span v-html="q3tohtml(w.winner_name)"></span>
+                            </component>
+                            <div class="text-xs text-gray-500 truncate">{{ w.title }}</div>
+                            <div v-if="w.winner_seconds" class="text-xs text-purple-300/80 truncate">
+                                {{ fmtWatch(w.winner_seconds) }} watched
+                                <template v-if="w.total_tickets"> · {{ w.winner_tickets }}/{{ w.total_tickets }} tickets ({{ (w.winner_tickets / w.total_tickets * 100).toFixed(1) }}% odds)</template>
+                            </div>
+                        </div>
+                        <div class="text-right shrink-0">
+                            <div class="font-bold text-emerald-400">{{ w.prize_currency === 'USD' ? '$' : '' }}{{ w.prize_amount }}</div>
+                            <div v-if="w.carried_over_amount > 0" class="text-[10px] text-purple-300/80 leading-tight">
+                                incl. {{ w.prize_currency === 'USD' ? '$' : '' }}{{ w.carried_over_amount.toFixed(2) }} carried over
+                            </div>
+                            <div class="text-[11px] uppercase" :class="statusColor(w.status)">{{ statusLabel(w.status) }}</div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -282,9 +387,44 @@ const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300'
                     <div class="text-right shrink-0">
                         <div class="font-bold text-white">{{ h.wins }} {{ h.wins === 1 ? 'win' : 'wins' }}</div>
                         <div class="text-xs text-emerald-400">{{ h.currency === 'USD' ? '$' : '' }}{{ h.total.toFixed(2) }}{{ h.currency !== 'USD' ? ' ' + h.currency : '' }} won</div>
+                        <div v-if="h.seconds" class="text-[11px] text-purple-300/80">{{ fmtWatch(h.seconds) }} watched</div>
                     </div>
                 </div>
             </div>
+        </div>
+
+        <!-- All-time watch stats - every watcher ever, loaded on demand -->
+        <div class="mt-8">
+            <button @click="toggleAllTime"
+                class="w-full flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-black/40 backdrop-blur-sm px-4 py-3 text-sm font-semibold text-gray-300 hover:bg-white/5 transition-colors">
+                <span>📊</span>
+                <span>{{ showAllTime ? 'Hide all-time watch stats' : 'Show all-time watch stats' }}</span>
+                <svg class="w-4 h-4 transition-transform" :class="showAllTime ? 'rotate-180' : ''" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                <svg v-if="allTimeLoading" class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" class="opacity-25"/><path d="M22 12a10 10 0 0 1-10 10" class="opacity-75"/></svg>
+            </button>
+            <div v-if="showAllTime && allTimeWatchers?.length" class="mt-3 rounded-2xl border border-white/10 bg-black/40 backdrop-blur-sm overflow-hidden shadow-2xl">
+                <div class="px-4 py-2.5 text-xs text-gray-500 border-b border-white/5">
+                    Everyone who has ever been watched on the DefragLive stream - total spectated time across all contests.
+                </div>
+                <div class="max-h-96 overflow-y-auto divide-y divide-white/5" @scroll.passive="onWatchersScroll">
+                    <div v-for="(t, i) in allTimeWatchers" :key="i" class="flex items-center gap-3 px-4 py-2.5 hover:bg-white/5">
+                        <div class="w-7 text-center font-black" :class="rankColor(i)">{{ i + 1 }}</div>
+                        <img :src="photo(t.user)" class="w-7 h-7 rounded-full object-cover shrink-0" alt="">
+                        <img v-if="t.user?.country" :src="`/images/flags/${t.user.country}.png`" class="w-5 h-3.5 shrink-0" onerror="this.style.display='none'">
+                        <component :is="t.user ? Link : 'span'" :href="t.user ? `/profile/${t.user.id}` : undefined"
+                            class="min-w-0 flex-1 font-semibold truncate text-sm" :class="t.user ? 'hover:underline' : ''">
+                            <span v-html="q3tohtml(t.name)"></span>
+                        </component>
+                        <div class="text-right shrink-0">
+                            <div class="font-bold text-purple-300 text-sm">{{ fmtLong(t.seconds) }}</div>
+                            <div class="text-[11px] text-gray-500">{{ t.sessions }} {{ t.sessions === 1 ? 'session' : 'sessions' }}</div>
+                        </div>
+                    </div>
+                    <div v-if="allTimeLoading" class="py-3 text-center text-xs text-gray-500">Loading more…</div>
+                    <div v-else-if="watchersDone" class="py-3 text-center text-xs text-gray-600">That's everyone!</div>
+                </div>
+            </div>
+            <div v-else-if="showAllTime" class="mt-3 text-center text-sm text-gray-500 py-4">No watch time recorded yet.</div>
         </div>
     </div>
 </template>

--- a/resources/js/Pages/Donations/Index.vue
+++ b/resources/js/Pages/Donations/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link } from '@inertiajs/vue3';
 import { Teleport } from 'vue';
 
 const props = defineProps({
@@ -437,6 +437,36 @@ const formatDate = (dateString) => {
     });
 };
 
+// --- Donation row presentation helpers -------------------------------------
+
+// Split a note into text/link parts so URLs render as safe <a> tags (we never
+// v-html user content).
+const noteParts = (note) => {
+    const parts = [];
+    const re = /https?:\/\/[^\s]+/g;
+    let last = 0, m;
+    while ((m = re.exec(note)) !== null) {
+        if (m.index > last) parts.push({ link: false, v: note.slice(last, m.index) });
+        parts.push({ link: true, v: m[0] });
+        last = m.index + m[0].length;
+    }
+    if (last < note.length) parts.push({ link: false, v: note.slice(last) });
+    return parts;
+};
+
+// Prizes donated back from the DefragLive watch contest get a special badge
+// (the note is machine-written by the admin "Resolve prize" action).
+const isContestDonation = (note) => (note || '').startsWith('DefragLive contest prize donated back');
+
+// Fallback avatar: initials on a hue picked from the donor's name, so rows
+// without a linked account still get a distinct, stable color.
+const donorInitials = (name) => (name || 'A').trim().slice(0, 2).toUpperCase();
+const donorHue = (name) => {
+    let h = 0;
+    for (const c of (name || 'anon')) h = (h * 31 + c.charCodeAt(0)) % 360;
+    return h;
+};
+
 // Currency symbols
 const currencySymbol = computed(() => {
     const symbols = {
@@ -703,14 +733,18 @@ const getYearProgress = (year, yearTotal) => {
                                 </svg>
                                 <h3 class="text-2xl font-bold text-white">{{ yearData.year }}</h3>
                             </div>
-                            <div class="flex flex-col items-end gap-1">
-                                <div class="text-2xl font-bold text-green-400">{{ currencySymbol }}{{ yearData.total.toFixed(2) }}</div>
-                                <div class="flex gap-3 text-xs text-gray-400">
-                                    <span v-if="yearData.donationsTotal > 0" class="flex items-center gap-1">
+                            <div class="flex flex-col items-end gap-2">
+                                <div class="text-4xl font-black text-green-400 tabular-nums leading-none drop-shadow-[0_0_12px_rgba(34,197,94,0.35)]">
+                                    {{ currencySymbol }}{{ yearData.total.toFixed(2) }}
+                                </div>
+                                <div class="flex gap-2">
+                                    <span v-if="yearData.donationsTotal > 0"
+                                        class="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-500/10 border border-green-500/25 text-xs font-semibold text-green-300 tabular-nums">
                                         <span class="w-2 h-2 bg-green-500 rounded-full"></span>
                                         {{ currencySymbol }}{{ yearData.donationsTotal.toFixed(2) }} crowd
                                     </span>
-                                    <span v-if="yearData.selfRaisedTotal > 0" class="flex items-center gap-1">
+                                    <span v-if="yearData.selfRaisedTotal > 0"
+                                        class="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-purple-500/10 border border-purple-500/25 text-xs font-semibold text-purple-300 tabular-nums">
                                         <span class="w-2 h-2 bg-purple-500 rounded-full"></span>
                                         {{ currencySymbol }}{{ yearData.selfRaisedTotal.toFixed(2) }} self
                                     </span>
@@ -725,21 +759,21 @@ const getYearProgress = (year, yearTotal) => {
                             <!-- Crowd-raised portion (green) -->
                             <div
                                 v-if="yearData.donationsTotal > 0"
-                                class="absolute h-full bg-green-500 transition-all duration-1000"
+                                class="absolute h-full bg-gradient-to-r from-green-600 to-emerald-400 transition-all duration-1000"
                                 :style="{ width: ((yearData.donationsTotal / getYearGoal(yearData.year).amount) * 100) + '%' }"
                             ></div>
                             <!-- Self-raised portion (purple) -->
                             <div
                                 v-if="yearData.selfRaisedTotal > 0"
-                                class="absolute h-full bg-purple-500 transition-all duration-1000"
+                                class="absolute h-full bg-gradient-to-r from-purple-600 to-fuchsia-400 transition-all duration-1000"
                                 :style="{ left: ((yearData.donationsTotal / getYearGoal(yearData.year).amount) * 100) + '%', width: ((yearData.selfRaisedTotal / getYearGoal(yearData.year).amount) * 100) + '%' }"
                             ></div>
                             <!-- Percentage label -->
                             <div class="absolute inset-0 flex items-center justify-end pr-3">
-                                <span class="text-white font-bold text-xs">{{ getYearProgress(yearData.year, yearData.total).percentage }}%</span>
+                                <span class="text-white font-black text-sm tabular-nums drop-shadow">{{ getYearProgress(yearData.year, yearData.total).percentage }}%</span>
                             </div>
                         </div>
-                        <div class="text-xs text-gray-400 mt-1 text-center">
+                        <div class="text-xs font-semibold text-gray-400 mt-1.5 text-center tabular-nums">
                             Goal: {{ currencySymbol }}{{ getYearProgress(yearData.year, yearData.total).goal }}
                         </div>
                     </div>
@@ -748,41 +782,90 @@ const getYearProgress = (year, yearTotal) => {
                     <div v-if="isYearExpanded(yearData.year)">
                         <!-- Donations -->
                         <div v-if="yearData.donations.length > 0" class="mb-4">
-                            <h4 class="text-sm font-bold text-gray-300 mb-2">Donations</h4>
-                            <div class="space-y-1.5">
+                            <div class="flex items-center gap-2.5 mb-3">
+                                <span class="w-1 h-5 rounded-full bg-green-500"></span>
+                                <h4 class="text-base font-black text-white uppercase tracking-wider">Donations</h4>
+                                <span class="px-2 py-0.5 rounded-full bg-green-500/10 border border-green-500/25 text-xs font-semibold text-green-300 tabular-nums">{{ yearData.donations.length }}</span>
+                            </div>
+                            <div class="space-y-2">
                                 <div
                                     v-for="donation in yearData.donations"
                                     :key="donation.id"
-                                    class="p-2 bg-black/20 rounded-lg border border-green-500/20"
+                                    class="flex items-start gap-3 p-3 bg-black/30 rounded-xl border transition-colors"
+                                    :class="isContestDonation(donation.note)
+                                        ? 'border-purple-500/30 hover:border-purple-400/50'
+                                        : 'border-green-500/20 hover:border-green-400/40'"
                                 >
-                                    <div class="flex items-center justify-between">
-                                        <div class="flex items-center gap-3">
-                                            <span class="text-sm font-medium text-white">{{ donation.donor_name || 'Anonymous Donor' }}</span>
-                                            <span class="text-xs text-gray-500">{{ formatDate(donation.donation_date) }}</span>
+                                    <!-- Avatar: profile photo for linked accounts, tinted initials otherwise -->
+                                    <component :is="donation.user ? Link : 'div'"
+                                        :href="donation.user ? `/profile/${donation.user.id}` : undefined"
+                                        class="shrink-0">
+                                        <img v-if="donation.user?.profile_photo_path"
+                                            :src="'/storage/' + donation.user.profile_photo_path"
+                                            class="w-10 h-10 rounded-full object-cover ring-2 ring-white/10" alt="">
+                                        <div v-else
+                                            class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-black text-white/90 ring-2 ring-white/10"
+                                            :style="{ background: `linear-gradient(135deg, hsl(${donorHue(donation.donor_name)}, 45%, 32%), hsl(${(donorHue(donation.donor_name) + 40) % 360}, 45%, 22%))` }">
+                                            {{ donorInitials(donation.donor_name) }}
                                         </div>
-                                        <div class="text-sm font-bold text-green-400">
-                                            {{ currencySymbol }}{{ convertCurrency(donation.amount, donation.currency).toFixed(2) }}
+                                    </component>
+                                    <div class="min-w-0 flex-1">
+                                        <div class="flex items-center gap-2 flex-wrap">
+                                            <component :is="donation.user ? Link : 'span'"
+                                                :href="donation.user ? `/profile/${donation.user.id}` : undefined"
+                                                class="font-bold text-white truncate" :class="donation.user ? 'hover:underline' : ''">
+                                                {{ donation.donor_name || 'Anonymous Donor' }}
+                                            </component>
+                                            <Link v-if="isContestDonation(donation.note)" href="/defraglive/contest"
+                                                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-purple-500/15 border border-purple-400/30 text-[11px] font-semibold text-purple-300 hover:bg-purple-500/25 transition-colors">
+                                                🎁 DefragLive prize
+                                            </Link>
+                                        </div>
+                                        <div class="text-xs text-gray-500 mt-0.5">{{ formatDate(donation.donation_date) }}</div>
+                                        <div v-if="donation.note" class="mt-1.5 px-3 py-1.5 rounded-lg bg-white/5 text-sm text-gray-300">
+                                            <template v-for="(part, pi) in noteParts(donation.note)" :key="pi">
+                                                <a v-if="part.link" :href="part.v" class="text-blue-400 hover:text-blue-300 underline break-all">{{ part.v }}</a>
+                                                <span v-else>{{ part.v }}</span>
+                                            </template>
                                         </div>
                                     </div>
-                                    <div v-if="donation.note" class="mt-1.5 pl-3 border-l-2 border-green-500/30 text-xs text-gray-400 italic">{{ donation.note }}</div>
+                                    <div class="text-lg font-black text-green-400 shrink-0 tabular-nums text-right min-w-[6.5rem]">
+                                        {{ currencySymbol }}{{ convertCurrency(donation.amount, donation.currency).toFixed(2) }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
 
                         <!-- Self-Raised Money -->
                         <div v-if="yearData.selfRaised.length > 0">
-                            <h4 class="text-sm font-bold text-gray-300 mb-2">Self-Raised (YouTube/Twitch)</h4>
-                            <div class="space-y-1.5">
+                            <div class="flex items-center gap-2.5 mb-3 mt-6 pt-5 border-t border-white/10">
+                                <span class="w-1 h-5 rounded-full bg-purple-500"></span>
+                                <h4 class="text-base font-black text-white uppercase tracking-wider">Self-Raised</h4>
+                                <span class="text-xs text-gray-500 font-semibold">YouTube / Twitch</span>
+                                <span class="px-2 py-0.5 rounded-full bg-purple-500/10 border border-purple-500/25 text-xs font-semibold text-purple-300 tabular-nums">{{ yearData.selfRaised.length }}</span>
+                            </div>
+                            <div class="space-y-2">
                                 <div
                                     v-for="money in yearData.selfRaised"
                                     :key="money.id"
-                                    class="flex items-center justify-between p-2 bg-black/20 rounded-lg border border-purple-500/20"
+                                    class="flex items-start gap-3 p-3 bg-black/30 rounded-xl border border-purple-500/20 hover:border-purple-400/40 transition-colors"
                                 >
-                                    <div class="flex items-center gap-3">
-                                        <span class="text-sm font-medium text-white">{{ money.source }}</span>
-                                        <span class="text-xs text-gray-500">{{ formatDate(money.earned_date) }}</span>
+                                    <!-- Source icon: brand-tinted circle (YouTube red, Twitch purple) -->
+                                    <div class="shrink-0 w-10 h-10 rounded-full flex items-center justify-center ring-2 ring-white/10"
+                                        :class="(money.source || '').toLowerCase().includes('youtube')
+                                            ? 'bg-red-600/25 text-red-300'
+                                            : (money.source || '').toLowerCase().includes('twitch')
+                                                ? 'bg-purple-600/25 text-purple-300'
+                                                : 'bg-white/10 text-gray-300'">
+                                        <svg v-if="(money.source || '').toLowerCase().includes('youtube')" class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31 31 0 0 0 0 12a31 31 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31 31 0 0 0 24 12a31 31 0 0 0-.5-5.8zM9.6 15.6V8.4L15.8 12l-6.2 3.6z"/></svg>
+                                        <svg v-else-if="(money.source || '').toLowerCase().includes('twitch')" class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M11.6 4.7h1.7v5h-1.7m4.6-5h1.7v5h-1.7M7 0 2.8 4.2v15.1h5V24l4.2-4.7h3.4L23 11.8V0M21.3 11 18 14.4h-3.4l-3 3v-3H7.8V1.7h13.5z"/></svg>
+                                        <span v-else class="font-black text-sm">{{ (money.source || '?').slice(0, 1).toUpperCase() }}</span>
                                     </div>
-                                    <div class="text-sm font-bold text-purple-400">
+                                    <div class="min-w-0 flex-1">
+                                        <div class="font-bold text-white truncate">{{ money.source }}</div>
+                                        <div class="text-xs text-gray-500 mt-0.5">{{ formatDate(money.earned_date) }}</div>
+                                    </div>
+                                    <div class="text-lg font-black text-purple-400 shrink-0 tabular-nums text-right min-w-[6.5rem]">
                                         {{ currencySymbol }}{{ convertCurrency(money.amount, money.currency).toFixed(2) }}
                                     </div>
                                 </div>

--- a/tests/Feature/DefragliveWatchServiceTest.php
+++ b/tests/Feature/DefragliveWatchServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\DefragliveContest;
+use App\Models\DefragliveWatchSession;
+use App\Services\DefragliveWatchService;
+use Illuminate\Support\Carbon;
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+test('leaderboard credits only the session time inside the contest window', function () {
+    Carbon::setTestNow('2026-07-10 12:00:00');
+
+    $contest = DefragliveContest::create([
+        'title' => 'Boundary test',
+        'starts_at' => '2026-07-10 10:00:00',
+        'ends_at' => '2026-07-10 11:00:00',
+        'status' => DefragliveContest::STATUS_ACTIVE,
+    ]);
+
+    foreach ([
+        ['2026-07-10 09:50:00', '2026-07-10 10:10:00'],
+        ['2026-07-10 10:50:00', '2026-07-10 11:10:00'],
+        ['2026-07-10 11:10:00', '2026-07-10 11:20:00'],
+    ] as [$start, $end]) {
+        DefragliveWatchSession::create([
+            'player_name' => '^1Runner',
+            'player_name_clean' => 'runner',
+            'seconds' => 1200,
+            'started_at' => $start,
+            'last_seen_at' => $end,
+            'ended_at' => $end,
+        ]);
+    }
+
+    $entries = app(DefragliveWatchService::class)->leaderboard($contest, null);
+
+    expect($entries)->toHaveCount(1)
+        ->and($entries[0]['seconds'])->toBe(1200)
+        ->and($entries[0]['tickets'])->toBe(20);
+});
+
+test('leaderboard counts an open session live and clips its start to the contest', function () {
+    Carbon::setTestNow('2026-07-10 10:30:00');
+
+    $contest = DefragliveContest::create([
+        'title' => 'Open session test',
+        'starts_at' => '2026-07-10 10:00:00',
+        'ends_at' => '2026-07-10 11:00:00',
+        'status' => DefragliveContest::STATUS_ACTIVE,
+    ]);
+
+    DefragliveWatchSession::create([
+        'player_name' => '^2LiveRunner',
+        'player_name_clean' => 'liverunner',
+        'seconds' => 0,
+        'started_at' => '2026-07-10 09:50:00',
+        'last_seen_at' => '2026-07-10 10:29:00',
+        'ended_at' => null,
+    ]);
+
+    $entries = app(DefragliveWatchService::class)->leaderboard($contest, null);
+
+    expect($entries)->toHaveCount(1)
+        ->and($entries[0]['seconds'])->toBe(1800)
+        ->and($entries[0]['tickets'])->toBe(30);
+});


### PR DESCRIPTION
## DefragLive contest - public page
- Past winners redesigned as a vertical timeline (center line, alternating cards, newest first; single column on mobile) with draw date, watch time, tickets and odds per winner
- Hall of Fame shows each winner's total watched time
- Prize pool transparency: hero shows "base + carried over from previous winners"; past winner cards show "incl. X carried over"
- All-time watch stats: expandable list of everyone ever watched, lazy-loaded 40 rows at a time with infinite scroll (server cap 400)
- Live-ticking "Now spectating" duration, current-watcher highlight in the leaderboard, 30s auto-refresh

## DefragLive contest - admin
- "Mark paid" replaced by "Resolve prize": paid / donated to the site / forwarded to the next winner
- Donated optionally records an approved SiteDonation in the winner's name (checkbox, default on) - with the contest URL in its note and the winner's email as donor_email, so it counts toward isDonor()/getDonationTotal() donor stats
- Forwarded adds the prize to the next upcoming contest's pool, tracked in the new `carried_over_amount` column

## Donation History page
- Donation rows are proper cards: avatar (profile photo + profile link for linked accounts, tinted-initials circle otherwise), bold name, date, and notes in a quote block with URLs rendered as safe clickable links (no v-html)
- DefragLive contest prize give-backs get a purple border and a "DefragLive prize" badge linking to the contest page
- Self-Raised rows match the card style with YouTube/Twitch brand icons
- Real section headers (accent bar, uppercase, count chip) and a divider between sections
- Year header: bigger glowing total, crowd/self pill chips, gradient progress bars
- Amounts use tabular-nums in a fixed right-aligned column; DonationController eager-loads the linked user for avatars

## Service & tests
- `leaderboard()` clips sessions to the contest window (no watch-time leaking across rollovers) - covered by new feature tests
- `allTimeLeaderboard()` aggregates all sessions incl. live open ones
- phpunit now forces the separate mysql `testing` DB - a test run can never wipe the dev database again

## Deploy note
Run `php artisan migrate` (adds `carried_over_amount`, default 0).
