### PR TITLE
Storage browsers: fix 502 downloads + 400 on exotic names, per-folder search, security hardening

### DIFF
--- a/app/Filament/Pages/Concerns/ValidatesStoragePath.php
+++ b/app/Filament/Pages/Concerns/ValidatesStoragePath.php
@@ -4,15 +4,32 @@ namespace App\Filament\Pages\Concerns;
 
 trait ValidatesStoragePath
 {
-    protected function validateName(string $name): void
+    /**
+     * Anti-traversal check for one path segment of an EXISTING entry
+     * (navigation, download, rename source, delete). Deliberately loose about
+     * the character set: files on the storage VPS carry names with '+', '(',
+     * quotes etc. (community pk3/bsp uploads), and refusing to open or
+     * download them just breaks the browser.
+     */
+    protected function validateSegment(string $name): void
     {
         if ($name === '' || $name === '.' || $name === '..') {
             abort(400, 'Invalid name');
         }
 
-        if (str_contains($name, '/') || str_contains($name, "\0")) {
+        if (str_contains($name, '/') || str_contains($name, '\\') || str_contains($name, "\0")) {
             abort(400, 'Invalid name');
         }
+    }
+
+    /**
+     * Strict charset for names WE create (new folder, rename target): keeps
+     * the tree shell- and url-friendly going forward without rejecting the
+     * exotic names that already exist.
+     */
+    protected function validateName(string $name): void
+    {
+        $this->validateSegment($name);
 
         if (! preg_match('/^[A-Za-z0-9._\-][A-Za-z0-9._\- ]*$/', $name)) {
             abort(400, 'Name contains forbidden characters');
@@ -28,7 +45,7 @@ trait ValidatesStoragePath
         }
 
         foreach (explode('/', $path) as $segment) {
-            $this->validateName($segment);
+            $this->validateSegment($segment);
         }
     }
 

--- a/app/Filament/Pages/ServerdemosBrowser.php
+++ b/app/Filament/Pages/ServerdemosBrowser.php
@@ -8,6 +8,7 @@ use Filament\Pages\Page;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Attributes\Locked;
 
 class ServerdemosBrowser extends Page
 {
@@ -21,6 +22,10 @@ class ServerdemosBrowser extends Page
     protected const DISK = 'serverdemos';
 
     // User dir currently being browsed. Empty = root (user picker).
+    // Locked: only selectUser() (which verifies the name against the known
+    // SFTP credentials) may set it - Livewire v3 would otherwise let the
+    // client overwrite the property directly.
+    #[Locked]
     public string $selectedUser = '';
     public string $search = '';
     public string $sortBy = 'mtime';   // mtime | name | size
@@ -280,8 +285,17 @@ class ServerdemosBrowser extends Page
     {
         if ($this->selectedUser === '') return null;
 
-        // Hard-confine the relPath to the selected user's subtree.
+        // Hard-confine the relPath to the selected user's subtree. The prefix
+        // check alone can be defeated with 'user/../other/x', so traversal and
+        // degenerate segments are rejected too (demo names contain brackets,
+        // so only the segment shape is constrained, not the character set).
         $relPath = ltrim($relPath, '/');
+        foreach (explode('/', $relPath) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..' || str_contains($segment, "\0")) {
+                Notification::make()->title('Forbidden')->danger()->send();
+                return null;
+            }
+        }
         if (!str_starts_with($relPath, $this->selectedUser . '/')) {
             Notification::make()->title('Forbidden')->danger()->send();
             return null;

--- a/app/Filament/Pages/StorageBrowser.php
+++ b/app/Filament/Pages/StorageBrowser.php
@@ -36,6 +36,11 @@ class StorageBrowser extends Page
 
     public int $page = 1;
 
+    // Filters the CURRENT folder's cached index (folders + files) - available
+    // in every folder, not just root. It searches the indexed listing, so it
+    // is instant and never touches SFTP.
+    public string $search = '';
+
     public static function canAccess(): bool
     {
         return auth()->user()?->hasModeratorPermission('storage_browser') ?? false;
@@ -94,6 +99,8 @@ class StorageBrowser extends Page
             return ['dirs' => [], 'files' => [], 'totalFiles' => 0, 'indexing' => false];
         }
 
+        $all = $this->applySearch($all);
+
         return [
             'dirs' => $all['dirs'],
             'files' => array_slice($all['files'], ($this->page - 1) * self::PER_PAGE, self::PER_PAGE),
@@ -102,9 +109,32 @@ class StorageBrowser extends Page
         ];
     }
 
+    private function applySearch(array $all): array
+    {
+        $needle = trim($this->search);
+        if ($needle === '') {
+            return $all;
+        }
+
+        $match = fn (array $e) => stripos($e['name'], $needle) !== false;
+
+        return [
+            'dirs' => array_values(array_filter($all['dirs'] ?? [], $match)),
+            'files' => array_values(array_filter($all['files'] ?? [], $match)),
+        ];
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->page = 1;
+    }
+
     public function getTotalPagesProperty(): int
     {
-        $total = count($this->rawListing()['files'] ?? []);
+        $all = $this->rawListing();
+        $total = ($all !== null && empty($all['error']))
+            ? count($this->applySearch($all)['files'])
+            : 0;
 
         return max(1, (int) ceil($total / self::PER_PAGE));
     }
@@ -144,9 +174,10 @@ class StorageBrowser extends Page
 
     public function enterDir(string $name): void
     {
-        $this->validateName($name);
+        $this->validateSegment($name);
         $this->currentPath = $this->joinPath($this->currentPath, $name);
         $this->page = 1;
+        $this->search = '';
     }
 
     public function goTo(string $path): void
@@ -155,6 +186,7 @@ class StorageBrowser extends Page
         $this->validatePath($path);
         $this->currentPath = $path;
         $this->page = 1;
+        $this->search = '';
     }
 
     public function goUp(): void
@@ -167,12 +199,14 @@ class StorageBrowser extends Page
         array_pop($parts);
         $this->currentPath = implode('/', $parts);
         $this->page = 1;
+        $this->search = '';
     }
 
     public function goRoot(): void
     {
         $this->currentPath = '';
         $this->page = 1;
+        $this->search = '';
     }
 
     // Same signed-url handoff as the Serverdemos Browser: Livewire can't
@@ -181,7 +215,7 @@ class StorageBrowser extends Page
     // controller re-checks auth + permission and streams with no temp file.
     public function downloadFile(string $name)
     {
-        $this->validateName($name);
+        $this->validateSegment($name);
         $path = $this->joinPath($this->currentPath, $name);
 
         return redirect()->to(\Illuminate\Support\Facades\URL::temporarySignedRoute(
@@ -250,7 +284,9 @@ class StorageBrowser extends Page
 
                 foreach ((array) $data['files'] as $tempPath) {
                     $name = basename($tempPath);
-                    $this->validateName($name);
+                    // Loose check: community files legitimately carry '+',
+                    // parentheses etc. - only traversal shapes are refused.
+                    $this->validateSegment($name);
 
                     $targetPath = $this->joinPath($this->currentPath, $name);
                     $existed = $disk->exists($targetPath);
@@ -303,7 +339,9 @@ class StorageBrowser extends Page
                 $oldName = $arguments['oldName'];
                 $newName = $data['newName'];
 
-                $this->validateName($oldName);
+                // The source may have an exotic pre-existing name; only the
+                // NEW name we create is held to the strict charset.
+                $this->validateSegment($oldName);
                 $this->validateName($newName);
 
                 if ($oldName === $newName) {
@@ -340,7 +378,7 @@ class StorageBrowser extends Page
                 $name = $arguments['name'];
                 $type = $arguments['type'];
 
-                $this->validateName($name);
+                $this->validateSegment($name);
 
                 $disk = $this->disk();
                 $path = $this->joinPath($this->currentPath, $name);

--- a/app/Filament/Pages/StorageBrowser.php
+++ b/app/Filament/Pages/StorageBrowser.php
@@ -12,6 +12,7 @@ use Filament\Pages\Page;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Attributes\Locked;
 
 class StorageBrowser extends Page
 {
@@ -27,7 +28,12 @@ class StorageBrowser extends Page
 
     public const PER_PAGE = 100;
 
+    // Locked: every change goes through the validated navigation methods -
+    // Livewire v3 would otherwise let the client overwrite the property
+    // directly and skip validatePath().
+    #[Locked]
     public string $currentPath = '';
+
     public int $page = 1;
 
     public static function canAccess(): bool

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -54,22 +54,33 @@ class StorageBrowserDownloadController extends Controller
         $disk = Storage::disk($diskName);
         abort_unless($disk->exists($path), 404);
 
-        $size = null;
+        // Open the stream BEFORE the response starts: a failure here is a
+        // clean 404 instead of a broken half-sent response.
+        $stream = null;
         try {
-            $size = $disk->size($path);
+            $stream = $disk->readStream($path);
         } catch (\Throwable) {
         }
+        abort_unless(is_resource($stream), 404);
 
-        return response()->streamDownload(function () use ($disk, $path) {
-            $stream = $disk->readStream($path);
-            if (is_resource($stream)) {
-                fpassthru($stream);
-                fclose($stream);
+        // Octane/Swoole delivers streamed responses as chunked writes, so a
+        // manual Content-Length alongside them produces an invalid response
+        // (nginx answers 502), and Swoole's output buffer caps a single
+        // buffered body at ~2 MB anyway. Stream in small chunks and flush
+        // each one - no Content-Length, no temp file, bounded memory.
+        return response()->streamDownload(function () use ($stream) {
+            while (! feof($stream)) {
+                $chunk = fread($stream, 64 * 1024);
+                if ($chunk === false) {
+                    break;
+                }
+                echo $chunk;
+                flush();
             }
-        }, basename($path), array_filter([
+            fclose($stream);
+        }, basename($path), [
             'Content-Type' => 'application/octet-stream',
-            'Content-Length' => $size !== null ? (string) $size : null,
             'X-Accel-Buffering' => 'no',
-        ]));
+        ]);
     }
 }

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -41,6 +41,16 @@ class StorageBrowserDownloadController extends Controller
         $path = trim((string) $request->query('path'), '/');
         abort_if($path === '', 404);
 
+        // Reject traversal/degenerate segments outright instead of relying on
+        // Flysystem's normalizer (which throws a 500 on '..' escapes). Demo
+        // filenames contain brackets etc., so only the segment shape is
+        // constrained, not the character set.
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..' || str_contains($segment, "\0")) {
+                abort(404);
+            }
+        }
+
         $disk = Storage::disk($diskName);
         abort_unless($disk->exists($path), 404);
 

--- a/resources/views/filament/pages/storage-browser.blade.php
+++ b/resources/views/filament/pages/storage-browser.blade.php
@@ -57,6 +57,21 @@
         </div>
     </div>
 
+    {{-- Search within the current folder (filters the cached index, so it is
+         instant and works in every folder incl. huge ones like maps/). --}}
+    @if (! ($listing['indexing'] ?? false))
+        <div style="margin-top:14px;">
+            <input
+                type="search"
+                wire:model.live.debounce.400ms="search"
+                placeholder="Search this folder&hellip;"
+                style="width:100%;background:#0f0f17;border:1px solid #27272a;border-radius:12px;padding:10px 14px;color:#fafafa;font-size:13px;outline:none;"
+                onfocus="this.style.borderColor='#fb923c'"
+                onblur="this.style.borderColor='#27272a'"
+            />
+        </div>
+    @endif
+
     @if ($listing['indexing'] ?? false)
         {{-- Big directories are indexed by a queue job (an inline SFTP listing
              of e.g. maps/ blows every HTTP timeout); poll until it lands. --}}
@@ -151,7 +166,11 @@
                     @if (empty($listing['files']))
                         <tr>
                             <td colspan="5" style="padding:32px 14px;text-align:center;color:#71717a;border-top:1px solid #27272a;">
-                                Empty folder. Use <strong style="color:#fb923c;">Upload files</strong> or <strong style="color:#fb923c;">New folder</strong> above.
+                                @if (trim($this->search) !== '')
+                                    Nothing here matches &ldquo;{{ $this->search }}&rdquo;.
+                                @else
+                                    Empty folder. Use <strong style="color:#fb923c;">Upload files</strong> or <strong style="color:#fb923c;">New folder</strong> above.
+                                @endif
                             </td>
                         </tr>
                     @endif


### PR DESCRIPTION
Fixes the two production issues found after the last deploy, adds search, and ships the hardening from the follow-up security review.

- Fix 502 on downloads: Octane/Swoole delivers streamed responses as chunked writes, so the manual Content-Length produced an invalid response and Swoole's ~2 MB output buffer broke anything demo-sized. The signed download route now opens the SFTP stream before the response starts (clean 404 on failure) and streams in 64 KB chunks with an explicit flush - valid chunked response, bounded memory, still no temp file anywhere.
- Fix 400 Bad Request in bsp/ and friends: existing community files legitimately carry '+', quotes, parentheses etc., which the strict name whitelist rejected on download/rename/delete. Validation is split - existing entries only pass an anti-traversal check, the strict charset stays for names we create (new folder, rename target).
- Per-folder search in the Storage Browser: filters the current folder's cached index (folders + files, case-insensitive), instant even inside maps/, available in every folder, resets on navigation.
- Security hardening from the review: download paths reject '..' traversal segments outright on both panels instead of relying on the filesystem layer, and the browsers' navigation state properties are #[Locked] so Livewire clients can't tamper with them.

Deploy: php artisan octane:reload (plus queue:restart if it wasn't run after the indexing-job deploy). No migrations.
