### PR TITLE
Storage Browser: index directories via a queue job (fix maps/ 504)

### DIFF
--- a/app/Filament/Pages/ServerdemosBrowser.php
+++ b/app/Filament/Pages/ServerdemosBrowser.php
@@ -8,7 +8,6 @@ use Filament\Pages\Page;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ServerdemosBrowser extends Page
 {
@@ -272,6 +271,11 @@ class ServerdemosBrowser extends Page
         Notification::make()->title('Stats refreshed')->success()->send();
     }
 
+    // Livewire can't reliably carry a streamed download itself (a hand-built
+    // StreamedResponse isn't recognised - the button silently did nothing on
+    // prod), so hand the browser a short-lived signed url instead. The
+    // controller re-checks auth + this panel's permission and streams the
+    // file SFTP -> HTTP with no local temp file anywhere.
     public function downloadFile(string $relPath)
     {
         if ($this->selectedUser === '') return null;
@@ -283,26 +287,10 @@ class ServerdemosBrowser extends Page
             return null;
         }
 
-        $disk = $this->disk();
-        if (!$disk->exists($relPath)) {
-            Notification::make()->title('File not found')->danger()->send();
-            return null;
-        }
-
-        $size = $disk->size($relPath);
-        $basename = basename($relPath);
-
-        return new StreamedResponse(function () use ($disk, $relPath) {
-            $stream = $disk->readStream($relPath);
-            if (is_resource($stream)) {
-                fpassthru($stream);
-                fclose($stream);
-            }
-        }, 200, [
-            'Content-Type'        => 'application/octet-stream',
-            'Content-Disposition' => 'attachment; filename="' . addslashes($basename) . '"',
-            'Content-Length'      => (string) $size,
-            'X-Accel-Buffering'   => 'no',
-        ]);
+        return redirect()->to(\Illuminate\Support\Facades\URL::temporarySignedRoute(
+            'defraghq.storage-download',
+            now()->addMinutes(5),
+            ['disk' => self::DISK, 'path' => $relPath],
+        ));
     }
 }

--- a/app/Filament/Pages/StorageBrowser.php
+++ b/app/Filament/Pages/StorageBrowser.php
@@ -11,7 +11,6 @@ use Filament\Pages\Page;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class StorageBrowser extends Page
 {
@@ -205,33 +204,20 @@ class StorageBrowser extends Page
         $this->page = 1;
     }
 
+    // Same signed-url handoff as the Serverdemos Browser: Livewire can't
+    // reliably carry a streamed download (and dl_storage holds multi-hundred
+    // MB files that must never ride through a Livewire payload). The
+    // controller re-checks auth + permission and streams with no temp file.
     public function downloadFile(string $name)
     {
         $this->validateName($name);
-        $disk = $this->disk();
         $path = $this->joinPath($this->currentPath, $name);
 
-        if (! $disk->exists($path)) {
-            Notification::make()->title('File not found')->danger()->send();
-
-            return null;
-        }
-
-        $size = $disk->size($path);
-
-        return new StreamedResponse(function () use ($disk, $path) {
-            $stream = $disk->readStream($path);
-
-            if (is_resource($stream)) {
-                fpassthru($stream);
-                fclose($stream);
-            }
-        }, 200, [
-            'Content-Type' => 'application/octet-stream',
-            'Content-Disposition' => 'attachment; filename="' . addslashes(basename($name)) . '"',
-            'Content-Length' => (string) $size,
-            'X-Accel-Buffering' => 'no',
-        ]);
+        return redirect()->to(\Illuminate\Support\Facades\URL::temporarySignedRoute(
+            'defraghq.storage-download',
+            now()->addMinutes(5),
+            ['disk' => self::DISK, 'path' => $path],
+        ));
     }
 
     public function mkdirAction(): Action

--- a/app/Filament/Pages/StorageBrowser.php
+++ b/app/Filament/Pages/StorageBrowser.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Filament\Pages\Concerns\ValidatesStoragePath;
+use App\Jobs\IndexStorageDirectory;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\TextInput;
@@ -45,95 +46,59 @@ class StorageBrowser extends Page
     }
 
     /**
-     * One cached listing per directory. The old code listed the directory
-     * twice (directories() + files()) and then stat'ed EVERY file for size
-     * and mtime - one SFTP round trip each, so a folder with thousands of
-     * pk3s took forever. Flysystem's listContents() carries size + mtime in
-     * the listing itself: single traversal, cached 30s (mutations below
-     * invalidate it). Files are paginated in getListingProperty().
-     *
-     * Symlinks (e.g. bsp/, maps/ on the storage VPS) arrive typed as FILES
-     * in the SFTP listing, which made them unbrowsable. Entries that look
-     * like that (no extension or unknown size) get one follow-the-link stat
-     * (directoryExists) and are reclassified as folders when they resolve to
-     * a directory.
+     * Listings are NEVER produced inline anymore: huge SFTP directories
+     * (maps/ mirrors tens of thousands of pk3s) take longer than any HTTP
+     * request may run - clicking maps/ 504'd through Cloudflare. Instead the
+     * cached index is served when present; on a miss an IndexStorageDirectory
+     * job is dispatched exactly once and null is returned, which the page
+     * renders as an "Indexing..." state polled via wire:poll until the job
+     * lands the cache entry. Mutations (upload/mkdir/rename/delete) drop the
+     * entry so the next visit re-indexes.
      */
