### PR TITLE
Homepage contest card + notifications button color fix

### DIFF
--- a/app/Http/Controllers/DefragliveMapLogController.php
+++ b/app/Http/Controllers/DefragliveMapLogController.php
@@ -20,8 +20,14 @@ use Inertia\Inertia;
  */
 class DefragliveMapLogController extends Controller
 {
-    public function index()
+    public function index(\Illuminate\Http\Request $request)
     {
+        // Lazy pagination: the page renders the first chunk of blocks and
+        // grows blocks_limit via Inertia partial reloads as the visitor
+        // scrolls (same pattern as the contest page's all-time stats). The
+        // 800-session window still bounds the grouping work itself.
+        $blocksLimit = max(1, min(300, (int) $request->input('blocks_limit', 25)));
+
         // Most recent sessions, oldest-first so we can group in order, then we
         // present the blocks newest-first.
         $sessions = DefragliveWatchSession::query()
@@ -76,8 +82,11 @@ class DefragliveMapLogController extends Controller
             $blocks[] = $cur;
         }
 
-        // Newest first.
+        // Newest first, then slice to the requested window - thumbnail/user
+        // resolution below only runs for the blocks actually sent.
         $blocks = array_reverse($blocks);
+        $blocksTotal = count($blocks);
+        $blocks = array_slice($blocks, 0, $blocksLimit);
 
         // Batch-resolve map thumbnails and player users (no N+1).
         $thumbs = Map::whereIn('name', collect($blocks)->pluck('map')->unique()->values())
@@ -120,6 +129,7 @@ class DefragliveMapLogController extends Controller
 
         return Inertia::render('DefragliveMapLog', [
             'blocks' => $payload,
+            'blocksTotal' => $blocksTotal,
         ]);
     }
 }

--- a/resources/js/Components/DefragliveContestBanner.vue
+++ b/resources/js/Components/DefragliveContestBanner.vue
@@ -3,9 +3,12 @@ import { Link, usePage } from '@inertiajs/vue3';
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 
 // Sitewide nudge toward the contest while one is live, fed by the
-// `defragliveContest` shared Inertia prop (cached). Two layouts:
+// `defragliveContest` shared Inertia prop (cached). Three layouts:
 //  - variant="floating" (default): dismissible fixed card, bottom-left.
 //  - variant="bar": a full-width one-line strip to drop into the footer area.
+//  - variant="hero": in-flow card with the prize and a segmented live
+//    countdown, made for the homepage. Not dismissible - it always shows
+//    the currently active contest (renders nothing when none is live).
 const props = defineProps({
     variant: { type: String, default: 'floating' },
 });
@@ -50,11 +53,52 @@ const prize = computed(() => {
     const c = contest.value;
     return (c.prize_currency === 'USD' ? '$' : '') + c.prize_amount + (c.prize_currency !== 'USD' ? ' ' + c.prize_currency : '');
 });
+
+// Segmented countdown for the hero variant's ticker boxes.
+const countdown = computed(() => {
+    if (!contest.value?.ends_at) return null;
+    const ms = new Date(contest.value.ends_at).getTime() - now.value;
+    if (ms <= 0) return null;
+    const s = Math.floor(ms / 1000);
+    return {
+        d: Math.floor(s / 86400),
+        h: Math.floor((s % 86400) / 3600),
+        m: Math.floor((s % 3600) / 60),
+        s: s % 60,
+    };
+});
 </script>
 
 <template>
+    <!-- Homepage hero card: prize + segmented live countdown -->
+    <Link v-if="variant === 'hero' && contest" href="/defraglive/contest"
+        class="group relative z-10 flex items-center gap-4 flex-wrap justify-center sm:justify-between px-5 py-3.5 bg-purple-950/70 backdrop-blur-sm border border-[#9147ff]/50 rounded-xl hover:bg-purple-900/60 hover:border-[#9147ff]/80 hover:shadow-[0_0_50px_rgba(145,71,255,0.35)] transition-all shadow-[0_4px_20px_rgba(0,0,0,0.4),0_0_30px_rgba(145,71,255,0.2)]">
+        <div class="absolute -top-2 -right-2 px-2.5 py-0.5 bg-gradient-to-r from-[#9147ff] to-fuchsia-500 rounded-full text-[10px] font-black text-white shadow-lg">LIVE</div>
+        <div class="flex items-center gap-3 min-w-0">
+            <span class="text-2xl leading-none">🏆</span>
+            <div class="min-w-0">
+                <div class="text-xs uppercase font-bold tracking-wider text-purple-300">DefragLive Contest</div>
+                <div class="text-sm font-bold text-white truncate">
+                    Most watched player wins <span class="text-emerald-400">{{ prize }}</span>
+                </div>
+            </div>
+        </div>
+        <div class="flex items-center gap-3">
+            <div v-if="countdown" class="flex gap-1.5 font-mono">
+                <div v-for="part in [['d', countdown.d], ['h', countdown.h], ['m', countdown.m], ['s', countdown.s]]" :key="part[0]"
+                    class="bg-black/40 rounded-lg px-2 py-1 text-center min-w-[42px]">
+                    <div class="text-lg font-black text-white tabular-nums leading-none">{{ String(part[1]).padStart(2, '0') }}</div>
+                    <div class="text-[9px] font-bold uppercase tracking-widest text-purple-300">{{ part[0] }}</div>
+                </div>
+            </div>
+            <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform flex-shrink-0 text-purple-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+        </div>
+    </Link>
+
     <!-- Full-width one-line strip (footer) -->
