### PR TITLE
Fix stuck rankings + server downloads, readable black nicks, download hardening

### DIFF
--- a/app/Filament/Pages/ServerdemosBrowser.php
+++ b/app/Filament/Pages/ServerdemosBrowser.php
@@ -289,9 +289,13 @@ class ServerdemosBrowser extends Page
         // check alone can be defeated with 'user/../other/x', so traversal and
         // degenerate segments are rejected too (demo names contain brackets,
         // so only the segment shape is constrained, not the character set).
+        // Backslash is rejected too: Flysystem rewrites '\' to '/' BEFORE
+        // resolving '..', so 'user/..\other' would otherwise pass this loop
+        // and the prefix check, then traverse out of the user's subtree.
         $relPath = ltrim($relPath, '/');
         foreach (explode('/', $relPath) as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..' || str_contains($segment, "\0")) {
+            if ($segment === '' || $segment === '.' || $segment === '..'
+                || str_contains($segment, '\\') || str_contains($segment, "\0")) {
                 Notification::make()->title('Forbidden')->danger()->send();
                 return null;
             }

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -56,10 +56,17 @@ class StorageBrowserDownloadController extends Controller
         }
 
         $disk = Storage::disk($diskName);
-        abort_unless($disk->exists($path), 404);
 
-        // Open the stream BEFORE the response starts: a failure here is a
-        // clean 404 instead of a broken half-sent response.
+        // Open the stream as the single source of truth for existence +
+        // readability. We deliberately DON'T gate on a separate exists()
+        // stat first: on the serverdemos disk the per-user directory is a
+        // symlink into the uploader's home, and an SFTP stat() through that
+        // symlink can report "not found" for a file the recursive listing
+        // found and readStream() opens fine - which 404'd every serverdemos
+        // download. readStream() is the operation that actually matters and
+        // still fails closed (throws -> not a resource -> 404) for a file
+        // that genuinely isn't there. Opening before the response starts
+        // also means a failure is a clean 404, not a half-sent body.
         $stream = null;
         try {
             $stream = $disk->readStream($path);

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -44,9 +44,13 @@ class StorageBrowserDownloadController extends Controller
         // Reject traversal/degenerate segments outright instead of relying on
         // Flysystem's normalizer (which throws a 500 on '..' escapes). Demo
         // filenames contain brackets etc., so only the segment shape is
-        // constrained, not the character set.
+        // constrained, not the character set. Backslash is rejected too:
+        // Flysystem rewrites '\' to '/' BEFORE resolving '..', so a segment
+        // like '..\other' would otherwise slip past this loop and then
+        // traverse.
         foreach (explode('/', $path) as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..' || str_contains($segment, "\0")) {
+            if ($segment === '' || $segment === '.' || $segment === '..'
+                || str_contains($segment, '\\') || str_contains($segment, "\0")) {
                 abort(404);
             }
         }

--- a/app/Jobs/GetLastMddRecords.php
+++ b/app/Jobs/GetLastMddRecords.php
@@ -31,6 +31,7 @@ class GetLastMddRecords implements ShouldQueue
     private int $duplicateCount = 0;
     private int $insertedCount = 0;
     private int $updatedCount = 0;
+    private int $failedCount = 0;
 
     public function __construct() {}
 
@@ -47,11 +48,12 @@ class GetLastMddRecords implements ShouldQueue
         $this->duplicateCount = 0;
         $this->insertedCount = 0;
         $this->updatedCount = 0;
+        $this->failedCount = 0;
 
         $this->logApiRecords($records);
         $this->processRecords($records);
 
-        echo ("Finished. Total: " . count($records) . ", New: {$this->insertedCount}, Updated: {$this->updatedCount}, Duplicates: {$this->duplicateCount}") . PHP_EOL;
+        echo ("Finished. Total: " . count($records) . ", New: {$this->insertedCount}, Updated: {$this->updatedCount}, Duplicates: {$this->duplicateCount}, Skipped: {$this->failedCount}") . PHP_EOL;
 
         // Anomaly detection: if we got a large batch with 0 duplicates, records were likely missed
         $totalRecords = count($records);
@@ -129,32 +131,54 @@ class GetLastMddRecords implements ShouldQueue
 
     private function processRecords($records) {
         foreach($records as $record) {
-            $find = Record::query()
-                    ->where('physics', $record['physics'])
-                    ->where('mode', $record['mode'])
-                    ->where('mdd_id', $record['mdd_id'])
-                    ->where('mapname', $record['map'])->first();
-
-            if (! $find) {
-                $this->insertRecord($record);
-                $this->insertedCount++;
-                continue;
+            // Isolate each record: a single bad row (e.g. a duplicate-key
+            // collision from a pre-existing orphaned record) used to throw and
+            // abort the ENTIRE minute's batch - every record after it was
+            // skipped and its RecalcMapRatingsJob never dispatched, which is
+            // what froze the rankings. Now one bad record is logged and
+            // skipped; the rest of the batch (and their rating recalcs) run.
+            try {
+                $this->processOneRecord($record);
+            } catch (\Throwable $e) {
+                $this->failedCount++;
+                Log::warning('GetLastMddRecords: skipped a record after an error', [
+                    'mdd_id'  => $record['mdd_id'] ?? null,
+                    'map'     => $record['map'] ?? null,
+                    'physics' => $record['physics'] ?? null,
+                    'mode'    => $record['mode'] ?? null,
+                    'time'    => $record['time'] ?? null,
+                    'error'   => $e->getMessage(),
+                ]);
             }
+        }
+    }
 
-            if ($find->time === $record['time']) {
-                $this->duplicateCount++;
-                echo ("Duplicate Found [" . $find->name . "] (" . $find->time . ") (" . $find->mapname . ") (" . $find->physics . ")") . PHP_EOL;
-                continue;
-            }
+    private function processOneRecord($record) {
+        $find = Record::query()
+                ->where('physics', $record['physics'])
+                ->where('mode', $record['mode'])
+                ->where('mdd_id', $record['mdd_id'])
+                ->where('mapname', $record['map'])->first();
 
-            if ($find->time !== $record['time']) {
-                $this->insertHistoricRecord($find, $record);
-                $this->updatedCount++;
-            }
-
+        if (! $find) {
             $this->insertRecord($record);
             $this->insertedCount++;
+            return;
         }
+
+        if ($find->time === $record['time']) {
+            $this->duplicateCount++;
+            echo ("Duplicate Found [" . $find->name . "] (" . $find->time . ") (" . $find->mapname . ") (" . $find->physics . ")") . PHP_EOL;
+            return;
+        }
+
+        if ($find->time !== $record['time']) {
+            $this->insertHistoricRecord($find, $record);
+            $this->updatedCount++;
+        }
+
+        $this->insertRecord($record);
+        $this->insertedCount++;
     }
 
     private function insertHistoricRecord($oldrecord, $newrecord) {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,13 +24,17 @@
     to { transform: translate(-90px, 45px); }
 }
 
-/* Q3 color ^0 is true black — render it as such. Containers that show
- * Q3 nicks (e.g. server cards' player list) provide a warm-glass
- * backdrop that gives every colour code a legible kontrast. No
- * outline / halo trickery here: a black glyph reads exactly as it
- * does in the game scoreboard. */
+/* Q3 color ^0 is true black. On the site's dark surfaces (leaderboards,
+ * record lists) a pure-black glyph is unreadable - it vanishes into the
+ * background. Keep the fill black so the name still reads as "black",
+ * but add a thin light outline so it stays legible on any background. */
 .q3c-0 {
     color: #000 !important;
+    text-shadow:
+        -1px -1px 0 rgba(255, 255, 255, 0.55),
+         1px -1px 0 rgba(255, 255, 255, 0.55),
+        -1px  1px 0 rgba(255, 255, 255, 0.55),
+         1px  1px 0 rgba(255, 255, 255, 0.55);
 }
 
 .rotate-animation {

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -4,7 +4,14 @@
 
 /* Q3 Color Codes */
 .q3c-0 {
-    color: black;
+    /* Black nick on the dark admin panel: keep it black but outline it so
+       it stays readable (matches the public site's .q3c-0 treatment). */
+    color: #000;
+    text-shadow:
+        -1px -1px 0 rgba(255, 255, 255, 0.55),
+         1px -1px 0 rgba(255, 255, 255, 0.55),
+        -1px  1px 0 rgba(255, 255, 255, 0.55),
+         1px  1px 0 rgba(255, 255, 255, 0.55);
 }
 
 .q3c-1 {

--- a/resources/css/items.css
+++ b/resources/css/items.css
@@ -65,7 +65,15 @@
 
 
 .q3c-0 {
-    color: black;
+    /* Pure black (^0) is unreadable on the site's dark background. Keep the
+       glyph black but add a thin light outline so the name stays legible on
+       any background while still reading as "black". */
+    color: #000;
+    text-shadow:
+        -1px -1px 0 rgba(255, 255, 255, 0.55),
+         1px -1px 0 rgba(255, 255, 255, 0.55),
+        -1px  1px 0 rgba(255, 255, 255, 0.55),
+         1px  1px 0 rgba(255, 255, 255, 0.55);
 }
 
 .q3c-1 {


### PR DESCRIPTION
Four fixes from live reports and the storage security review.

**Rankings were frozen (imoor [MCC])** - GetLastMddRecords inserts new MDD records every minute and dispatches a per-map rating recalc for each. A single record hitting a hard DB error (a duplicate-key collision against a pre-existing orphaned row) threw out of the whole batch, so every record after it was skipped and its RecalcMapRatingsJob never fired. Because the scrape kept hitting the same row every minute, ratings stopped moving entirely (1402 failed jobs since March). Each record is now processed in its own try/catch: a bad row is logged and skipped, the rest of the batch and their recalcs proceed. Genuine duplicate detection is unchanged. (A stuck `rating_recalc:status=running` cache flag that also blocked incremental recalcs was cleared on prod.)

**Black nicks unreadable (Eat Veggies)** - pure-black ^0 nicks vanished into the dark leaderboards and record lists; the main rule even forced color:#000 !important with no outline on purpose. The fill stays black but gets a thin light outline (4-way text-shadow) so it reads on any background. Applied to all three q3c-0 definitions (public app.css, items.css, Filament admin theme).

**Download path hardening**

Deploy: octane:reload, npm run build (CSS), and queue:flush to clear the old failed jobs.