-    private function rawListing(): array
+    private function rawListing(): ?array
     {
-        $path = $this->currentPath;
+        $cached = Cache::get(IndexStorageDirectory::cacheKey(self::DISK, $this->currentPath));
+        if ($cached !== null) {
+            return $cached;
+        }
 
-        return Cache::remember('dlstorage:list:' . $path, 30, function () use ($path) {
-            $disk = $this->disk();
-            $dirs = [];
-            $files = [];
+        // Cache::add is atomic - only the first request dispatches the job.
+        if (Cache::add(IndexStorageDirectory::pendingKey(self::DISK, $this->currentPath), 1, 600)) {
+            IndexStorageDirectory::dispatch(self::DISK, $this->currentPath);
+        }
 
-            foreach ($disk->getDriver()->listContents($path, false) as $item) {
-                $name = basename($item->path());
-                if ($item->isDir()) {
-                    $dirs[] = ['name' => $name, 'path' => $item->path(), 'type' => 'dir'];
-                } else {
-                    $files[] = [
-                        'name' => $name,
-                        'path' => $item->path(),
-                        'type' => 'file',
-                        'size' => $item->fileSize(),
-                        'mtime' => $item->lastModified(),
-                    ];
-                }
-            }
-
-            // Symlink-to-directory fixup (see docblock).
-            foreach ($files as $i => $f) {
-                $suspicious = $f['size'] === null || ! str_contains($f['name'], '.');
-                if (! $suspicious) {
-                    continue;
-                }
-                try {
-                    if ($disk->directoryExists($f['path'])) {
-                        $dirs[] = ['name' => $f['name'], 'path' => $f['path'], 'type' => 'dir'];
-                        unset($files[$i]);
-                    }
-                } catch (\Throwable) {
-                }
-            }
-
-            $byName = fn ($a, $b) => strnatcasecmp($a['name'], $b['name']);
-            usort($dirs, $byName);
-            $files = array_values($files);
-            usort($files, $byName);
-
-            return ['dirs' => $dirs, 'files' => $files];
-        });
+        return null;
     }
 
     public function getListingProperty(): array
     {
-        try {
-            $all = $this->rawListing();
-        } catch (\Throwable $e) {
+        $all = $this->rawListing();
+
+        if ($all === null) {
+            return ['dirs' => [], 'files' => [], 'totalFiles' => 0, 'indexing' => true];
+        }
+
+        if (! empty($all['error'])) {
             Notification::make()
                 ->title('Cannot list directory')
-                ->body($e->getMessage())
+                ->body($all['error'])
                 ->danger()
                 ->send();
 
-            return ['dirs' => [], 'files' => [], 'totalFiles' => 0];
+            return ['dirs' => [], 'files' => [], 'totalFiles' => 0, 'indexing' => false];
         }
 
         return [
             'dirs' => $all['dirs'],
             'files' => array_slice($all['files'], ($this->page - 1) * self::PER_PAGE, self::PER_PAGE),
             'totalFiles' => count($all['files']),
+            'indexing' => false,
         ];
     }
 
     public function getTotalPagesProperty(): int
     {
-        try {
-            $total = count($this->rawListing()['files']);
-        } catch (\Throwable) {
-            return 1;
-        }
+        $total = count($this->rawListing()['files'] ?? []);
 
         return max(1, (int) ceil($total / self::PER_PAGE));
     }
@@ -150,7 +115,7 @@ class StorageBrowser extends Page
 
     private function forgetListing(): void
     {
-        Cache::forget('dlstorage:list:' . $this->currentPath);
+        Cache::forget(IndexStorageDirectory::cacheKey(self::DISK, $this->currentPath));
     }
 
     public function getBreadcrumbsProperty(): array

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Download endpoint for the admin storage browsers (Serverdemos Browser +
+ * Storage Browser). The Filament pages hand the browser a short-lived SIGNED
+ * url to this route instead of streaming through Livewire - Livewire doesn't
+ * recognise a hand-built StreamedResponse as a download (the button silently
+ * did nothing), and streaming large files through its JSON payload is wrong
+ * anyway.
+ *
+ * Security properties (deliberate):
+ * - 'signed' middleware: the url expires (5 min) and can't be forged.
+ * - auth + the SAME granular moderator permission the originating panel
+ *   requires, re-checked here on every hit.
+ * - The file is streamed SFTP -> HTTP response directly; NOTHING is ever
+ *   written to local disk, so no watcher/worker (e.g. the public demo
+ *   pipeline) can accidentally pick a private serverdemo up.
+ * - Flysystem path normalisation rejects '..' traversal outside the disk
+ *   root, and only the two whitelisted disks are reachable.
+ */
+class StorageBrowserDownloadController extends Controller
+{
+    /** disk name => moderator permission required to pull from it */
+    private const DISKS = [
+        'serverdemos' => 'serverdemos_browser',
+        'dl_storage' => 'storage_browser',
+    ];
+
+    public function __invoke(Request $request)
+    {
+        $diskName = (string) $request->query('disk');
+        $permission = self::DISKS[$diskName] ?? null;
+        abort_if($permission === null, 404);
+        abort_unless($request->user()?->hasModeratorPermission($permission) ?? false, 403);
+
+        $path = trim((string) $request->query('path'), '/');
+        abort_if($path === '', 404);
+
+        $disk = Storage::disk($diskName);
+        abort_unless($disk->exists($path), 404);
+
+        $size = null;
+        try {
+            $size = $disk->size($path);
+        } catch (\Throwable) {
+        }
+
+        return response()->streamDownload(function () use ($disk, $path) {
+            $stream = $disk->readStream($path);
+            if (is_resource($stream)) {
+                fpassthru($stream);
+                fclose($stream);
+            }
+        }, basename($path), array_filter([
+            'Content-Type' => 'application/octet-stream',
+            'Content-Length' => $size !== null ? (string) $size : null,
+            'X-Accel-Buffering' => 'no',
+        ]));
+    }
+}

--- a/app/Jobs/IndexStorageDirectory.php
+++ b/app/Jobs/IndexStorageDirectory.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Index one storage-VPS directory for the admin Storage Browser.
+ *
+ * Listing a huge SFTP directory (maps/ mirrors tens of thousands of pk3s)
+ * takes longer than any HTTP request may run - clicking it 504'd through
+ * Cloudflare. So the page never lists SFTP inline anymore: it shows
+ * "Indexing..." and dispatches this job, which does the traversal without a
+ * timeout, caches the result, and the page's poll picks it up.
+ */
+class IndexStorageDirectory implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /** Huge dirs stream tens of thousands of READDIR entries over WAN. */
+    public int $timeout = 600;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public string $disk,
+        public string $path,
+    ) {
+    }
+
+    public static function cacheKey(string $disk, string $path): string
+    {
+        return "storage-index:{$disk}:{$path}";
+    }
+
+    public static function pendingKey(string $disk, string $path): string
+    {
+        return "storage-index:pending:{$disk}:{$path}";
+    }
+
+    public function handle(): void
+    {
+        try {
+            $listing = self::scan($this->disk, $this->path);
+            // Listings change rarely (uploads go through the same panel and
+            // invalidate explicitly), so cache generously - re-indexing maps/
+            // on every visit is exactly what we're avoiding.
+            Cache::put(self::cacheKey($this->disk, $this->path), $listing, now()->addHours(6));
+        } catch (\Throwable $e) {
+            // Short-lived error entry: the page surfaces it, and a retry is
+            // possible right after instead of a stuck "Indexing..." state.
+            Cache::put(self::cacheKey($this->disk, $this->path), [
+                'dirs' => [],
+                'files' => [],
+                'error' => $e->getMessage(),
+            ], 30);
+        } finally {
+            Cache::forget(self::pendingKey($this->disk, $this->path));
+        }
+    }
+
+    /**
+     * One listContents() pass (size + mtime ride along in the listing), plus
+     * the symlink-to-directory fixup: symlinked dirs (bsp/, maps/) arrive
+     * typed as FILES in SFTP listings - entries with no extension or unknown
+     * size get one follow-the-link stat and become folders when they resolve
+     * to a directory.
+     */
+    public static function scan(string $diskName, string $path): array
+    {
+        $disk = Storage::disk($diskName);
+        $dirs = [];
+        $files = [];
+
+        foreach ($disk->getDriver()->listContents($path, false) as $item) {
+            $name = basename($item->path());
+            if ($item->isDir()) {
+                $dirs[] = ['name' => $name, 'path' => $item->path(), 'type' => 'dir'];
+            } else {
+                $files[] = [
+                    'name' => $name,
+                    'path' => $item->path(),
+                    'type' => 'file',
+                    'size' => $item->fileSize(),
+                    'mtime' => $item->lastModified(),
+                ];
+            }
+        }
+
+        foreach ($files as $i => $f) {
+            $suspicious = $f['size'] === null || ! str_contains($f['name'], '.');
+            if (! $suspicious) {
+                continue;
+            }
+            try {
+                if ($disk->directoryExists($f['path'])) {
+                    $dirs[] = ['name' => $f['name'], 'path' => $f['path'], 'type' => 'dir'];
+                    unset($files[$i]);
+                }
+            } catch (\Throwable) {
+            }
+        }
+
+        $byName = fn ($a, $b) => strnatcasecmp($a['name'], $b['name']);
+        usort($dirs, $byName);
+        $files = array_values($files);
+        usort($files, $byName);
+
+        return ['dirs' => $dirs, 'files' => $files];
+    }
+}