-    <Link v-if="variant === 'bar' && contest" href="/defraglive/contest"
+    <Link v-else-if="variant === 'bar' && contest" href="/defraglive/contest"
         class="group block border-y border-[#9147ff]/30 bg-[#9147ff]/10 hover:bg-[#9147ff]/20 transition-colors">
         <div class="max-w-8xl mx-auto px-4 py-2.5 flex items-center justify-center gap-x-3 gap-y-1 flex-wrap text-sm text-center">
             <span class="text-lg leading-none">🏆</span>

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -42,7 +42,7 @@
             rankings: route().current('ranking') || route().current('community'),
             mapsmodels: route().current('maps') || route().current('maps.stats') || route().current('models.*'),
             demos: route().current('demos.*') || route().current('youtube'),
-            challenges: route().current('headhunter.*') || route().current('marketplace.*') || route().current('community.tasks'),
+            challenges: route().current('headhunter.*') || route().current('marketplace.*') || route().current('community.tasks') || route().current('defraglive.*'),
             tournaments: route().current('tournaments.*'),
             wiki: route().current('wiki.*'),
             bundles: route().current('bundles'),
@@ -60,6 +60,7 @@
             headhunter: route().current('headhunter.*'),
             marketplace: route().current('marketplace.*'),
             communityTasks: route().current('community.tasks'),
+            defragliveContest: route().current('defraglive.contest'),
         };
     });
 
@@ -850,6 +851,7 @@
                                     <DropdownLink :href="route('headhunter.index')" :active="navActive.headhunter">Headhunter</DropdownLink>
                                     <DropdownLink :href="route('marketplace.index')" :active="navActive.marketplace">Marketplace</DropdownLink>
                                     <DropdownLink :href="route('community.tasks')" :active="navActive.communityTasks">Community Tasks</DropdownLink>
+                                    <DropdownLink :href="route('defraglive.contest')" :active="navActive.defragliveContest">DefragLive Contest</DropdownLink>
                                 </template>
                             </Dropdown>
                         </div>
@@ -916,6 +918,7 @@
                                         <DropdownLink :href="route('headhunter.index')" :active="navActive.headhunter">Headhunter</DropdownLink>
                                         <DropdownLink :href="route('marketplace.index')" :active="navActive.marketplace">Marketplace</DropdownLink>
                                         <DropdownLink :href="route('community.tasks')" :active="navActive.communityTasks">Community Tasks</DropdownLink>
+                                        <DropdownLink :href="route('defraglive.contest')" :active="navActive.defragliveContest">DefragLive Contest</DropdownLink>
                                         <div class="border-t border-white/10 my-1.5"></div>
                                     </div>
                                     <!-- Items always in More (hidden inline below xl) -->

--- a/resources/js/Pages/DefragliveMapLog.vue
+++ b/resources/js/Pages/DefragliveMapLog.vue
@@ -1,19 +1,55 @@
 <script setup>
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import { ref, computed, onMounted, onUnmounted, getCurrentInstance } from 'vue';
 
 const props = defineProps({
     blocks: Array,
+    blocksTotal: Number,
 });
 
 const { proxy } = getCurrentInstance();
 const q3tohtml = proxy.q3tohtml;
 
+// Lazy pagination: 25 blocks per chunk, the next chunk loads when the visitor
+// scrolls near the page bottom (the server just re-slices with a bigger limit).
+const BLOCKS_PAGE = 25;
+const loadingMore = ref(false);
+// Set once a fetch stops growing the list (server cap reached) so the scroll
+// handler can't loop on re-requesting the same slice forever.
+const exhausted = ref(false);
+let requestedLimit = 0;
+const hasMore = computed(() =>
+    !exhausted.value && (props.blocks?.length ?? 0) < (props.blocksTotal ?? 0));
+const onScroll = () => {
+    if (loadingMore.value || !hasMore.value) return;
+    const el = document.documentElement;
+    if (window.innerHeight + window.scrollY < el.scrollHeight - 400) return;
+    loadingMore.value = true;
+    const before = props.blocks?.length ?? 0;
+    requestedLimit = Math.max(requestedLimit, before) + BLOCKS_PAGE;
+    router.reload({
+        only: ['blocks', 'blocksTotal'],
+        data: { blocks_limit: requestedLimit },
+        preserveScroll: true,
+        preserveState: true,
+        onFinish: () => {
+            loadingMore.value = false;
+            if ((props.blocks?.length ?? 0) <= before) exhausted.value = true;
+        },
+    });
+};
+
 // Tick so the open (live) block's duration keeps counting up.
 const now = ref(Date.now());
 let timer = null;
