### PR TITLE
DefragLive contest bans (time-scoped, public) + scraper prefers getdfstatus

### DIFF
--- a/app/Console/Commands/ScrapeServers.php
+++ b/app/Console/Commands/ScrapeServers.php
@@ -105,29 +105,25 @@ class ScrapeServers extends Command
         try {
             $connection = new DefragServer($server->ip, $server->port);
 
-            // Try rcon first if password available
-            if ($server->rconpassword) {
-                $result = $connection->getRconData($server->rconpassword);
+            // Try getdfstatus first - new engines (KG7X/oDFe extended) send
+            // full player info, so no rcon spam on the server console
+            $result = $connection->getDfStatusData();
 
-                if ($result == 'Bad rconpassword') {
+            // Rcon only when getdfstatus failed or came back in the legacy
+            // format (no uid/country/model) - there dumpuser is still richer
+            if (($result === null || !empty($result['legacy_format'])) && $server->rconpassword) {
+                $rconResult = $connection->getRconData($server->rconpassword);
+
+                if ($rconResult == 'Bad rconpassword') {
                     $this->info('Bad rconpassword ' . $server->ip . ':' . $server->port);
-                    $result = null;
-                } elseif ($result == 'Rcon not usable') {
+                } elseif ($rconResult == 'Rcon not usable') {
                     $this->info('Rcon not usable (missing rs_id ?) ' . $server->ip . ':' . $server->port);
-                    $result = null;
+                } elseif ($rconResult !== null) {
+                    $result = $rconResult;
                 }
             }
 
-            // If rcon failed or not available, try getdfstatus
-            if ($result === null) {
-                $result = $connection->getDfStatusData();
-
-                if ($result !== null) {
-                    $this->info('Using getdfstatus for ' . $server->ip . ':' . $server->port);
-                }
-            }
-
-            // If getdfstatus also failed, fall back to basic getstatus
+            // If both failed, fall back to basic getstatus
             if ($result === null) {
                 $result = $connection->getData();
             }

--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -14,7 +14,7 @@ class DefragServer
     private $previousData;
 
     public function __construct ($ip, $port) {
-        // socket_connect/socket_sendto on AF_INET need a numeric IPv4 — they
+        // socket_connect/socket_sendto on AF_INET need a numeric IPv4 - they
         // don't resolve hostnames themselves, so credentials that declare a
         // server by FQDN (e.g. "deimos.baseq.fr") silently never connect.
         // Resolve once up front; on failure gethostbyname returns the input
@@ -182,6 +182,7 @@ class DefragServer
         $legacyRegex = '/^(-?\d+)\s+(\d+)\s+"([^"]*)"\s+"([^"]*)"$/';
 
         $parsedPlayers = [];
+        $legacyFormat = false;
 
         foreach ($playerLines as $line) {
             if (empty(trim($line))) {
@@ -223,6 +224,7 @@ class DefragServer
                     'nospec' => ($m[10] == 'nospec' || $m[10] == 'nospecpm'),
                 ];
             } elseif (preg_match($legacyRegex, $line, $m)) {
+                $legacyFormat = true;
                 $idx = count($parsedPlayers);
                 $parsedPlayers[$idx] = [
                     'clientId' => $idx,
@@ -294,6 +296,9 @@ class DefragServer
                 'players' => $scorePlayers,
             ],
             'rcon' => true,
+            // Legacy GTK getdfstatus lacks uid/country/model - rcon dumpuser
+            // still gives richer data there, so the scraper falls back to it.
+            'legacy_format' => $legacyFormat,
         ];
     }
 

--- a/app/Filament/Resources/DefragliveWatchExclusionResource.php
+++ b/app/Filament/Resources/DefragliveWatchExclusionResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\DefragliveWatchExclusionResource\Pages;
 use App\Models\DefragliveWatchExclusion;
+use App\Models\DefragliveWatchSession;
 use App\Services\DefragliveWatchService;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -38,6 +39,22 @@ class DefragliveWatchExclusionResource extends Resource
     {
         return $form->schema([
             Forms\Components\Section::make('Player')->schema([
+                Forms\Components\Select::make('player_pick')
+                    ->label('Pick a watched player')
+                    ->options(fn () => self::playerOptions())
+                    ->searchable()
+                    ->dehydrated(false)
+                    ->live()
+                    ->afterStateUpdated(function (Forms\Set $set, ?string $state) {
+                        if (! $state) {
+                            return;
+                        }
+                        $p = json_decode($state, true);
+                        $set('player_name', $p['name']);
+                        $set('name_clean', $p['clean']);
+                        $set('mdd_id', $p['mdd']);
+                    })
+                    ->helperText('Everyone the stream has ever watched. Picking one fills the fields below - or skip it and type manually.'),
                 Forms\Components\TextInput::make('player_name')
                     ->label('Player name')
                     ->helperText('Name as seen on stream / leaderboard. Color codes are fine - matching uses the cleaned form below.')
@@ -69,6 +86,40 @@ class DefragliveWatchExclusionResource extends Resource
                     ->helperText('Why the time was excluded, e.g. "AFK-farming watch time on an endless map".'),
             ])->columns(1),
         ]);
+    }
+
+    /**
+     * Every identity the stream has ever watched, one option per leaderboard
+     * key (mdd account, else cleaned name), newest sighting's spelling wins.
+     * Option value carries the full identity as JSON for afterStateUpdated.
+     */
+    protected static function playerOptions(): array
+    {
+        $options = [];
+        $seen = [];
+        $rows = DefragliveWatchSession::query()
+            ->orderByDesc('id')
+            ->get(['mdd_id', 'player_name', 'player_name_clean']);
+        foreach ($rows as $s) {
+            $key = $s->mdd_id ? 'mdd:'.$s->mdd_id : 'name:'.$s->player_name_clean;
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $value = json_encode([
+                'name' => $s->player_name,
+                'clean' => $s->player_name_clean,
+                'mdd' => $s->mdd_id ? (int) $s->mdd_id : null,
+            ]);
+            $label = trim(preg_replace('/\^[0-9A-Za-z]/', '', (string) $s->player_name)) ?: $s->player_name_clean;
+            if ($s->mdd_id) {
+                $label .= ' (mdd '.$s->mdd_id.')';
+            }
+            $options[$value] = $label;
+        }
+        natcasesort($options);
+
+        return $options;
     }
 
     public static function table(Table $table): Table

--- a/app/Filament/Resources/DefragliveWatchExclusionResource.php
+++ b/app/Filament/Resources/DefragliveWatchExclusionResource.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DefragliveWatchExclusionResource\Pages;
+use App\Models\DefragliveWatchExclusion;
+use App\Services\DefragliveWatchService;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * Contest bans for the DefragLive watch contest: exclude a player's watch time
+ * accrued BEFORE the given moment (AFK-farming on endless maps etc.). Time
+ * after the cutoff counts again, so a legit player whose nick was abused can
+ * still compete from the ban onward.
+ */
+class DefragliveWatchExclusionResource extends Resource
+{
+    protected static ?string $model = DefragliveWatchExclusion::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-no-symbol';
+
+    protected static ?string $navigationGroup = 'DefragLive';
+
+    protected static ?string $navigationLabel = 'Contest Bans';
+
+    protected static ?int $navigationSort = 25;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Section::make('Player')->schema([
+                Forms\Components\TextInput::make('player_name')
+                    ->label('Player name')
+                    ->helperText('Name as seen on stream / leaderboard. Color codes are fine - matching uses the cleaned form below.')
+                    ->required()
+                    ->maxLength(255)
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (Forms\Set $set, ?string $state) {
+                        $set('name_clean', app(DefragliveWatchService::class)->cleanName((string) $state));
+                    }),
+                Forms\Components\TextInput::make('name_clean')
+                    ->label('Cleaned name (matching key)')
+                    ->helperText('Lowercase, color codes stripped. Auto-filled from the name; adjust only if needed.')
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('mdd_id')
+                    ->label('mDd id (optional)')
+                    ->helperText('Set when the player is a resolved defrag account - the ban then also matches their sessions credited by account.')
+                    ->numeric(),
+            ])->columns(1),
+            Forms\Components\Section::make('Ban')->schema([
+                Forms\Components\DateTimePicker::make('excluded_before')
+                    ->label('Exclude watch time before')
+                    ->seconds(false)
+                    ->default(now())
+                    ->required()
+                    ->helperText('Everything watched BEFORE this moment is discarded from tickets and stats. Time after it counts normally, so a legit player behind an abused nick can still compete.'),
+                Forms\Components\Textarea::make('reason')
+                    ->required()
+                    ->rows(3)
+                    ->helperText('Why the time was excluded, e.g. "AFK-farming watch time on an endless map".'),
+            ])->columns(1),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('player_name')
+                    ->label('Player')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('name_clean')
+                    ->label('Match key')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('mdd_id')
+                    ->label('mDd id')
+                    ->placeholder('-'),
+                Tables\Columns\TextColumn::make('excluded_before')
+                    ->label('Time excluded before')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('reason')
+                    ->limit(60)
+                    ->wrap(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Banned at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDefragliveWatchExclusions::route('/'),
+            'create' => Pages\CreateDefragliveWatchExclusion::route('/create'),
+            'edit' => Pages\EditDefragliveWatchExclusion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DefragliveWatchExclusionResource.php
+++ b/app/Filament/Resources/DefragliveWatchExclusionResource.php
@@ -3,8 +3,8 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\DefragliveWatchExclusionResource\Pages;
+use App\Models\DefragliveContest;
 use App\Models\DefragliveWatchExclusion;
-use App\Models\DefragliveWatchSession;
 use App\Services\DefragliveWatchService;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -39,9 +39,21 @@ class DefragliveWatchExclusionResource extends Resource
     {
         return $form->schema([
             Forms\Components\Section::make('Player')->schema([
+                Forms\Components\Select::make('contest_pick')
+                    ->label('Contest')
+                    ->options(fn () => DefragliveContest::query()
+                        ->orderByDesc('starts_at')
+                        ->pluck('title', 'id')
+                        ->all())
+                    ->default(fn () => DefragliveContest::query()
+                        ->orderByDesc('starts_at')
+                        ->value('id'))
+                    ->dehydrated(false)
+                    ->live()
+                    ->helperText('Which contest to list tracked players from.'),
                 Forms\Components\Select::make('player_pick')
-                    ->label('Pick a watched player')
-                    ->options(fn () => self::playerOptions())
+                    ->label('Pick a tracked player')
+                    ->options(fn (Forms\Get $get) => self::playerOptions($get('contest_pick')))
                     ->searchable()
                     ->dehydrated(false)
                     ->live()
@@ -54,7 +66,7 @@ class DefragliveWatchExclusionResource extends Resource
                         $set('name_clean', $p['clean']);
                         $set('mdd_id', $p['mdd']);
                     })
-                    ->helperText('Everyone the stream has ever watched. Picking one fills the fields below - or skip it and type manually.'),
+                    ->helperText('Players with measured watch time in the selected contest, most time first. Picking one fills the fields below - or skip it and type manually.'),
                 Forms\Components\TextInput::make('player_name')
                     ->label('Player name')
                     ->helperText('Name as seen on stream / leaderboard. Color codes are fine - matching uses the cleaned form below.')
@@ -89,35 +101,38 @@ class DefragliveWatchExclusionResource extends Resource
     }
 
     /**
-     * Every identity the stream has ever watched, one option per leaderboard
-     * key (mdd account, else cleaned name), newest sighting's spelling wins.
-     * Option value carries the full identity as JSON for afterStateUpdated.
+     * Players with measured watch time in the given contest, most time first
+     * (the suspicious totals float to the top), labelled with their hours and
+     * tickets. Option value carries the full identity as JSON for
+     * afterStateUpdated. Uses the same leaderboard the contest itself runs on,
+     * so the list is exactly "who is competing right now".
      */
-    protected static function playerOptions(): array
+    protected static function playerOptions($contestId): array
     {
+        $contest = $contestId ? DefragliveContest::find($contestId) : null;
+        if (! $contest) {
+            return [];
+        }
+
         $options = [];
-        $seen = [];
-        $rows = DefragliveWatchSession::query()
-            ->orderByDesc('id')
-            ->get(['mdd_id', 'player_name', 'player_name_clean']);
-        foreach ($rows as $s) {
-            $key = $s->mdd_id ? 'mdd:'.$s->mdd_id : 'name:'.$s->player_name_clean;
-            if (isset($seen[$key])) {
+        foreach (app(DefragliveWatchService::class)->leaderboard($contest, null) as $e) {
+            if ($e['seconds'] < 1) {
                 continue;
             }
-            $seen[$key] = true;
             $value = json_encode([
-                'name' => $s->player_name,
-                'clean' => $s->player_name_clean,
-                'mdd' => $s->mdd_id ? (int) $s->mdd_id : null,
+                'name' => $e['name'],
+                'clean' => $e['name_clean'],
+                'mdd' => $e['mdd_id'],
             ]);
-            $label = trim(preg_replace('/\^[0-9A-Za-z]/', '', (string) $s->player_name)) ?: $s->player_name_clean;
-            if ($s->mdd_id) {
-                $label .= ' (mdd '.$s->mdd_id.')';
+            $label = trim(preg_replace('/\^[0-9A-Za-z]/', '', (string) $e['name'])) ?: $e['name_clean'];
+            $h = intdiv($e['seconds'], 3600);
+            $m = intdiv($e['seconds'] % 3600, 60);
+            $label .= ' - '.($h ? $h.'h ' : '').$m.'m ('.$e['tickets'].' tickets)';
+            if ($e['mdd_id']) {
+                $label .= ' [mdd '.$e['mdd_id'].']';
             }
             $options[$value] = $label;
         }
-        natcasesort($options);
 
         return $options;
     }

--- a/app/Filament/Resources/DefragliveWatchExclusionResource/Pages/CreateDefragliveWatchExclusion.php
+++ b/app/Filament/Resources/DefragliveWatchExclusionResource/Pages/CreateDefragliveWatchExclusion.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveWatchExclusionResource\Pages;
+
+use App\Filament\Resources\DefragliveWatchExclusionResource;
+use App\Services\DefragliveWatchService;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDefragliveWatchExclusion extends CreateRecord
+{
+    protected static string $resource = DefragliveWatchExclusionResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        // Never persist an empty matching key: derive it from the display name
+        // when the admin left the auto-filled field blank.
+        if (blank($data['name_clean'] ?? null)) {
+            $data['name_clean'] = app(DefragliveWatchService::class)->cleanName($data['player_name']);
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/DefragliveWatchExclusionResource/Pages/EditDefragliveWatchExclusion.php
+++ b/app/Filament/Resources/DefragliveWatchExclusionResource/Pages/EditDefragliveWatchExclusion.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveWatchExclusionResource\Pages;
+
+use App\Filament\Resources\DefragliveWatchExclusionResource;
+use App\Services\DefragliveWatchService;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDefragliveWatchExclusion extends EditRecord
+{
+    protected static string $resource = DefragliveWatchExclusionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if (blank($data['name_clean'] ?? null)) {
+            $data['name_clean'] = app(DefragliveWatchService::class)->cleanName($data['player_name']);
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/DefragliveWatchExclusionResource/Pages/ListDefragliveWatchExclusions.php
+++ b/app/Filament/Resources/DefragliveWatchExclusionResource/Pages/ListDefragliveWatchExclusions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DefragliveWatchExclusionResource\Pages;
+
+use App\Filament\Resources\DefragliveWatchExclusionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDefragliveWatchExclusions extends ListRecords
+{
+    protected static string $resource = DefragliveWatchExclusionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Http/Controllers/DefragliveContestController.php
+++ b/app/Http/Controllers/DefragliveContestController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\DefragliveContest;
+use App\Models\DefragliveWatchExclusion;
 use App\Models\DefragliveWatchSession;
 use App\Services\DefragliveWatchService;
 use Illuminate\Http\Request;
@@ -72,6 +73,20 @@ class DefragliveContestController extends Controller
             'leaderboard' => $leaderboard,
             'totalTickets' => $totalTickets,
             'myEntry' => $myEntry,
+            // Bans issued during the ACTIVE contest window - a small factual
+            // note under the leaderboard (name, reason, date). Deliberately no
+            // hours/avatars (no trophy for cheating) and nothing for past
+            // contests; the full history stays admin-only.
+            'exclusions' => $contest
+                ? DefragliveWatchExclusion::whereBetween('excluded_before', [$contest->starts_at, $contest->ends_at])
+                    ->orderByDesc('excluded_before')
+                    ->get()
+                    ->map(fn (DefragliveWatchExclusion $x) => [
+                        'name' => trim(preg_replace('/\^[0-9A-Za-z]/', '', $x->player_name)) ?: $x->name_clean,
+                        'reason' => $x->reason,
+                        'date' => $x->excluded_before->toDateString(),
+                    ])
+                : [],
             'nowWatching' => $open ? [
                 'name' => $open->player_name,
                 'mapname' => $open->mapname,

--- a/app/Models/DefragliveWatchExclusion.php
+++ b/app/Models/DefragliveWatchExclusion.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A contest exclusion ("ban") for a watched player - watch time they accrued
+ * BEFORE `excluded_before` does not count toward DefragLive contest tickets or
+ * the public watch stats. Time after that moment counts normally again, so a
+ * legit player whose nick was abused by a cheater can still compete from the
+ * ban onward. Created from the Filament admin with a written reason.
+ *
+ * Identity matches watch sessions the same way the leaderboard groups them:
+ * by mdd_id when set, and/or by the color-stripped lowercase name.
+ */
+class DefragliveWatchExclusion extends Model
+{
+    protected $table = 'defraglive_watch_exclusions';
+
+    protected $fillable = [
+        'mdd_id',
+        'name_clean',
+        'player_name',
+        'reason',
+        'excluded_before',
+    ];
+
+    protected $casts = [
+        'mdd_id' => 'integer',
+        'excluded_before' => 'datetime',
+    ];
+}

--- a/app/Services/DefragliveWatchService.php
+++ b/app/Services/DefragliveWatchService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\DefragliveContest;
+use App\Models\DefragliveWatchExclusion;
 use App\Models\DefragliveWatchSession;
 use App\Models\OnlinePlayer;
 use App\Models\Server;
@@ -251,6 +252,8 @@ class DefragliveWatchService
             ->orderBy('id')
             ->get(['mdd_id', 'user_id', 'player_name', 'player_name_clean', 'seconds', 'started_at', 'ended_at']);
 
+        $cutoffs = $this->exclusionCutoffs();
+
         $groups = [];
         foreach ($rows as $r) {
             $key = $this->keyFor($r->mdd_id, $r->player_name_clean);
@@ -269,12 +272,23 @@ class DefragliveWatchService
             $sessionStart = $r->started_at->lessThan($periodStart)
                 ? $periodStart
                 : $r->started_at;
+            // Admin exclusion: anything watched before the ban moment does not
+            // count (the effective window start moves up to the cutoff).
+            $cutoff = $this->cutoffFor($cutoffs, $r->mdd_id, $r->player_name_clean);
+            if ($cutoff && $cutoff->greaterThan($sessionStart)) {
+                $sessionStart = $cutoff;
+            }
             $rawEnd = $r->ended_at ?? $windowEnd;
             $sessionEnd = $rawEnd->greaterThan($windowEnd)
                 ? $windowEnd
                 : $rawEnd;
 
-            $groups[$key]['seconds'] += $this->span($sessionStart, $sessionEnd);
+            // Guard the clamps: a session lying entirely before the exclusion
+            // cutoff (or outside the window) must contribute nothing - span()
+            // is absolute-valued and would count a reversed interval.
+            if ($sessionStart->lessThan($sessionEnd)) {
+                $groups[$key]['seconds'] += $this->span($sessionStart, $sessionEnd);
+            }
             // Keep the latest seen colored name / resolved identity.
             $groups[$key]['name'] = $r->player_name ?: $groups[$key]['name'];
             if ($r->mdd_id) {
@@ -319,6 +333,8 @@ class DefragliveWatchService
             ->orderBy('id')
             ->get(['mdd_id', 'user_id', 'player_name', 'player_name_clean', 'seconds', 'started_at', 'ended_at']);
 
+        $cutoffs = $this->exclusionCutoffs();
+
         $groups = [];
         foreach ($rows as $r) {
             $key = $this->keyFor($r->mdd_id, $r->player_name_clean);
@@ -331,10 +347,19 @@ class DefragliveWatchService
                     'sessions' => 0,
                 ];
             }
-            // An open session is being watched right now - count it live.
-            $groups[$key]['seconds'] += $r->ended_at
-                ? (int) $r->seconds
-                : $this->span($r->started_at, now());
+            // Admin exclusion: drop the part of the session before the ban
+            // moment (whole session when it ended before the ban).
+            $cutoff = $this->cutoffFor($cutoffs, $r->mdd_id, $r->player_name_clean);
+            $start = ($cutoff && $cutoff->greaterThan($r->started_at)) ? $cutoff : $r->started_at;
+            $end = $r->ended_at ?? now();
+            // An open session is being watched right now - count it live. A
+            // clipped closed session is re-measured from its timestamps
+            // (stored seconds cover the full span).
+            if ($start->lessThan($end)) {
+                $groups[$key]['seconds'] += ($r->ended_at && $start === $r->started_at)
+                    ? (int) $r->seconds
+                    : $this->span($start, $end);
+            }
             $groups[$key]['sessions']++;
             $groups[$key]['name'] = $r->player_name ?: $groups[$key]['name'];
             if ($r->mdd_id) {
@@ -414,6 +439,49 @@ class DefragliveWatchService
         ]);
 
         return $winner;
+    }
+
+    /**
+     * Per-identity exclusion cutoffs from admin bans: `key => Carbon`, where
+     * watch time BEFORE the cutoff is discarded. Keys mirror keyFor() for both
+     * identity forms so an exclusion hits sessions whether or not they resolved
+     * to an mdd account. Multiple bans of the same player keep the latest.
+     */
+    private function exclusionCutoffs(): array
+    {
+        $cutoffs = [];
+        foreach (DefragliveWatchExclusion::all() as $x) {
+            $keys = [];
+            if ($x->mdd_id) {
+                $keys[] = 'mdd:'.$x->mdd_id;
+            }
+            if ($x->name_clean) {
+                $keys[] = 'name:'.$x->name_clean;
+            }
+            foreach ($keys as $key) {
+                if (! isset($cutoffs[$key]) || $x->excluded_before->greaterThan($cutoffs[$key])) {
+                    $cutoffs[$key] = $x->excluded_before;
+                }
+            }
+        }
+
+        return $cutoffs;
+    }
+
+    /**
+     * The exclusion cutoff applying to one session row (by either identity),
+     * or null. Rows matched by name keep being excluded even after they later
+     * resolve to an mdd account and vice versa.
+     */
+    private function cutoffFor(array $cutoffs, $mddId, ?string $clean): ?\Carbon\Carbon
+    {
+        $byMdd = $mddId ? ($cutoffs['mdd:'.(int) $mddId] ?? null) : null;
+        $byName = $clean ? ($cutoffs['name:'.$clean] ?? null) : null;
+        if ($byMdd && $byName) {
+            return $byMdd->greaterThan($byName) ? $byMdd : $byName;
+        }
+
+        return $byMdd ?? $byName;
     }
 
     /** Strip Quake 3 colour codes, collapse whitespace, lowercase: a stable key. */

--- a/database/migrations/2026_07_12_172111_create_defraglive_watch_exclusions_table.php
+++ b/database/migrations/2026_07_12_172111_create_defraglive_watch_exclusions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('defraglive_watch_exclusions', function (Blueprint $table) {
+            $table->id();
+            // Identity to exclude - same matching rules as watch sessions:
+            // mdd_id when the player resolved to a defrag account, otherwise
+            // the color-stripped lowercase name. Either (or both) can be set.
+            $table->unsignedInteger('mdd_id')->nullable()->index();
+            $table->string('name_clean')->nullable()->index();
+            $table->string('player_name');
+            $table->text('reason');
+            // Watch time accrued BEFORE this moment does not count. Time after
+            // it counts normally, so a legit player whose nick was abused by
+            // the cheater can still compete from the ban moment onward.
+            $table->timestamp('excluded_before');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('defraglive_watch_exclusions');
+    }
+};

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -11,6 +11,7 @@ const props = defineProps({
     pastWinners: Array,
     hallOfFame: Array,
     allTimeWatchers: Array,
+    exclusions: Array,
 });
 
 const { proxy } = getCurrentInstance();
@@ -326,6 +327,18 @@ const statusColor = (s) => ({
 
             <div v-else class="px-4 py-12 text-center text-gray-500">
                 No watch time recorded yet this period. Hop on a server the bot is spectating!
+            </div>
+
+            <!-- Bans issued during this contest: a small factual note for
+                 transparency (farmed time was voided) and deterrence. No
+                 hours or avatars on purpose - no trophy for cheating. -->
+            <div v-if="exclusions?.length" class="px-4 py-3 border-t border-white/10">
+                <div class="text-[10px] uppercase tracking-wider text-gray-500 mb-1.5">Removed from this contest</div>
+                <div v-for="(x, i) in exclusions" :key="i" class="text-xs text-gray-500">
+                    <span class="font-semibold text-gray-400">{{ x.name }}</span>
+                    <span class="mx-1">-</span>{{ x.reason }}
+                    <span class="mx-1">-</span>{{ x.date }}
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
**Contest bans**

A player farmed contest watch time by idling on an endless map, where the bot's AFK rotation never triggers. This adds a full moderation flow:

- New **Contest Bans** Filament resource (DefragLive group): pick a contest (defaults to the latest), then pick from the players with measured watch time in it - sorted most time first so suspicious totals float to the top, labelled with hours, tickets and mdd id. Picking auto-fills the name, cleaned matching key and mdd id (manual entry stays as a fallback). Each ban requires a written reason and an "excluded before" timestamp (defaults to now).
- `DefragliveWatchService` discards watch time accrued **before** the cutoff from contest tickets, the public leaderboard, the all-time stats and the winner draw. Time **after** the cutoff counts normally again, so a legit player whose nick was abused by a cheater can still compete from the ban onward.
- Sessions straddling the cutoff are clipped by timestamps to the second, not dropped whole; sessions entirely before it contribute nothing (guarded against Carbon 2's absolute-valued diff). Bans are editable/deletable and removing one instantly restores the time.
- The public contest page lists bans issued during the **active** contest window in a small note under the leaderboard (name, reason, date) - transparency plus deterrence, deliberately without hours or avatars. Past contests show nothing; history stays admin-only.

**Server scraper**

- Probe order flipped: `getdfstatus` first - new engines (KG7X / extended oDFe) return full player info there, so routine scraping no longer spams rcon on server consoles. Rcon `dumpuser` runs only when `getdfstatus` failed or answered in the legacy format (new `legacy_format` flag), which lacks uid/country/model. Plain `getstatus` remains the last fallback.

**Deploy note:** requires `php artisan migrate` (new table `defraglive_watch_exclusions`).