--- a/resources/views/filament/pages/storage-browser.blade.php
+++ b/resources/views/filament/pages/storage-browser.blade.php
@@ -48,11 +48,25 @@
             @endforeach
 
             <span style="margin-left:auto;color:#71717a;font-size:11px;">
-                {{ count($listing['dirs']) }} folder(s) &middot; {{ $listing['totalFiles'] }} file(s)
+                @if ($listing['indexing'] ?? false)
+                    indexing&hellip;
+                @else
+                    {{ count($listing['dirs']) }} folder(s) &middot; {{ $listing['totalFiles'] }} file(s)
+                @endif
             </span>
         </div>
     </div>
 
+    @if ($listing['indexing'] ?? false)
+        {{-- Big directories are indexed by a queue job (an inline SFTP listing
+             of e.g. maps/ blows every HTTP timeout); poll until it lands. --}}
+        <div wire:poll.2s style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;margin-top:14px;padding:56px;text-align:center;">
+            <div style="color:#fb923c;font-weight:700;font-size:14px;">Indexing this folder&hellip;</div>
+            <div style="color:#71717a;font-size:12px;margin-top:6px;">
+                Large folders (tens of thousands of files) can take a minute on the first visit - the result is then cached.
+            </div>
+        </div>
+    @else
     {{-- Listing --}}
     <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;overflow:hidden;margin-top:14px;">
         <table style="width:100%;border-collapse:collapse;font-size:13px;">