-onMounted(() => { timer = setInterval(() => { now.value = Date.now(); }, 1000); });
-onUnmounted(() => { if (timer) clearInterval(timer); });
+onMounted(() => {
+    timer = setInterval(() => { now.value = Date.now(); }, 1000);
+    window.addEventListener('scroll', onScroll, { passive: true });
+});
+onUnmounted(() => {
+    if (timer) clearInterval(timer);
+    window.removeEventListener('scroll', onScroll);
+});
 
 const photo = (u) => u?.profile_photo_path ? '/storage/' + u.profile_photo_path : '/images/null.jpg';
 
@@ -139,6 +175,9 @@ const byDay = computed(() => {
                     </div>
                 </div>
             </div>
+            <!-- Lazy-load tail: spinner while fetching the next chunk, quiet end note otherwise -->
+            <div v-if="loadingMore" class="py-6 text-center text-sm text-gray-500">Loading more…</div>
+            <div v-else-if="!hasMore && blocks?.length" class="py-6 text-center text-xs text-gray-600">That's the whole log we keep.</div>
         </div>
     </div>
 </template>

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -10,6 +10,7 @@
 <script setup>
     import { Head, usePage } from '@inertiajs/vue3';
     import { computed, ref } from 'vue';
+    import DefragliveContestBanner from '@/Components/DefragliveContestBanner.vue';
 
     const props = defineProps({
         maps: Array,
@@ -177,6 +178,12 @@
                                 </svg>
                             </Link>
                         </div>
+                    </div>
+
+                    <!-- Active DefragLive contest: prize + live countdown; hides
+                         itself automatically when no contest is running -->
+                    <div class="mt-3 max-w-3xl mx-auto">
+                        <DefragliveContestBanner variant="hero" />
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/NotificationsView.vue
+++ b/resources/js/Pages/NotificationsView.vue
@@ -429,15 +429,15 @@
 
                     <!-- Bulk Actions -->
                     <div class="flex items-center justify-end gap-2 px-3 py-1.5 bg-black/20 border-b border-white/10">
-                        <button @click="markAllAsRead" class="px-2.5 py-1 rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 text-yellow-400 font-semibold text-xs transition-all flex items-center gap-1.5">
+                        <button @click="markAllAsRead" class="px-2.5 py-1 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/30 text-green-400 font-semibold text-xs transition-all flex items-center gap-1.5">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                             </svg>
                             Mark All as Read
                         </button>
-                        <button @click="markAllAsUnread" class="px-2.5 py-1 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/30 text-green-400 font-semibold text-xs transition-all flex items-center gap-1.5">
+                        <button @click="markAllAsUnread" class="px-2.5 py-1 rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 text-yellow-400 font-semibold text-xs transition-all flex items-center gap-1.5">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
                             </svg>
                             Mark All as Unread
                         </button>
@@ -625,15 +625,15 @@
 
                     <!-- Bulk Actions -->
                     <div class="flex items-center justify-end gap-2 px-3 py-1.5 bg-black/20 border-b border-white/10">
-                        <button @click="markAllSystemAsRead" class="px-2.5 py-1 rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 text-yellow-400 font-semibold text-xs transition-all flex items-center gap-1.5">
+                        <button @click="markAllSystemAsRead" class="px-2.5 py-1 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/30 text-green-400 font-semibold text-xs transition-all flex items-center gap-1.5">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                             </svg>
                             Mark All as Read
                         </button>
-                        <button @click="markAllSystemAsUnread" class="px-2.5 py-1 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/30 text-green-400 font-semibold text-xs transition-all flex items-center gap-1.5">
+                        <button @click="markAllSystemAsUnread" class="px-2.5 py-1 rounded-lg bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 text-yellow-400 font-semibold text-xs transition-all flex items-center gap-1.5">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
                             </svg>
                             Mark All as Unread
                         </button>


### PR DESCRIPTION
## Homepage: active DefragLive contest card
- New "hero" variant of DefragliveContestBanner: in-flow card with the prize and a segmented d/h/m/s live countdown, styled to match the Latest News pill
- Placed under Latest News; always shows the currently active contest (shared `defragliveContest` prop) and renders nothing when none is live

## Notifications
- "Mark All as Read" / "Mark All as Unread" had their colors (and icons) reversed in both bulk-action bars (user + system sections): Read is now green with a check-circle, Unread yellow with a slashed bell
