### PR TITLE
Contest: expand the period leaderboard to everyone

### DIFF
--- a/app/Http/Controllers/DefragliveContestController.php
+++ b/app/Http/Controllers/DefragliveContestController.php
@@ -126,6 +126,50 @@ class DefragliveContestController extends Controller
     }
 
     /**
+     * OBS stream overlay: a tiny self-contained page (transparent background,
+     * no Inertia/app shell) that shows the current contest's top 3 and polls
+     * overlayData() to stay live. Meant to be added as an OBS Browser Source.
+     */
+    public function overlay()
+    {
+        return response()
+            ->view('defraglive.contest-overlay')
+            // Never cache the shell either - OBS keeps sources for days.
+            ->header('Cache-Control', 'no-store');
+    }
+
+    /** JSON feed for the overlay: top 3 + pool size, cached briefly. */
+    public function overlayData(DefragliveWatchService $service)
+    {
+        $data = cache()->remember('defraglive:contest-overlay', 20, function () use ($service) {
+            $contest = DefragliveContest::current()->first();
+            if (! $contest) {
+                return ['contest' => null, 'top' => []];
+            }
+
+            $all = $service->leaderboard($contest, null);
+            $totalTickets = array_sum(array_map(fn ($e) => max(0, $e['tickets']), $all));
+
+            return [
+                'contest' => [
+                    'title' => $contest->title,
+                    'ends_at' => $contest->ends_at?->toIso8601String(),
+                    'prize_amount' => (float) $contest->prize_amount,
+                    'prize_currency' => $contest->prize_currency,
+                ],
+                'top' => array_map(fn ($e) => [
+                    'name' => $e['name'],
+                    'seconds' => $e['seconds'],
+                    'tickets' => $e['tickets'],
+                    'odds' => $totalTickets > 0 ? round($e['tickets'] / $totalTickets * 100, 1) : 0,
+                ], array_slice($all, 0, 3)),
+            ];
+        });
+
+        return response()->json($data)->header('Cache-Control', 'no-store');
+    }
+
+    /**
      * All-time winners: every drawn contest grouped by winner, ranked by number
      * of wins then total prize won. A small hall of fame under the page.
      */

--- a/app/Http/Controllers/DefragliveContestController.php
+++ b/app/Http/Controllers/DefragliveContestController.php
@@ -53,9 +53,12 @@ class DefragliveContestController extends Controller
                 }
             }
 
+            // Top 10 by default; "Show all" grows the limit via partial
+            // reloads (same growing-limit pattern as the all-time stats), so
+            // everyone can find themselves. Capped like the all-time list.
             $leaderboard = array_map(
                 fn (array $entry) => $this->present($entry, $open),
-                array_slice($all, 0, 10)
+                array_slice($all, 0, max(10, min(400, (int) $request->input('leaderboard_limit', 10))))
             );
         }
 
@@ -71,6 +74,7 @@ class DefragliveContestController extends Controller
                 'ends_at' => $contest->ends_at?->toIso8601String(),
             ] : null,
             'leaderboard' => $leaderboard,
+            'leaderboardTotal' => isset($all) ? count($all) : 0,
             'totalTickets' => $totalTickets,
             'myEntry' => $myEntry,
             // Bans issued during the ACTIVE contest window - a small factual

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -12,6 +12,7 @@ const props = defineProps({
     hallOfFame: Array,
     allTimeWatchers: Array,
     exclusions: Array,
+    leaderboardTotal: Number,
 });
 
 const { proxy } = getCurrentInstance();