@@ -205,8 +219,10 @@
         </table>
     </div>
 
+    @endif
+
     {{-- Pagination (files only; folders always show) --}}
-    @if ($this->totalPages > 1)
+    @if (! ($listing['indexing'] ?? false) && $this->totalPages > 1)
         <div style="display:flex;align-items:center;justify-content:center;gap:12px;padding:10px;">
             <button type="button" wire:click="prevPage" @disabled($this->page <= 1)
                 style="background:transparent;border:1px solid #27272a;cursor:pointer;color:#fb923c;padding:4px 12px;border-radius:6px;font-size:11px;font-weight:600;{{ $this->page <= 1 ? 'opacity:.4;cursor:default;' : '' }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,12 @@ Route::get('/ranking/how-it-works', [RankingController::class, 'howItWorks'])->n
 
 Route::get('/community', [CommunityLeaderboardController::class, 'index'])->name('community');
 
+// Signed, permission-checked download for the admin storage browsers
+// (Serverdemos Browser + Storage Browser) - streams SFTP -> browser, no disk.
+Route::get('/defraghq/storage-download', \App\Http\Controllers\StorageBrowserDownloadController::class)
+    ->middleware(['auth', 'signed'])
+    ->name('defraghq.storage-download');
+
 // DefragLive most-watched-player contest (public leaderboard + raffle odds).
 Route::get('/defraglive/contest', [DefragliveContestController::class, 'index'])->name('defraglive.contest');
 // OBS Browser Source overlay (transparent top-3 widget) + its JSON feed.


### PR DESCRIPTION
Clicking maps/ 504'd through Cloudflare: the folder mirrors tens of thousands of pk3s and listing it over SFTP takes longer than any HTTP request may run. Listings are never produced inline anymore - the page serves the cached index when present; on a miss it atomically dispatches an IndexStorageDirectory job (600s timeout, no HTTP limits), shows an "Indexing this folder..." state and polls every 2s until the job lands the cache entry. The index is cached for 6 hours; upload/mkdir/rename/delete invalidate it, and job errors surface as a notification with a short-lived error entry so a retry is immediate. The initial page load is instant too, since the root listing goes through the same cache.

Deploy note: run php artisan queue:restart so workers pick up the new job class.
