### PR TITLE
Server Browser: fix production 500 + instant page load

### DIFF
--- a/app/Filament/Pages/ServerdemosBrowser.php
+++ b/app/Filament/Pages/ServerdemosBrowser.php
@@ -28,6 +28,14 @@ class ServerdemosBrowser extends Page
     public string $sortDir = 'desc';
     public int $page = 1;
 
+    /**
+     * The sidebar stats need a full SFTP traversal per credential, which over
+     * WAN takes seconds on a cold cache - too slow to block the initial page
+     * render on. The page paints immediately with placeholders and wire:init
+     * flips this to load the stats in a follow-up request.
+     */
+    public bool $sidebarReady = false;
+
     public const PER_PAGE = 50;
 
     public static function canAccess(): bool
@@ -54,7 +62,7 @@ class ServerdemosBrowser extends Page
      */
     private function listing(string $user): array
     {
-        return Cache::remember("serverdemos:list:{$user}", 60, function () use ($user) {
+        return Cache::remember("serverdemos:list:{$user}", 300, function () use ($user) {
             $rows = [];
             // listContents() is lazy - connection/listing errors surface during
             // iteration, so the whole loop sits inside the try.
@@ -81,8 +89,15 @@ class ServerdemosBrowser extends Page
         });
     }
 
+    public function initSidebar(): void
+    {
+        $this->sidebarReady = true;
+    }
+
     // Sidebar: every active SFTP credential + live stats, derived from the
-    // same cached listing the file pane uses (no separate traversal).
+    // same cached listing the file pane uses (no separate traversal). Until
+    // wire:init flips $sidebarReady, only the credential names render (stats
+    // null -> placeholders) so the initial page load never touches SFTP.
     public function getCredentialsProperty(): array
     {
         $creds = SftpCredential::with('user:id,name,plain_name,mdd_id')
@@ -91,19 +106,24 @@ class ServerdemosBrowser extends Page
 
         return $creds->map(function ($c) {
             $user = $c->sftp_username;
-            $files = $this->listing($user);
             $last = null;
-            $bytes = 0;
-            foreach ($files as $f) {
-                $bytes += (int) ($f['size'] ?? 0);
-                if ($f['mtime'] && (!$last || $f['mtime'] > $last)) $last = $f['mtime'];
+            $bytes = null;
+            $count = null;
+            if ($this->sidebarReady) {
+                $files = $this->listing($user);
+                $count = count($files);
+                $bytes = 0;
+                foreach ($files as $f) {
+                    $bytes += (int) ($f['size'] ?? 0);
+                    if ($f['mtime'] && (!$last || $f['mtime'] > $last)) $last = $f['mtime'];
+                }
             }
 
             return [
                 'sftp_username' => $user,
                 'owner_name'    => $c->user?->plain_name ?: ($c->user?->name ?: '?'),
                 'owner_id'      => $c->user_id,
-                'count'         => count($files),
+                'count'         => $count,
                 'last'          => $last,
                 'bytes'         => $bytes,
             ];

--- a/resources/views/filament/pages/serverdemos-browser.blade.php
+++ b/resources/views/filament/pages/serverdemos-browser.blade.php
@@ -132,8 +132,8 @@
                                     <td style="padding:8px 10px;">
                                         @if ($f['player'] ?? null)
                                             @php
-                                                {{-- Paired site account -> site profile; otherwise the mdd
-                                                     profile page (works for every scraped mdd id). --}}
+                                                // Paired site account -> site profile; otherwise the mdd
+                                                // profile page (works for every scraped mdd id).
                                                 $playerUrl = ($f['player_user_id'] ?? null)
                                                     ? url('/profile/' . $f['player_user_id'])
                                                     : url('/profile/mdd/' . $f['player']);

--- a/resources/views/filament/pages/serverdemos-browser.blade.php
+++ b/resources/views/filament/pages/serverdemos-browser.blade.php
@@ -30,7 +30,7 @@
         };
     @endphp
 
-    <div style="display:grid;grid-template-columns:320px 1fr;gap:14px;align-items:start;">
+    <div wire:init="initSidebar" style="display:grid;grid-template-columns:320px 1fr;gap:14px;align-items:start;">
 
         {{-- Sidebar: SFTP credentials --}}
         <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;overflow:hidden;">
@@ -55,14 +55,18 @@
                         onmouseout="this.style.background='{{ $active ? 'rgba(234,88,12,0.10)' : 'transparent' }}'">
                         <div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">
                             <span style="font-weight:600;color:#fafafa;font-size:13px;">{{ $c['sftp_username'] }}</span>
-                            <span style="font-size:11px;color:#fb923c;font-weight:700;">{{ $c['count'] }}</span>
+                            <span style="font-size:11px;color:#fb923c;font-weight:700;">{{ $c['count'] ?? '…' }}</span>
                         </div>
                         <div style="font-size:11px;color:#71717a;margin-top:2px;">
                             {{ $c['owner_name'] }}
                         </div>
                         <div style="display:flex;justify-content:space-between;font-size:11px;color:#52525b;margin-top:4px;">
-                            <span>{{ $fmtSize($c['bytes']) }}</span>
-                            <span>{{ $fmtAgo($c['last']) }}</span>
+                            @if ($this->sidebarReady)
+                                <span>{{ $fmtSize($c['bytes']) }}</span>
+                                <span>{{ $fmtAgo($c['last']) }}</span>
+                            @else
+                                <span>loading stats…</span>
+                            @endif
                         </div>
                     </button>
                 @endforeach


### PR DESCRIPTION
**Fix the 500**

A {{-- --}} Blade comment sat inside an @php block in the player column. Blade keeps @php block contents as raw PHP, so the comment compiled into syntactically invalid PHP and the whole page threw 500 in production. It's a plain PHP comment now, and the compiled view is lint-checked this time.

**Don't block the page load on SFTP**

The initial render computed the sidebar stats (demo counts, sizes, last upload) synchronously - a full SFTP traversal per credential over WAN before anything painted, so opening the page took seconds on a cold cache. The page now renders instantly with placeholder stats and wire:init fetches them in a follow-up request; the listing cache TTL is raised from 60s to 5 minutes (the sidebar Refresh button still clears it on demand).