@@ -29,6 +30,8 @@ onMounted(() => {
     refreshTimer = setInterval(() => {
         router.reload({
             only: ['leaderboard', 'totalTickets', 'myEntry', 'nowWatching'],
+            // Keep the expanded list expanded across auto-refreshes.
+            data: { leaderboard_limit: boardLimit.value },
             preserveScroll: true,
             preserveState: true,
         });
@@ -73,6 +76,44 @@ const maxSeconds = computed(() => Math.max(1, ...(props.leaderboard || []).map(e
 const odds = (tickets) => props.totalTickets > 0 ? (tickets / props.totalTickets * 100) : 0;
 const photo = (u) => u?.profile_photo_path ? '/storage/' + u.profile_photo_path : '/images/null.jpg';
 const rankColor = (i) => i === 0 ? 'text-yellow-400' : i === 1 ? 'text-gray-300' : i === 2 ? 'text-amber-600' : 'text-gray-500';
+
+// Period leaderboard: top 10 by default, "Show all" grows it 40 at a time by
+// scrolling (same growing-limit pattern as the all-time stats below), so
+// everyone competing can find themselves.
+const BOARD_PAGE = 40;
+const boardLimit = ref(10);
+const boardExpanded = ref(false);
+const boardLoading = ref(false);
+const boardDone = computed(() =>
+    boardLimit.value >= 400 || (props.leaderboard?.length ?? 0) < boardLimit.value);
+
+const fetchBoard = (limit) => {
+    boardLoading.value = true;
+    router.reload({
+        only: ['leaderboard'],
+        data: { leaderboard_limit: limit },
+        preserveScroll: true,
+        preserveState: true,
+        onFinish: () => { boardLoading.value = false; boardLimit.value = limit; },
+    });
+};
+const toggleBoard = () => {
+    if (boardExpanded.value) {
+        boardExpanded.value = false;
+        boardLimit.value = 10;
+        fetchBoard(10);
+        return;
+    }
+    boardExpanded.value = true;
+    fetchBoard(BOARD_PAGE);
+};
+const onBoardScroll = (e) => {
+    const el = e.target;
+    if (!boardExpanded.value || boardLoading.value || boardDone.value) return;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+        fetchBoard(boardLimit.value + BOARD_PAGE);
+    }
+};
 
 // All-time watch stats: lazy Inertia prop, fetched when the view is expanded.
 // Loads 40 rows at a time; scrolling near the bottom of the list fetches the
@@ -299,7 +340,9 @@ const statusColor = (s) => ({
                 <span class="text-xs text-gray-500">{{ totalTickets }} tickets in the pool</span>
             </div>
 
-            <div v-if="leaderboard.length" class="divide-y divide-white/5">
+            <div v-if="leaderboard.length" class="divide-y divide-white/5"
+                :class="boardExpanded ? 'max-h-[32rem] overflow-y-auto' : ''"
+                @scroll="onBoardScroll">
                 <div v-for="(e, i) in leaderboard" :key="i" class="flex items-center gap-3 px-4 py-3 hover:bg-white/5">
                     <div class="w-7 text-center font-black text-lg" :class="rankColor(i)">{{ i + 1 }}</div>
 
@@ -327,6 +370,18 @@ const statusColor = (s) => ({
 
             <div v-else class="px-4 py-12 text-center text-gray-500">
                 No watch time recorded yet this period. Hop on a server the bot is spectating!
+            </div>
+
+            <!-- Everyone competing, not just the top 10 - fairness: anyone can
+                 find themselves. Expands in place, grows 40 rows per scroll. -->
+            <div v-if="leaderboardTotal > 10" class="px-4 py-2.5 border-t border-white/10 text-center">
+                <button @click="toggleBoard"
+                    class="text-xs font-semibold text-purple-300 hover:text-purple-200 disabled:opacity-50"
+                    :disabled="boardLoading">
+                    <span v-if="boardLoading">Loading...</span>
+                    <span v-else-if="!boardExpanded">Show everyone ({{ leaderboardTotal }})</span>
+                    <span v-else>Show top 10 only</span>
+                </button>
             </div>
 
             <!-- Bans issued during this contest: a small factual note for

--- a/resources/views/defraglive/contest-overlay.blade.php
+++ b/resources/views/defraglive/contest-overlay.blade.php
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>DefragLive Contest Overlay</title>
+<style>
+    /* OBS Browser Source widget: transparent page, one dark glass card.
+       Recommended source size: 400 x 190. */
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { background: transparent; overflow: hidden; }
+    body {
+        font-family: 'Segoe UI', 'Noto Sans', Arial, sans-serif;
+        color: #fff;
+        padding: 8px;
+    }
+    #card {
+        background: rgba(10, 12, 18, .82);
+        border: 1px solid rgba(255, 255, 255, .12);
+        border-radius: 12px;
+        padding: 10px 12px;
+        max-width: 380px;
+        display: none;
+    }
+    #head {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 8px;
+    }
+    #head .t {
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: .14em;
+        text-transform: uppercase;
+        color: #a78bfa;
+        white-space: nowrap;
+    }
+    #head .p {
+        font-size: 11px;
+        color: #9ca3af;
+        white-space: nowrap;
+    }
+    .row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 0;
+    }
+    .rank {
+        width: 22px;
+        height: 22px;
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 900;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        color: #0b0d12;
+    }
+    .r1 { background: #fbbf24; }
+    .r2 { background: #d1d5db; }
+    .r3 { background: #d97706; }
+    .name {
+        flex: 1;
+        min-width: 0;
+        font-size: 14px;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-shadow: 0 1px 2px rgba(0,0,0,.9);
+    }
+    .stat {
+        flex: none;
+        text-align: right;
+        font-size: 12px;
+        color: #d1d5db;
+        font-variant-numeric: tabular-nums;
+    }
+    .stat b { color: #fff; font-size: 13px; }
+    .stat .odds { color: #34d399; }
+    /* Quake 3 name colours (^0-^8); black gets a readable fallback. */
+    .q0 { color: #6b7280; } .q1 { color: #ff4d4d; } .q2 { color: #4dff4d; }
+    .q3 { color: #ffe14d; } .q4 { color: #4d6bff; } .q5 { color: #4de1ff; }
+    .q6 { color: #ff4dff; } .q7 { color: #ffffff; } .q8 { color: #ff8c1a; }
+</style>
+</head>
+<body>
+<div id="card">
+    <div id="head">
+        <span class="t">Watch contest &middot; Top 3</span>
+        <span class="p" id="prize"></span>
+    </div>
+    <div id="rows"></div>
+</div>
+<script>
+    // ^^ escapes a caret; ^X switches colour. Same algorithm as the site's
+    // q3tohtml, self-contained so the overlay needs no app bundle.
+    function q3name(name) {
+        let out = '', color = '7', buf = '';
+        const esc = s => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const flush = () => {
+            if (buf) out += '<span class="q' + (/^[0-8]$/.test(color) ? color : '7') + '">' + esc(buf) + '</span>';
+            buf = '';
+        };
+        for (let i = 0; i < name.length; i++) {
+            if (name[i] === '^') {
+                if (name[i + 1] === '^') { buf += '^'; i++; }
+                else { flush(); color = name[i + 1] ?? '7'; i++; }
+            } else buf += name[i];
+        }
+        flush();
+        return out;
+    }
+
+    function fmt(s) {
+        const h = Math.floor(s / 3600), m = Math.floor(s % 3600 / 60);
+        return (h ? h + 'h ' : '') + m + 'm';
+    }
+
+    async function tick() {
+        try {
+            const r = await fetch('/defraglive/contest/overlay.json', { cache: 'no-store' });
+            const d = await r.json();
+            const card = document.getElementById('card');
+            if (!d.contest || !d.top.length) { card.style.display = 'none'; return; }
+            document.getElementById('prize').textContent =
+                d.contest.prize_amount ? (d.contest.prize_amount + ' ' + d.contest.prize_currency + ' prize') : '';
+            document.getElementById('rows').innerHTML = d.top.map((e, i) =>
+                '<div class="row">'
+                + '<div class="rank r' + (i + 1) + '">' + (i + 1) + '</div>'
+                + '<div class="name">' + q3name(e.name || '') + '</div>'
+                + '<div class="stat"><b>' + fmt(e.seconds) + '</b> &middot; '
+                + e.tickets + ' t &middot; <span class="odds">' + e.odds + '%</span></div>'
+                + '</div>').join('');
+            card.style.display = 'block';
+        } catch (e) { /* keep the last good render; retry on the next tick */ }
+    }
+
+    tick();
+    setInterval(tick, 20000);
+</script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,9 @@ Route::get('/community', [CommunityLeaderboardController::class, 'index'])->name
 
 // DefragLive most-watched-player contest (public leaderboard + raffle odds).
 Route::get('/defraglive/contest', [DefragliveContestController::class, 'index'])->name('defraglive.contest');
+// OBS Browser Source overlay (transparent top-3 widget) + its JSON feed.
+Route::get('/defraglive/contest/overlay', [DefragliveContestController::class, 'overlay'])->name('defraglive.contest.overlay');
+Route::get('/defraglive/contest/overlay.json', [DefragliveContestController::class, 'overlayData'])->name('defraglive.contest.overlay.data');
 Route::get('/defraglive/maps', [DefragliveMapLogController::class, 'index'])->name('defraglive.maps');
 Route::get('/community-tasks', [CommunityTasksController::class, 'index'])->middleware(['auth', 'verified'])->name('community.tasks');
 Route::post('/community-tasks/refresh', [CommunityTasksController::class, 'refresh'])->middleware(['auth', 'verified'])->name('community.tasks.refresh');


### PR DESCRIPTION
"Most watched this period" showed only the top 10, so anyone below rank 10 couldn't find themselves - unfair for a raffle where every ticket counts. A "Show everyone (N)" button under the list now expands it in place: scrollable, growing 40 rows per scroll via partial reloads with a growing leaderboard_limit (the same pattern as the all-time stats, capped at 400). The 30s auto-refresh passes the current limit along, so the expanded list survives refreshes instead of snapping back to ten.
