### PR TITLE
Community downloads hub: user uploads, category tree, auto-updating articles

### DIFF
--- a/app/Console/Commands/BuildServerBundle.php
+++ b/app/Console/Commands/BuildServerBundle.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Process\Process;
+
+/**
+ * Assembles the "core" server bundle that defrag server owners download.
+ *
+ * The bundle is split in two:
+ *  - dfsv-baseq3.tar  : the ~485 MB id-Quake3 paks, static forever, built once
+ *                       by hand and uploaded. This command never touches it.
+ *  - dfsv-core.tar    : everything that actually changes - the oDFe engine and
+ *                       the DeFRaG mod - plus the small static bits (recordsystem
+ *                       modules, qagame, ip4db.dat, uglifix2.so). THIS command
+ *                       rebuilds and publishes it.
+ *
+ * Only two inputs are dynamic:
+ *  - oDFe.ded  : pulled from the latest Defrag-racing/oDFe GitHub release.
+ *  - the mod   : latest non-beta defrag_*.zip from q3defrag.org.
+ * Everything else lives in dfsv-core-static.tar (uploaded once, next to the
+ * output on the dl_storage disk).
+ *
+ * A marker file records which engine build + mod filename produced the current
+ * dfsv-core.tar, so a scheduled run is a cheap no-op until something changes.
+ */
+class BuildServerBundle extends Command
+{
+    protected $signature = 'bundle:build-server {--force : Rebuild even if the engine and mod are unchanged}';
+    protected $description = 'Assemble dfsv-core.tar (oDFe engine + DeFRaG mod + static base) and publish it to the downloads disk';
+
+    /** dl_storage disk root is /www/downloads on the storage VPS (local dir in dev). */
+    private const DISK = 'dl_storage';
+
+    private const STATIC_TAR = 'dfsv-core-static.tar';   // input, uploaded once (modules + qagame + ip4db + uglifix)
+    private const OUTPUT_TAR = 'dfsv-core.tar';          // published output
+    private const MARKER     = 'dfsv-core.version.json'; // records what produced the current output
+
+    private const ENGINE_RELEASE = 'https://api.github.com/repos/Defrag-racing/oDFe/releases/latest';
+    private const ENGINE_ASSET   = 'oDFe-linux-x86_64.zip';
+    private const MOD_INDEX      = 'https://q3defrag.org/files/defrag/';
+
+    public function handle(): int
+    {
+        $disk = Storage::disk(self::DISK);
+
+        $engine = $this->latestEngine();
+        if ($engine === null) {
+            $this->error('Could not resolve the latest oDFe engine release.');
+            return self::FAILURE;
+        }
+
+        $mod = $this->latestMod();
+        if ($mod === null) {
+            $this->error('Could not resolve the latest DeFRaG mod on q3defrag.org.');
+            return self::FAILURE;
+        }
+
+        $this->info("Latest engine build: {$engine['version']}");
+        $this->info("Latest mod:          {$mod['file']}");
+
+        // Cheap no-op when nothing changed since the last successful build.
+        if (! $this->option('force') && $disk->exists(self::OUTPUT_TAR) && $disk->exists(self::MARKER)) {
+            $marker = json_decode((string) $disk->get(self::MARKER), true) ?: [];
+            if (($marker['engine'] ?? null) === $engine['version'] && ($marker['mod'] ?? null) === $mod['file']) {
+                $this->info('Engine and mod unchanged since last build - nothing to do (use --force to rebuild).');
+                return self::SUCCESS;
+            }
+        }
+
+        if (! $disk->exists(self::STATIC_TAR)) {
+            $this->error(self::STATIC_TAR . ' is missing on the ' . self::DISK . ' disk. Upload it once before building.');
+            return self::FAILURE;
+        }
+
+        $work  = storage_path('app/bundle-build-' . uniqid());
+        $stage = $work . '/stage';
+        @mkdir($stage, 0775, true);
+
+        try {
+            // Static base -> stage/
+            file_put_contents($work . '/static.tar', $disk->get(self::STATIC_TAR));
+            $this->runProcess(['tar', '-xf', $work . '/static.tar', '-C', $stage]);
+
+            // Fresh engine -> stage/oDFe.ded
+            $this->info('Downloading engine...');
+            $this->download($engine['url'], $work . '/engine.zip');
+            $this->runProcess(['unzip', '-o', '-q', $work . '/engine.zip', '-d', $work . '/engine']);
+            // The dedicated server binary ships as oDFe.ded.x64 in the x86_64
+            // zip; the bundle expects it plainly named oDFe.ded.
+            $ded = $this->findFile($work . '/engine', 'oDFe.ded.x64')
+                ?? $this->findFile($work . '/engine', 'oDFe.ded');
+            if ($ded === null) {
+                throw new \RuntimeException('oDFe.ded(.x64) not found inside ' . self::ENGINE_ASSET);
+            }
+            copy($ded, $stage . '/oDFe.ded');
+            chmod($stage . '/oDFe.ded', 0755);
+
+            // Fresh mod -> stage/defrag/zz-*.pk3
+            $this->info('Downloading mod...');
+            $this->download($mod['url'], $work . '/mod.zip');
+            $this->runProcess(['unzip', '-o', '-q', $work . '/mod.zip', '-d', $work . '/mod']);
+            @mkdir($stage . '/defrag', 0775, true);
+            $pk3s = $this->findAll($work . '/mod', 'zz-*.pk3');
+            if (empty($pk3s)) {
+                throw new \RuntimeException('no zz-*.pk3 found inside ' . $mod['file']);
+            }
+            foreach ($pk3s as $pk3) {
+                copy($pk3, $stage . '/defrag/' . basename($pk3));
+            }
+
+            // Repack -> dfsv-core.tar
+            $this->runProcess(['tar', '-cf', $work . '/' . self::OUTPUT_TAR, '-C', $stage, '.']);
+
+            // Publish (stream so a ~10 MB body never sits in one buffer)
+            $out = fopen($work . '/' . self::OUTPUT_TAR, 'rb');
+            $disk->writeStream(self::OUTPUT_TAR, $out);
+            if (is_resource($out)) {
+                fclose($out);
+            }
+
+            $disk->put(self::MARKER, json_encode([
+                'engine'   => $engine['version'],
+                'mod'      => $mod['file'],
+                'built_at' => now()->toIso8601String(),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            $mb = round(filesize($work . '/' . self::OUTPUT_TAR) / 1048576, 2);
+            $this->info("Published " . self::OUTPUT_TAR . " ({$mb} MB) with " . count($pk3s) . ' mod pk3(s).');
+            Log::info('bundle:build-server published', ['engine' => $engine['version'], 'mod' => $mod['file'], 'mb' => $mb]);
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error('Build failed: ' . $e->getMessage());
+            Log::error('bundle:build-server failed', ['error' => $e->getMessage()]);
+            return self::FAILURE;
+        } finally {
+            $this->runProcess(['rm', '-rf', $work], false);
+        }
+    }
+
+    /**
+     * Latest oDFe Linux build. The release tag is the rolling "latest", so the
+     * asset's updated_at is what actually identifies a given build.
+     *
+     * @return array{version:string,url:string}|null
+     */
+    private function latestEngine(): ?array
+    {
+        $res = Http::withHeaders(['User-Agent' => 'defrag-racing-bundle'])
+            ->acceptJson()->timeout(20)->get(self::ENGINE_RELEASE);
+        if (! $res->successful()) {
+            return null;
+        }
+        $data = $res->json();
+        foreach ($data['assets'] ?? [] as $asset) {
+            if (($asset['name'] ?? '') === self::ENGINE_ASSET) {
+                return [
+                    'version' => (string) ($asset['updated_at'] ?? $data['published_at'] ?? ''),
+                    'url'     => (string) $asset['browser_download_url'],
+                ];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Newest non-beta defrag_*.zip from the q3defrag.org directory listing.
+     *
+     * @return array{file:string,url:string}|null
+     */
+    private function latestMod(): ?array
+    {
+        $res = Http::withOptions(['verify' => false])->timeout(20)->get(self::MOD_INDEX);
+        if (! $res->successful()) {
+            return null;
+        }
+        preg_match_all('/href="(defrag_[\d.]+\.zip)"/i', $res->body(), $m);
+        $files = array_values(array_filter($m[1] ?? [], static fn ($f) => stripos($f, 'beta') === false));
+        if (empty($files)) {
+            return null;
+        }
+        usort($files, 'strnatcasecmp');
+        $file = end($files);
+        return ['file' => $file, 'url' => self::MOD_INDEX . $file];
+    }
+
+    private function download(string $url, string $dest): void
+    {
+        $res = Http::withOptions(['verify' => false, 'sink' => $dest])
+            ->withHeaders(['User-Agent' => 'defrag-racing-bundle'])
+            ->timeout(180)->get($url);
+        if (! $res->successful()) {
+            throw new \RuntimeException("download failed ({$url}): HTTP " . $res->status());
+        }
+    }
+
+    private function runProcess(array $cmd, bool $check = true): void
+    {
+        $p = new Process($cmd);
+        $p->setTimeout(300);
+        $p->run();
+        if ($check && ! $p->isSuccessful()) {
+            throw new \RuntimeException('command failed: ' . implode(' ', $cmd) . ' :: ' . $p->getErrorOutput());
+        }
+    }
+
+    private function findFile(string $dir, string $name): ?string
+    {
+        foreach ($this->walk($dir) as $file) {
+            if ($file->getFilename() === $name) {
+                return $file->getPathname();
+            }
+        }
+        return null;
+    }
+
+    /** @return string[] */
+    private function findAll(string $dir, string $pattern): array
+    {
+        $out = [];
+        foreach ($this->walk($dir) as $file) {
+            if (fnmatch($pattern, $file->getFilename())) {
+                $out[] = $file->getPathname();
+            }
+        }
+        return $out;
+    }
+
+    private function walk(string $dir): \RecursiveIteratorIterator
+    {
+        return new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+    }
+}

--- a/app/Console/Commands/CheckDefragReleases.php
+++ b/app/Console/Commands/CheckDefragReleases.php
@@ -55,17 +55,25 @@ class CheckDefragReleases extends Command
             return 0;
         }
 
-        // Check if content changed (new file detected)
+        // Save whenever the rendered content differs, not only when a release
+        // is added. A layout change (the new hub banner, restyling) has to
+        // reach the page too, otherwise it never appears until the next
+        // release happens to land.
         $oldFileCount = substr_count($oldContent, 'defrag_1.');
         $newFileCount = substr_count($newContent, 'defrag_1.');
 
-        if ($newFileCount > $oldFileCount) {
+        if ($newContent !== $oldContent) {
             $page->content = $newContent;
             $page->save();
-            $this->info("Wiki updated! New releases detected ({$oldFileCount} -> {$newFileCount} entries).");
-            Log::info("CheckDefragReleases: New releases detected ({$oldFileCount} -> {$newFileCount}). Wiki updated.");
+
+            $note = $newFileCount > $oldFileCount
+                ? "new releases ({$oldFileCount} -> {$newFileCount} entries)"
+                : 'content changed';
+
+            $this->info("Wiki updated! ({$note})");
+            Log::info("CheckDefragReleases: Wiki updated - {$note}.");
         } else {
-            $this->info("No new releases. ({$newFileCount} entries, unchanged)");
+            $this->info("No changes. ({$newFileCount} entries, unchanged)");
         }
 
         return 0;
@@ -141,6 +149,10 @@ class CheckDefragReleases extends Command
         $latestDate = $latest ? $latest['date'] : '';
 
         $content = "<h2 style=\"{$h2}\">DeFRaG Mod Releases</h2>\n";
+        $content .= "<div style=\"background: rgba(6, 182, 212, 0.1); border: 1px solid rgba(6, 182, 212, 0.3); border-radius: 0.5rem; padding: 0.75rem 1rem; margin: 0 0 1rem;\">"
+            . "<p style=\"color: #cbd5e1; margin: 0;\">The mod now lives in the "
+            . "<a href=\"/downloads/0/defrag-mod\" style=\"color: #22d3ee; font-weight: 600;\">Downloads section</a>, "
+            . "alongside the server bundle and other community files. This page is kept for reference.</p></div>\n";
         $content .= "<p style=\"{$p}\">Official DeFRaG mod releases from <a href=\"https://q3defrag.org/files/defrag/\" style=\"color: #60a5fa;\">q3defrag.org</a>. This page is <strong style=\"{$s}\">automatically updated weekly</strong>.</p>\n";
         $content .= "<p style=\"{$p}\"><strong style=\"{$s}\">Latest stable version:</strong> <code style=\"{$c}\">{$latestVersion}</code> ({$latestDate})</p>\n";
 

--- a/app/Console/Commands/MigrateBundlesToDownloads.php
+++ b/app/Console/Commands/MigrateBundlesToDownloads.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Bundle;
+use App\Models\BundleCategory;
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+/**
+ * Moves the pre-hub bundles/bundle_categories data into the downloads hub.
+ *
+ * The old categories are curated collections rather than asset types (a repack
+ * holds maps, textures and shaders at once), so they are kept intact as
+ * children of "Bundles and repacks" instead of being scattered across the
+ * asset tree.
+ *
+ * Idempotent: every migrated row is tagged with a source_key, so a re-run
+ * updates in place. The source tables are left untouched.
+ */
+class MigrateBundlesToDownloads extends Command
+{
+    protected $signature = 'downloads:migrate-bundles {--dry-run : Show what would happen without writing}';
+
+    protected $description = 'Migrate the legacy Bundle/BundleCategory downloads into the community downloads hub';
+
+    private const PARENT_SLUG = 'bundles-and-repacks';
+
+    /**
+     * Legacy rows the Family-Friendly article now owns. Migrating them too
+     * would put the same pk3 in two places, which is exactly what the hub is
+     * meant to stop. Matched on the old category name and on the file itself.
+     */
+    private const SUPERSEDED_CATEGORIES = ['Family-Friendly defrag'];
+    private const SUPERSEDED_URLS = ['zzz-all_models-safe.pk3'];
+
+    public function handle(): int
+    {
+        $dry = (bool) $this->option('dry-run');
+
+        $parent = DownloadCategory::whereNull('parent_id')->where('slug', self::PARENT_SLUG)->first();
+
+        if (! $parent) {
+            $this->error('Root category "' . self::PARENT_SLUG . '" is missing. Run: db:seed --class=DownloadCategorySeeder');
+            return 1;
+        }
+
+        $categories = BundleCategory::orderBy('position')->get();
+
+        if ($categories->isEmpty()) {
+            $this->info('No legacy bundle categories found. Nothing to do.');
+            return 0;
+        }
+
+        $categoriesTouched = 0;
+        $downloadsTouched = 0;
+        $skipped = [];
+
+        foreach ($categories as $old) {
+            if (in_array($old->name, self::SUPERSEDED_CATEGORIES, true)) {
+                $this->line("Skipping {$old->name}: the Family-Friendly article owns it now.");
+                continue;
+            }
+
+            $slug = Str::slug($old->name);
+
+            $this->line("Category: {$old->name} -> {$slug}");
+
+            if ($dry) {
+                $categoriesTouched++;
+            } else {
+                $category = DownloadCategory::updateOrCreate(
+                    ['parent_id' => $parent->id, 'slug' => $slug],
+                    ['name' => $old->name, 'position' => $old->position]
+                );
+                $categoriesTouched++;
+            }
+
+            $bundles = Bundle::where('category_id', $old->id)->orderBy('position')->get();
+
+            foreach ($bundles as $bundle) {
+                // Everything in the legacy table points at an external host;
+                // `file` is a leftover column that was never populated. Handle
+                // it anyway so a stray row cannot be silently dropped.
+                $target = $bundle->url ?: ($bundle->file ? '/storage/' . $bundle->file : null);
+
+                if (! $target) {
+                    $skipped[] = "{$old->name} / {$bundle->name} (no url and no file)";
+                    continue;
+                }
+
+                foreach (self::SUPERSEDED_URLS as $superseded) {
+                    if (str_contains($target, $superseded)) {
+                        $this->line("   - skipping {$bundle->name}: the Family-Friendly article owns it now.");
+                        // 2 = the bundles loop, so only this file is skipped.
+                        continue 2;
+                    }
+                }
+
+                if (! $dry) {
+                    Download::updateOrCreate(
+                        ['source_key' => 'bundle:' . $bundle->id],
+                        [
+                            'user_id' => null,
+                            'category_id' => $category->id,
+                            'name' => $bundle->name,
+                            'slug' => Str::slug($bundle->name),
+                            'description' => $bundle->description,
+                            'external_url' => $target,
+                            'status' => Download::STATUS_PUBLISHED,
+                            'is_locked' => false,
+                            'position' => $bundle->position,
+                        ]
+                    );
+                }
+
+                $downloadsTouched++;
+                $this->line("   - {$bundle->name}");
+            }
+        }
+
+        foreach ($skipped as $s) {
+            $this->warn("SKIPPED: {$s}");
+        }
+
+        $verb = $dry ? 'Would migrate' : 'Migrated';
+        $this->info("{$verb} {$categoriesTouched} categories and {$downloadsTouched} downloads.");
+
+        if (! empty($skipped)) {
+            $this->warn(count($skipped) . ' entry/entries skipped (see above).');
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/SyncDefragMod.php
+++ b/app/Console/Commands/SyncDefragMod.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use App\Services\DefragReleaseScraper;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Mirrors the q3defrag.org release listing into the locked "DeFRaG mod"
+ * category, which renders as a self-updating article rather than a listing.
+ *
+ * The files stay on q3defrag.org: each entry only carries an external_url plus
+ * the version, date, size and channel needed to draw the release tables.
+ *
+ * Idempotent via source_key ('defrag_mod:stable:1.91').
+ */
+class SyncDefragMod extends Command
+{
+    protected $signature = 'downloads:sync-defrag-mod';
+
+    protected $description = 'Mirror the DeFRaG mod releases from q3defrag.org into the downloads hub';
+
+    public function handle(DefragReleaseScraper $scraper): int
+    {
+        $category = DownloadCategory::where('auto_source', DownloadCategory::SOURCE_DEFRAG_MOD)->first();
+
+        if (! $category) {
+            $this->error('The DeFRaG mod category is missing. Run: db:seed --class=DownloadCategorySeeder');
+            return 1;
+        }
+
+        try {
+            $stable = $scraper->stable();
+            $beta = $scraper->beta();
+        } catch (\Throwable $e) {
+            $this->error('Failed to fetch: ' . $e->getMessage());
+            Log::warning('SyncDefragMod: fetch failed - ' . $e->getMessage());
+            return 1;
+        }
+
+        if (empty($stable)) {
+            $this->warn('No stable releases found. q3defrag.org may be down - leaving existing entries alone.');
+            return 1;
+        }
+
+        $seen = [];
+        $latestVersion = end($stable)['version'];
+
+        foreach ([['stable', $stable], ['beta', $beta]] as [$channel, $files]) {
+            foreach ($files as $file) {
+                $key = "defrag_mod:{$channel}:{$file['version']}";
+                $seen[] = $key;
+
+                Download::updateOrCreate(
+                    ['source_key' => $key],
+                    [
+                        'user_id' => null,
+                        'category_id' => $category->id,
+                        'name' => "DeFRaG {$file['version']}" . ($channel === 'beta' ? ' beta' : ''),
+                        'slug' => Str::slug("defrag-{$file['version']}-{$channel}"),
+                        'description' => null,
+                        'external_url' => $file['url'],
+                        'is_locked' => true,
+                        'status' => Download::STATUS_PUBLISHED,
+                        'defrag_only' => true,
+                        'meta' => [
+                            'channel' => $channel,
+                            'version' => $file['version'],
+                            'date' => $file['date'],
+                            'size' => (int) $file['size'],
+                            'filename' => $file['filename'],
+                            'is_latest' => $channel === 'stable' && $file['version'] === $latestVersion,
+                        ],
+                    ]
+                );
+            }
+        }
+
+        // A release pulled from q3defrag.org should not linger here.
+        $removed = Download::where('category_id', $category->id)
+            ->where('source_key', 'like', 'defrag_mod:%')
+            ->whereNotIn('source_key', $seen)
+            ->delete();
+
+        $this->info(sprintf(
+            'Synced %d stable + %d beta releases (latest %s)%s.',
+            count($stable),
+            count($beta),
+            $latestVersion,
+            $removed ? ", removed {$removed} stale" : ''
+        ));
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/SyncFamilyFriendly.php
+++ b/app/Console/Commands/SyncFamilyFriendly.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Publishes the family-friendly pk3 set into its locked category, which
+ * renders as a self-updating article rather than a listing.
+ *
+ * The files are hosted on our own download hosts and change rarely, so there
+ * is no listing to scrape: the set is declared here and a HEAD request keeps
+ * each entry's size and date honest.
+ *
+ * Idempotent via source_key.
+ */
+class SyncFamilyFriendly extends Command
+{
+    protected $signature = 'downloads:sync-family-friendly';
+
+    protected $description = 'Refresh the Family-Friendly defrag pk3 set in the downloads hub';
+
+    private const FILES = [
+        [
+            'key' => 'safe-textures',
+            'name' => 'Safe textures',
+            'url' => 'https://bundles.defrag.racing/zzzzz-safe-textures.pk3',
+            'description' => 'Replaces the adult and gore artwork on world surfaces with clean versions. The zzzzz- prefix makes it load last, so it overrides everything else.',
+        ],
+        [
+            'key' => 'safe-models',
+            'name' => 'Safe player models',
+            'url' => 'https://dl.defrag.racing/downloads/useful-pk3s/zzz-all_models-safe.pk3',
+            'description' => 'Every player model in one pack, with the revealing and gory skins swapped for safe ones. Large, but it covers whoever you run into on a server.',
+        ],
+    ];
+
+    public function handle(): int
+    {
+        $category = DownloadCategory::where('auto_source', DownloadCategory::SOURCE_FAMILY_FRIENDLY)->first();
+
+        if (! $category) {
+            $this->error('The Family-Friendly category is missing. Run: db:seed --class=DownloadCategorySeeder');
+            return 1;
+        }
+
+        $seen = [];
+
+        foreach (self::FILES as $position => $file) {
+            $head = $this->head($file['url']);
+
+            if (! $head) {
+                // Keep whatever is already published rather than blanking the
+                // article because a host blipped.
+                $this->warn("Unreachable, leaving as is: {$file['url']}");
+                $existing = Download::where('source_key', 'family_friendly:' . $file['key'])->first();
+
+                if ($existing) {
+                    $seen[] = $existing->source_key;
+                }
+
+                continue;
+            }
+
+            $key = 'family_friendly:' . $file['key'];
+            $seen[] = $key;
+
+            Download::updateOrCreate(
+                ['source_key' => $key],
+                [
+                    'user_id' => null,
+                    'category_id' => $category->id,
+                    'name' => $file['name'],
+                    'slug' => $file['key'],
+                    'description' => $file['description'],
+                    'external_url' => $file['url'],
+                    'is_locked' => true,
+                    'status' => Download::STATUS_PUBLISHED,
+                    'position' => $position,
+                    'meta' => [
+                        'filename' => basename(parse_url($file['url'], PHP_URL_PATH)),
+                        'size' => $head['size'],
+                        'updated_at' => $head['last_modified'],
+                    ],
+                ]
+            );
+
+            $this->line("  {$file['name']} - " . $this->human($head['size']));
+        }
+
+        $removed = Download::where('category_id', $category->id)
+            ->where('source_key', 'like', 'family_friendly:%')
+            ->whereNotIn('source_key', $seen)
+            ->delete();
+
+        $this->info(sprintf(
+            'Published %d file(s)%s.',
+            count($seen),
+            $removed ? ", removed {$removed} stale" : ''
+        ));
+
+        return 0;
+    }
+
+    /**
+     * @return array{size: int, last_modified: ?string}|null
+     */
+    private function head(string $url): ?array
+    {
+        try {
+            $response = Http::withOptions(['verify' => false])->timeout(20)->head($url);
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $modified = $response->header('Last-Modified');
+
+            return [
+                'size' => (int) $response->header('Content-Length'),
+                'last_modified' => $modified ? Carbon::parse($modified)->toIso8601String() : null,
+            ];
+        } catch (\Throwable $e) {
+            Log::warning('SyncFamilyFriendly: HEAD failed for ' . $url . ' - ' . $e->getMessage());
+
+            return null;
+        }
+    }
+
+    private function human(int $bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            return round($bytes / 1073741824, 2) . ' GB';
+        }
+
+        if ($bytes >= 1048576) {
+            return round($bytes / 1048576, 1) . ' MB';
+        }
+
+        return round($bytes / 1024) . ' KB';
+    }
+}

--- a/app/Console/Commands/SyncServerBundle.php
+++ b/app/Console/Commands/SyncServerBundle.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Publishes the server bundle archives into the locked "DeFRaG server bundle"
+ * category, which renders as a self-updating article rather than a listing.
+ *
+ * Reads what bundle:build-server produced on the dl_storage disk: the two
+ * archives plus the dfsv-core.version.json marker recording the engine build
+ * and mod that went into them.
+ *
+ * Idempotent via source_key.
+ */
+class SyncServerBundle extends Command
+{
+    protected $signature = 'downloads:sync-server-bundle';
+
+    protected $description = 'Publish the DeFRaG server bundle archives into the downloads hub';
+
+    private const DISK = 'dl_storage';
+    private const MARKER = 'dfsv-core.version.json';
+    private const PUBLIC_BASE = 'https://dl.defrag.racing/downloads/';
+
+    private const ARCHIVES = [
+        [
+            'file' => 'dfsv-core.tar',
+            'name' => 'Server core',
+            'description' => 'The oDFe dedicated engine, the DeFRaG mod, the record system modules and ip4db. Rebuilt automatically whenever a new engine build or mod release appears.',
+        ],
+        [
+            'file' => 'dfsv-baseq3.tar',
+            'name' => 'baseq3 assets',
+            'description' => 'The stock Quake III Arena paks (pak0 to pak8). Never changes, so the installer only pulls it when baseq3/pak0.pk3 is missing.',
+        ],
+    ];
+
+    public function handle(): int
+    {
+        $category = DownloadCategory::where('auto_source', DownloadCategory::SOURCE_SERVER_BUNDLE)->first();
+
+        if (! $category) {
+            $this->error('The server bundle category is missing. Run: db:seed --class=DownloadCategorySeeder');
+            return 1;
+        }
+
+        $disk = Storage::disk(self::DISK);
+        $marker = [];
+
+        if ($disk->exists(self::MARKER)) {
+            $marker = json_decode($disk->get(self::MARKER), true) ?: [];
+        } else {
+            $this->warn(self::MARKER . ' not found. Run bundle:build-server first; publishing sizes only.');
+        }
+
+        $seen = [];
+
+        foreach (self::ARCHIVES as $position => $archive) {
+            if (! $disk->exists($archive['file'])) {
+                $this->warn("Missing on {$disk->getConfig()['driver']} disk, skipping: {$archive['file']}");
+                continue;
+            }
+
+            $key = 'server_bundle:' . $archive['file'];
+            $seen[] = $key;
+
+            Download::updateOrCreate(
+                ['source_key' => $key],
+                [
+                    'user_id' => null,
+                    'category_id' => $category->id,
+                    'name' => $archive['name'],
+                    'slug' => str_replace('.', '-', $archive['file']),
+                    'description' => $archive['description'],
+                    'external_url' => self::PUBLIC_BASE . $archive['file'],
+                    'is_locked' => true,
+                    'status' => Download::STATUS_PUBLISHED,
+                    'position' => $position,
+                    'meta' => [
+                        'filename' => $archive['file'],
+                        'size' => $disk->size($archive['file']),
+                        'built_at' => $marker['built_at'] ?? null,
+                        'engine' => $marker['engine'] ?? null,
+                        'mod' => $marker['mod'] ?? null,
+                    ],
+                ]
+            );
+
+            $this->line("  {$archive['file']} - " . $this->human($disk->size($archive['file'])));
+        }
+
+        if (empty($seen)) {
+            $this->error('Neither archive is on the disk. Nothing published.');
+            return 1;
+        }
+
+        $removed = Download::where('category_id', $category->id)
+            ->where('source_key', 'like', 'server_bundle:%')
+            ->whereNotIn('source_key', $seen)
+            ->delete();
+
+        $this->info(sprintf(
+            'Published %d archive(s)%s. Engine %s, mod %s.',
+            count($seen),
+            $removed ? ", removed {$removed} stale" : '',
+            $marker['engine'] ?? 'unknown',
+            $marker['mod'] ?? 'unknown'
+        ));
+
+        return 0;
+    }
+
+    private function human(int $bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            return round($bytes / 1073741824, 1) . ' GB';
+        }
+
+        if ($bytes >= 1048576) {
+            return round($bytes / 1048576, 1) . ' MB';
+        }
+
+        return round($bytes / 1024) . ' KB';
+    }
+}

--- a/app/Console/Commands/SyncServerBundle.php
+++ b/app/Console/Commands/SyncServerBundle.php
@@ -61,9 +61,19 @@ class SyncServerBundle extends Command
         $seen = [];
 
         foreach (self::ARCHIVES as $position => $archive) {
-            if (! $disk->exists($archive['file'])) {
-                $this->warn("Missing on {$disk->getConfig()['driver']} disk, skipping: {$archive['file']}");
-                continue;
+            // Prefer the disk (authoritative right after a build), but fall
+            // back to a HEAD request on the public URL: dfsv-baseq3.tar only
+            // exists on the prod disk, and the article should be complete no
+            // matter which host runs the sync.
+            if ($disk->exists($archive['file'])) {
+                $size = $disk->size($archive['file']);
+            } else {
+                $size = $this->remoteSize(self::PUBLIC_BASE . $archive['file']);
+
+                if ($size === null) {
+                    $this->warn("Not on the disk and unreachable at the public URL, skipping: {$archive['file']}");
+                    continue;
+                }
             }
 
             $key = 'server_bundle:' . $archive['file'];
@@ -83,7 +93,7 @@ class SyncServerBundle extends Command
                     'position' => $position,
                     'meta' => [
                         'filename' => $archive['file'],
-                        'size' => $disk->size($archive['file']),
+                        'size' => $size,
                         'built_at' => $marker['built_at'] ?? null,
                         'engine' => $marker['engine'] ?? null,
                         'mod' => $marker['mod'] ?? null,
@@ -91,7 +101,7 @@ class SyncServerBundle extends Command
                 ]
             );
 
-            $this->line("  {$archive['file']} - " . $this->human($disk->size($archive['file'])));
+            $this->line("  {$archive['file']} - " . $this->human($size));
         }
 
         if (empty($seen)) {
@@ -113,6 +123,23 @@ class SyncServerBundle extends Command
         ));
 
         return 0;
+    }
+
+    private function remoteSize(string $url): ?int
+    {
+        try {
+            $response = \Illuminate\Support\Facades\Http::withOptions(['verify' => false])
+                ->timeout(20)
+                ->head($url);
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            return (int) $response->header('Content-Length') ?: null;
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 
     private function human(int $bytes): string

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,6 +32,13 @@ class Kernel extends ConsoleKernel
         // Full rating recalc daily (backup - incremental handles new records in real-time)
         $schedule->command('ratings:calculate')->withoutOverlapping()->daily();
 
+        // Rebuild the server bundle (dfsv-core.tar) when a new oDFe engine build
+        // or DeFRaG mod appears; a no-op when nothing changed. The sync right
+        // after publishes the fresh archives (size, built_at) to the downloads
+        // hub, so it has to run second.
+        $schedule->command('bundle:build-server')->withoutOverlapping()->daily();
+        $schedule->command('downloads:sync-server-bundle')->withoutOverlapping()->dailyAt('00:30');
+
         // Update last_activity in player_ratings from records (~20s)
         $schedule->command('ratings:update-activity')->withoutOverlapping()->hourly();
 
@@ -128,6 +135,14 @@ class Kernel extends ConsoleKernel
 
         // Check q3defrag.org for new DeFRaG mod releases every Sunday at 12:00
         $schedule->command('wiki:check-defrag-releases')->withoutOverlapping()->weeklyOn(0, '12:00');
+
+        // Mirror those same releases into the downloads hub, whose DeFRaG mod
+        // category renders them as a self-updating article.
+        $schedule->command('downloads:sync-defrag-mod')->withoutOverlapping()->weeklyOn(0, '12:15');
+
+        // Refresh the size and date on the family-friendly pk3 set. The files
+        // rarely change, so weekly is plenty.
+        $schedule->command('downloads:sync-family-friendly')->withoutOverlapping()->weeklyOn(0, '12:30');
 
         // Prune guest sessions older than 24h so bot traffic doesn't bloat
         // the sessions table. Logged-in sessions keep the 30-day lifetime.

--- a/app/Filament/Pages/ServerBundle.php
+++ b/app/Filament/Pages/ServerBundle.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Jobs\BuildServerBundleJob;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Admin view for the auto-generated server bundle (dfsv-core.tar). Shows when
+ * it was last rebuilt (from the marker the build command writes) and offers a
+ * manual "Rebuild now" that dispatches the same job the daily scheduler runs.
+ */
+class ServerBundle extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-cube';
+    protected static ?string $navigationLabel = 'Server Bundle';
+    protected static ?string $navigationGroup = 'Storage';
+    protected static ?int $navigationSort = 42;
+    protected static string $view = 'filament.pages.server-bundle';
+
+    private const DISK = 'dl_storage';
+    private const MARKER = 'dfsv-core.version.json';
+    private const PUBLIC_BASE = 'https://dl.defrag.racing/downloads/';
+
+    public static function canAccess(): bool
+    {
+        $user = auth()->user();
+        return $user?->isAdmin() || $user?->hasModeratorPermission('storage_browser');
+    }
+
+    /** Build marker written by bundle:build-server (engine build + mod + built_at). */
+    public function getMarkerProperty(): ?array
+    {
+        $disk = Storage::disk(self::DISK);
+        if (! $disk->exists(self::MARKER)) {
+            return null;
+        }
+        return json_decode((string) $disk->get(self::MARKER), true) ?: null;
+    }
+
+    /** The three archives on the downloads disk with size + public URL. */
+    public function getFilesProperty(): array
+    {
+        $disk = Storage::disk(self::DISK);
+        $out = [];
+        foreach ([
+            'dfsv-core.tar'        => 'Core bundle (engine + mod + modules) - rebuilt automatically',
+            'dfsv-baseq3.tar'      => 'baseq3 paks - static, one-time',
+            'dfsv-core-static.tar' => 'Static base input (modules + qagame + ip4db + uglifix)',
+        ] as $name => $desc) {
+            $exists = $disk->exists($name);
+            $out[] = [
+                'name'   => $name,
+                'desc'   => $desc,
+                'exists' => $exists,
+                'size'   => $exists ? $disk->size($name) : null,
+                'url'    => self::PUBLIC_BASE . $name,
+            ];
+        }
+        return $out;
+    }
+
+    public function getStatusProperty(): ?string
+    {
+        return Cache::get('bundle_build:status');
+    }
+
+    /** @return string[] */
+    public function getLogProperty(): array
+    {
+        return Cache::get('bundle_build:log', []);
+    }
+
+    public function rebuild(): void
+    {
+        if (Cache::get('bundle_build:status') === 'running') {
+            Notification::make()->title('A rebuild is already running')->warning()->send();
+            return;
+        }
+
+        Cache::put('bundle_build:status', 'running', 3600);
+        Cache::put('bundle_build:log', ['[' . now()->format('H:i:s') . '] Dispatched, waiting for worker...'], 3600);
+
+        BuildServerBundleJob::dispatch();
+
+        Notification::make()
+            ->title('Rebuild dispatched')
+            ->body('Running in the background - the log below updates as it goes.')
+            ->success()
+            ->send();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('rebuild')
+                ->label('Rebuild now')
+                ->icon('heroicon-o-arrow-path')
+                ->requiresConfirmation()
+                ->modalDescription('Fetch the latest oDFe engine and DeFRaG mod and repackage dfsv-core.tar.')
+                ->action('rebuild'),
+        ];
+    }
+
+    public function formatBytes(?int $bytes): string
+    {
+        if ($bytes === null) {
+            return '-';
+        }
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $i = 0;
+        $value = (float) $bytes;
+        while ($value >= 1024 && $i < count($units) - 1) {
+            $value /= 1024;
+            $i++;
+        }
+        return round($value, $i === 0 ? 0 : 1) . ' ' . $units[$i];
+    }
+}

--- a/app/Filament/Resources/DownloadResource.php
+++ b/app/Filament/Resources/DownloadResource.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DownloadResource\Pages;
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use App\Models\ModerationLog;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Storage;
+
+class DownloadResource extends Resource
+{
+    protected static ?string $model = Download::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-down-tray';
+
+    protected static ?string $navigationGroup = 'Moderation';
+
+    protected static ?string $navigationLabel = 'Downloads';
+
+    protected static ?int $navigationSort = 7;
+
+    protected static ?string $modelLabel = 'Download';
+
+    protected static ?string $pluralModelLabel = 'Downloads';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasModeratorPermission('downloads') ?? false;
+    }
+
+    /**
+     * Auto-managed entries (the mod, server bundle, family-friendly set) are
+     * kept out of the moderation list: they are rebuilt by sync commands, so
+     * editing one by hand would just be overwritten on the next run.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('is_locked', false)
+            ->withCount('files');
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = static::getEloquentQuery()->whereNotNull('user_id')->count();
+
+        return $count ? (string) $count : null;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(150),
+            Forms\Components\Select::make('category_id')
+                ->label('Category')
+                ->options(fn () => static::categoryOptions())
+                ->searchable()
+                ->required(),
+            Forms\Components\Textarea::make('description')
+                ->maxLength(5000)
+                ->columnSpanFull(),
+            Forms\Components\TextInput::make('youtube_url')
+                ->label('YouTube URL')
+                ->url()
+                ->maxLength(255),
+            Forms\Components\Select::make('status')
+                ->options([
+                    Download::STATUS_PUBLISHED => 'Published',
+                    Download::STATUS_HIDDEN => 'Hidden',
+                    Download::STATUS_REJECTED => 'Rejected',
+                ])
+                ->required(),
+            Forms\Components\Toggle::make('defrag_only')
+                ->label('DeFRaG only'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->striped()
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->description(fn (Download $r) => $r->files_count . ' file(s)'),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Uploader')
+                    ->formatStateUsing(fn ($state) => $state ?? 'system')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('category.name')
+                    ->label('Category')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        Download::STATUS_PUBLISHED => 'success',
+                        Download::STATUS_HIDDEN => 'warning',
+                        Download::STATUS_REJECTED => 'danger',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('downloads_count')
+                    ->label('DL')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        Download::STATUS_PUBLISHED => 'Published',
+                        Download::STATUS_HIDDEN => 'Hidden',
+                        Download::STATUS_REJECTED => 'Rejected',
+                    ]),
+                Tables\Filters\SelectFilter::make('category_id')
+                    ->label('Category')
+                    ->options(fn () => static::categoryOptions())
+                    ->searchable(),
+                Tables\Filters\TernaryFilter::make('user_id')
+                    ->label('Source')
+                    ->placeholder('All')
+                    ->trueLabel('User uploads only')
+                    ->falseLabel('System only')
+                    ->queries(
+                        true: fn (Builder $q) => $q->whereNotNull('user_id'),
+                        false: fn (Builder $q) => $q->whereNull('user_id'),
+                        blank: fn (Builder $q) => $q,
+                    ),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('view')
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->color('gray')
+                    ->url(fn (Download $r) => "/downloads/entry/{$r->id}/{$r->slug}")
+                    ->openUrlInNewTab(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\Action::make('publish')
+                    ->icon('heroicon-o-check-circle')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->action(function (Download $record) {
+                        $record->update(['status' => Download::STATUS_PUBLISHED]);
+                        ModerationLog::log('downloads', 'published', $record, ['name' => $record->name]);
+                    })
+                    ->visible(fn (Download $r) => $r->status !== Download::STATUS_PUBLISHED),
+                Tables\Actions\Action::make('hide')
+                    ->icon('heroicon-o-eye-slash')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->action(function (Download $record) {
+                        $record->update(['status' => Download::STATUS_HIDDEN]);
+                        ModerationLog::log('downloads', 'hidden', $record, ['name' => $record->name]);
+                    })
+                    ->visible(fn (Download $r) => $r->status === Download::STATUS_PUBLISHED),
+                Tables\Actions\DeleteAction::make()
+                    ->before(fn (Download $record) => static::purgeFiles($record)),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->before(fn ($records) => $records->each(fn ($r) => static::purgeFiles($r))),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    /**
+     * Deletes an entry's stored objects before the row goes, so a removed
+     * upload does not leave orphans sitting in the bucket. cascadeOnDelete
+     * handles the download_files rows; this handles the bytes.
+     */
+    public static function purgeFiles(Download $record): void
+    {
+        foreach ($record->allFiles as $file) {
+            try {
+                Storage::disk($file->disk)->delete($file->path);
+            } catch (\Throwable $e) {
+                // A missing object should not block deleting the record.
+            }
+        }
+    }
+
+    private static function categoryOptions(): array
+    {
+        return DownloadCategory::where('is_locked', false)
+            ->whereNull('auto_source')
+            ->orderBy('name')
+            ->pluck('name', 'id')
+            ->all();
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDownloads::route('/'),
+            'edit' => Pages\EditDownload::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DownloadResource/Pages/EditDownload.php
+++ b/app/Filament/Resources/DownloadResource/Pages/EditDownload.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\DownloadResource\Pages;
+
+use App\Filament\Resources\DownloadResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDownload extends EditRecord
+{
+    protected static string $resource = DownloadResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make()
+                ->before(fn () => DownloadResource::purgeFiles($this->record)),
+        ];
+    }
+}

--- a/app/Filament/Resources/DownloadResource/Pages/ListDownloads.php
+++ b/app/Filament/Resources/DownloadResource/Pages/ListDownloads.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Resources\DownloadResource\Pages;
+
+use App\Filament\Resources\DownloadResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDownloads extends ListRecords
+{
+    protected static string $resource = DownloadResource::class;
+
+    // No create action: entries come from user uploads and sync commands, not
+    // from the admin panel.
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/DownloadsController.php
+++ b/app/Http/Controllers/DownloadsController.php
@@ -1,0 +1,525 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use App\Models\DownloadFile;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+
+class DownloadsController extends Controller
+{
+    private const PER_PAGE = 30;
+
+    private const UPLOAD_DISK = 'community';
+
+    /**
+     * Capped by docker/php.ini (upload_max_filesize + post_max_size = 100M).
+     * MAX_POST_MB is what the whole request may weigh, so several files have
+     * to fit inside it together. Raising these means raising the ini first.
+     */
+    private const MAX_FILE_MB = 95;
+    private const MAX_POST_MB = 100;
+
+    /**
+     * Anything a pk3 can hold, plus the archives people ship them in. No
+     * executables: this list is a whitelist for that reason.
+     */
+    private const ALLOWED_EXTENSIONS = [
+        'pk3', 'zip', '7z', 'rar', 'tar', 'gz',
+        'cfg', 'txt', 'shader', 'menu', 'arena', 'skin', 'md3', 'map', 'aas', 'bsp',
+        'tga', 'jpg', 'jpeg', 'png', 'webp', 'gif', 'pcx',
+        'wav', 'ogg', 'mp3', 'roq', 'dat',
+    ];
+
+    /**
+     * The hub listing: category tree on the left, downloads table on the right.
+     *
+     * The route keeps its legacy `/downloads/{id}/{slug}` shape. Pre-hub links
+     * carry ids from the old bundle_categories table, which no longer line up
+     * with anything, so the slug is resolved first and the id is only a
+     * fallback. The old slugs were built in JS as name.toLowerCase() with
+     * spaces dashed, which matches the Str::slug() the migration used, so
+     * every old link still lands on the right category.
+     */
+    public function index(Request $request, $id = null, $slug = null)
+    {
+        $category = $this->resolveCategory($id, $slug);
+
+        // A locked category is not a listing: it renders as its own article
+        // that keeps itself up to date, so it skips the table entirely.
+        if ($category && $category->auto_source) {
+            return Inertia::render('Downloads/Index', [
+                'tree' => $this->tree(),
+                'current' => $this->currentPayload($category),
+                'panel' => $this->panel($category),
+                'downloads' => null,
+                'filters' => ['q' => '', 'sort' => 'newest', 'defrag' => false],
+                'totalCount' => Download::published()->count(),
+            ]);
+        }
+
+        $search = trim((string) $request->input('q', ''));
+        $sort = $request->input('sort', 'newest');
+        $defragOnly = $request->boolean('defrag');
+
+        // total_size stays 0 for entries that only carry an external_url, where
+        // the bytes live on someone else's host and the listing shows a dash.
+        $query = Download::published()
+            ->with(['user:id,name', 'category:id,name,slug'])
+            ->withCount('files')
+            ->withSum('files as total_size', 'size');
+
+        if ($category) {
+            $query->whereIn('category_id', $category->descendantIds());
+        }
+
+        if ($search !== '') {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('description', 'like', "%{$search}%");
+            });
+        }
+
+        if ($defragOnly) {
+            $query->where('defrag_only', true);
+        }
+
+        match ($sort) {
+            'popular' => $query->orderByDesc('downloads_count')->orderByDesc('id'),
+            'name' => $query->orderBy('name'),
+            default => $query->orderByDesc('created_at')->orderByDesc('id'),
+        };
+
+        $downloads = $query->paginate(self::PER_PAGE)->withQueryString();
+
+        return Inertia::render('Downloads/Index', [
+            'tree' => $this->tree(),
+            'current' => $category ? $this->currentPayload($category) : null,
+            'panel' => null,
+            'downloads' => $downloads,
+            'filters' => [
+                'q' => $search,
+                'sort' => $sort,
+                'defrag' => $defragOnly,
+            ],
+            'totalCount' => Download::published()->count(),
+        ]);
+    }
+
+    /**
+     * Upload form. Locked categories are filtered out of the picker, so the
+     * auto-managed articles cannot be posted into.
+     */
+    public function create()
+    {
+        return Inertia::render('Downloads/Upload', [
+            'categories' => $this->selectableCategories(),
+            'maxFileMb' => self::MAX_FILE_MB,
+            'maxTotalMb' => self::MAX_POST_MB,
+            'allowedExtensions' => self::ALLOWED_EXTENSIONS,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $extensions = implode(',', self::ALLOWED_EXTENSIONS);
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:150'],
+            'category_id' => ['required', 'exists:download_categories,id'],
+            'description' => ['nullable', 'string', 'max:5000'],
+            'youtube_url' => ['nullable', 'url', 'max:255'],
+            'defrag_only' => ['boolean'],
+            'files' => ['required', 'array', 'min:1', 'max:10'],
+            // extensions, not mimes: mimes validates the content-sniffed type,
+            // and binary Quake formats (md3, bsp, aas, roq, dat) all sniff as
+            // octet-stream, so mimes would reject every one of them.
+            'files.*' => ['file', "extensions:{$extensions}", 'max:' . (self::MAX_FILE_MB * 1024)],
+            'screenshots' => ['nullable', 'array', 'max:6'],
+            'screenshots.*' => ['image', 'mimes:jpg,jpeg,png,webp,gif', 'max:5120'],
+        ]);
+
+        $category = DownloadCategory::findOrFail($data['category_id']);
+
+        // Belt and braces: the picker already hides these, but a handcrafted
+        // POST must not slip an upload into an auto-managed article.
+        if ($category->is_locked || $category->auto_source) {
+            return back()->withErrors(['category_id' => 'That category is managed automatically and does not take uploads.']);
+        }
+
+        $user = $request->user();
+
+        $download = Download::create([
+            'user_id' => $user->id,
+            'category_id' => $category->id,
+            'name' => $data['name'],
+            'slug' => Str::slug($data['name']) ?: 'upload',
+            'description' => $data['description'] ?? null,
+            'youtube_url' => $data['youtube_url'] ?? null,
+            'defrag_only' => $request->boolean('defrag_only'),
+            'status' => Download::STATUS_PUBLISHED,
+            'is_locked' => false,
+        ]);
+
+        $stored = [];
+
+        try {
+            foreach ($request->file('files') as $position => $file) {
+                $stored[] = $this->storeUpload($download, $file, DownloadFile::KIND_FILE, $position);
+            }
+
+            foreach ($request->file('screenshots') ?? [] as $position => $shot) {
+                $stored[] = $this->storeUpload($download, $shot, DownloadFile::KIND_SCREENSHOT, $position);
+            }
+        } catch (\Throwable $e) {
+            // Never leave a half-uploaded entry behind: drop the objects that
+            // did land, then the row itself.
+            foreach ($stored as $path) {
+                Storage::disk(self::UPLOAD_DISK)->delete($path);
+            }
+
+            $download->delete();
+
+            Log::error('Download upload failed', ['user_id' => $user->id, 'error' => $e->getMessage()]);
+
+            return back()->withErrors(['files' => 'Upload failed: ' . $e->getMessage()]);
+        }
+
+        return redirect()
+            ->route('downloads.show', [$download, $download->slug])
+            ->with('success', 'Upload published.');
+    }
+
+    /**
+     * Puts one uploaded file on the community bucket under the uploader's own
+     * folder and records it. Returns the stored path so a failed upload can be
+     * rolled back.
+     */
+    private function storeUpload(Download $download, $file, string $kind, int $position): string
+    {
+        $extension = strtolower($file->getClientOriginalExtension());
+        $path = "community/{$download->user_id}/{$download->id}/" . Str::ulid() . ".{$extension}";
+
+        // putFileAs streams from the temp file; ->get() would hold the whole
+        // upload (up to 95MB) as a string inside the Swoole worker.
+        Storage::disk(self::UPLOAD_DISK)->putFileAs(dirname($path), $file, basename($path));
+
+        DownloadFile::create([
+            'download_id' => $download->id,
+            'kind' => $kind,
+            'disk' => self::UPLOAD_DISK,
+            'path' => $path,
+            'original_name' => $file->getClientOriginalName(),
+            'size' => $file->getSize(),
+            'extension' => $extension,
+            'position' => $position,
+        ]);
+
+        return $path;
+    }
+
+    /**
+     * The flat category list for the upload picker: every category a person is
+     * allowed to post into, with its full path so "Music" is not ambiguous.
+     */
+    private function selectableCategories(): array
+    {
+        $categories = DownloadCategory::orderBy('position')->orderBy('name')->get()->keyBy('id');
+
+        return $categories
+            ->filter(fn ($c) => ! $c->is_locked && ! $c->auto_source)
+            ->map(function ($category) use ($categories) {
+                $path = [];
+
+                for ($node = $category; $node; $node = $node->parent_id ? $categories->get($node->parent_id) : null) {
+                    array_unshift($path, $node->name);
+                }
+
+                return [
+                    'id' => $category->id,
+                    'name' => $category->name,
+                    'path' => implode(' / ', $path),
+                    'depth' => count($path) - 1,
+                ];
+            })
+            ->sortBy('path')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Detail page: description, screenshot gallery, YouTube embed, file list.
+     */
+    public function show(Request $request, Download $download)
+    {
+        if ($download->status !== Download::STATUS_PUBLISHED) {
+            $user = $request->user();
+            $owner = $user && $user->id === $download->user_id;
+
+            // A hidden entry stays reachable for its author and for staff, so
+            // moderation is reviewable without flipping it public first.
+            if (! $owner && ! ($user && $this->isStaff($user))) {
+                abort(404);
+            }
+        }
+
+        $download->load(['user:id,name,country', 'category:id,name,slug,parent_id', 'files', 'screenshots']);
+
+        return Inertia::render('Downloads/Show', [
+            'download' => [
+                'id' => $download->id,
+                'name' => $download->name,
+                'slug' => $download->slug,
+                'description' => $download->description,
+                'youtube_id' => $download->youtube_id,
+                'external_url' => $download->external_url,
+                'is_locked' => $download->is_locked,
+                'status' => $download->status,
+                'defrag_only' => $download->defrag_only,
+                'downloads_count' => $download->downloads_count,
+                'created_at' => $download->created_at,
+                'user' => $download->user,
+                'category' => $download->category ? [
+                    'id' => $download->category->id,
+                    'name' => $download->category->name,
+                    'slug' => $download->category->slug,
+                    'breadcrumb' => $this->breadcrumb($download->category),
+                ] : null,
+                'files' => $download->files->map(fn ($f) => [
+                    'id' => $f->id,
+                    'original_name' => $f->original_name,
+                    'size' => $f->size,
+                    'extension' => $f->extension,
+                    'url' => route('downloads.file', $f),
+                ]),
+                'screenshots' => $download->screenshots->map(fn ($f) => [
+                    'id' => $f->id,
+                    'url' => $f->viewUrl(),
+                ]),
+            ],
+            // Editing happens in Filament for now; there is no Inertia edit
+            // page yet, so only staff get a link and it points at the admin.
+            'canModerate' => $request->user() && $this->isStaff($request->user()),
+        ]);
+    }
+
+    /**
+     * Serves one file.
+     *
+     * On S3 the browser is redirected to a short-lived signed link: the bucket
+     * is private, so a public URL would 401, and signing keeps the bytes off
+     * the app server, which matters for the bigger pk3 packs. Local disks have
+     * no signing and no public URL, so there the file is streamed instead,
+     * which is what dev runs on.
+     */
+    public function file(DownloadFile $file)
+    {
+        $download = $file->download;
+
+        if (! $download || $download->status !== Download::STATUS_PUBLISHED) {
+            abort(404);
+        }
+
+        $disk = Storage::disk($file->disk);
+
+        if (! $disk->exists($file->path)) {
+            Log::error('Download file missing from storage', [
+                'download_file_id' => $file->id,
+                'disk' => $file->disk,
+                'path' => $file->path,
+            ]);
+
+            abort(404);
+        }
+
+        // Counting the parent rather than the file keeps a multi-file entry
+        // from inflating its own number.
+        $download->increment('downloads_count');
+
+        if (config("filesystems.disks.{$file->disk}.driver") === 's3') {
+            return redirect()->away($disk->temporaryUrl($file->path, now()->addMinutes(15)));
+        }
+
+        return $disk->download($file->path, $file->original_name);
+    }
+
+    private function isStaff($user): bool
+    {
+        // Already true for admins.
+        return $user->hasModeratorPermission('downloads');
+    }
+
+    private function currentPayload(DownloadCategory $category): array
+    {
+        return [
+            'id' => $category->id,
+            'name' => $category->name,
+            'slug' => $category->slug,
+            'description' => $category->description,
+            'is_locked' => $category->is_locked,
+            'auto_source' => $category->auto_source,
+            'breadcrumb' => $this->breadcrumb($category),
+        ];
+    }
+
+    /**
+     * The article payload for a locked category. Everything here comes from a
+     * sync command, so a stale or empty result means the sync has not run yet
+     * rather than that something is broken.
+     */
+    private function panel(DownloadCategory $category): array
+    {
+        $entries = Download::published()
+            ->where('category_id', $category->id)
+            ->orderBy('position')
+            ->get();
+
+        if ($category->auto_source === DownloadCategory::SOURCE_DEFRAG_MOD) {
+            $byChannel = $entries->groupBy(fn ($d) => $d->meta['channel'] ?? 'stable');
+
+            $shape = fn ($d) => [
+                'id' => $d->id,
+                'version' => $d->meta['version'] ?? '?',
+                'date' => $d->meta['date'] ?? null,
+                'size' => $d->meta['size'] ?? null,
+                'filename' => $d->meta['filename'] ?? null,
+                'url' => $d->external_url,
+                'is_latest' => (bool) ($d->meta['is_latest'] ?? false),
+            ];
+
+            // Newest first: version_compare beats a string sort, which would
+            // put 1.9 above 1.91.
+            $sort = fn ($items) => $items
+                ->sort(fn ($a, $b) => version_compare($b['version'], $a['version']))
+                ->values()
+                ->all();
+
+            $stable = $sort(($byChannel['stable'] ?? collect())->map($shape));
+            $beta = $sort(($byChannel['beta'] ?? collect())->map($shape));
+
+            return [
+                'type' => 'defrag_mod',
+                'stable' => $stable,
+                'beta' => $beta,
+                'latest' => collect($stable)->firstWhere('is_latest', true) ?? ($stable[0] ?? null),
+                'source_url' => \App\Services\DefragReleaseScraper::STABLE_URL,
+            ];
+        }
+
+        if ($category->auto_source === DownloadCategory::SOURCE_FAMILY_FRIENDLY) {
+            return [
+                'type' => 'family_friendly',
+                'files' => $entries->map(fn ($d) => [
+                    'id' => $d->id,
+                    'name' => $d->name,
+                    'description' => $d->description,
+                    'filename' => $d->meta['filename'] ?? null,
+                    'size' => $d->meta['size'] ?? null,
+                    'updated_at' => $d->meta['updated_at'] ?? null,
+                    'url' => $d->external_url,
+                ])->values()->all(),
+            ];
+        }
+
+        if ($category->auto_source === DownloadCategory::SOURCE_SERVER_BUNDLE) {
+            $archives = $entries->map(fn ($d) => [
+                'id' => $d->id,
+                'name' => $d->name,
+                'description' => $d->description,
+                'filename' => $d->meta['filename'] ?? null,
+                'size' => $d->meta['size'] ?? null,
+                'url' => $d->external_url,
+            ])->values()->all();
+
+            $marker = $entries->first()?->meta ?? [];
+
+            return [
+                'type' => 'server_bundle',
+                'archives' => $archives,
+                'built_at' => $marker['built_at'] ?? null,
+                'engine' => $marker['engine'] ?? null,
+                'mod' => $marker['mod'] ?? null,
+                'repo_url' => 'https://github.com/Defrag-racing/defrag-server-bundle',
+            ];
+        }
+
+        return ['type' => 'unknown'];
+    }
+
+    private function resolveCategory($id, $slug): ?DownloadCategory
+    {
+        if ($slug) {
+            $category = DownloadCategory::where('slug', $slug)->first();
+
+            if ($category) {
+                return $category;
+            }
+        }
+
+        if (is_numeric($id) && (int) $id > 0) {
+            return DownloadCategory::find((int) $id);
+        }
+
+        return null;
+    }
+
+    private function breadcrumb(DownloadCategory $category): array
+    {
+        $crumbs = [];
+
+        for ($node = $category; $node; $node = $node->parent) {
+            array_unshift($crumbs, [
+                'id' => $node->id,
+                'name' => $node->name,
+                'slug' => $node->slug,
+            ]);
+        }
+
+        return $crumbs;
+    }
+
+    /**
+     * The whole tree with per-node counts. A parent's count includes its
+     * descendants, so "Maps 124" means the branch holds 124 downloads rather
+     * than 124 sitting directly on the parent.
+     */
+    private function tree(): array
+    {
+        $categories = DownloadCategory::orderBy('position')->orderBy('name')->get();
+
+        $direct = Download::published()
+            ->select('category_id', DB::raw('count(*) as aggregate'))
+            ->groupBy('category_id')
+            ->pluck('aggregate', 'category_id');
+
+        $byParent = $categories->groupBy('parent_id');
+
+        $build = function ($parentId) use (&$build, $byParent, $direct) {
+            return $byParent->get($parentId, collect())->map(function ($category) use ($build, $direct) {
+                $children = $build($category->id);
+
+                $count = (int) ($direct[$category->id] ?? 0)
+                    + collect($children)->sum('count');
+
+                return [
+                    'id' => $category->id,
+                    'name' => $category->name,
+                    'slug' => $category->slug,
+                    'description' => $category->description,
+                    'is_locked' => $category->is_locked,
+                    'auto_source' => $category->auto_source,
+                    'count' => $count,
+                    'children' => $children,
+                ];
+            })->values()->all();
+        };
+
+        return $build(null);
+    }
+}

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\MddProfile;
 use App\Models\PlayerModel;
 use App\Models\UserAlias;
+use App\Models\Download;
 
 class SearchController extends Controller
 {
@@ -172,10 +173,30 @@ class SearchController extends Controller
             ->limit(10)
             ->get(['id', 'name', 'author', 'head_icon']);
 
+        // Community downloads by name (with the same fuzzy fallback). Locked
+        // entries are included: someone searching "defrag mod" should find it.
+        $downloads = Download::published()
+            ->with('category:id,name,slug')
+            ->where(function ($query) use ($request, $fuzzyPattern) {
+                $query->where('name', 'LIKE', '%' . $request->search . '%')
+                    ->orWhere('name', 'LIKE', $fuzzyPattern);
+            })
+            ->orderByDesc('downloads_count')
+            ->limit(10)
+            ->get(['id', 'name', 'slug', 'category_id', 'downloads_count'])
+            ->map(fn ($d) => [
+                'id' => $d->id,
+                'name' => $d->name,
+                'slug' => $d->slug,
+                'category' => $d->category?->name,
+                'url' => "/downloads/entry/{$d->id}/{$d->slug}",
+            ]);
+
         return [
             'maps'      => $maps,
             'players'   => $players,
-            'models'    => $models
+            'models'    => $models,
+            'bundles'   => $downloads,
         ];
     }
 }

--- a/app/Jobs/BuildServerBundleJob.php
+++ b/app/Jobs/BuildServerBundleJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Runs `bundle:build-server --force` in the background so the admin "Rebuild
+ * now" button returns immediately. Status/log land in the cache for the
+ * Server Bundle page to poll.
+ */
+class BuildServerBundleJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 600;
+
+    public function handle(): void
+    {
+        Cache::put('bundle_build:status', 'running', 3600);
+        Cache::put('bundle_build:log', ['[' . now()->format('H:i:s') . '] Building...'], 3600);
+
+        try {
+            $code = Artisan::call('bundle:build-server', ['--force' => true]);
+            $out = array_values(array_filter(array_map('trim', explode("\n", Artisan::output()))));
+            $out[] = '[' . now()->format('H:i:s') . '] ' . ($code === 0 ? 'Done.' : 'Failed.');
+
+            Cache::put('bundle_build:log', $out, 3600);
+            Cache::put('bundle_build:status', $code === 0 ? 'done' : 'error', 3600);
+        } catch (\Throwable $e) {
+            Cache::put('bundle_build:log', ['Error: ' . $e->getMessage()], 3600);
+            Cache::put('bundle_build:status', 'error', 3600);
+        }
+    }
+}

--- a/app/Models/Download.php
+++ b/app/Models/Download.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Download extends Model
+{
+    use HasFactory;
+
+    public const STATUS_PUBLISHED = 'published';
+    public const STATUS_HIDDEN = 'hidden';
+    public const STATUS_REJECTED = 'rejected';
+
+    protected $fillable = [
+        'user_id',
+        'category_id',
+        'name',
+        'slug',
+        'description',
+        'youtube_url',
+        'external_url',
+        'source_key',
+        'is_locked',
+        'status',
+        'defrag_only',
+        'position',
+        'meta',
+    ];
+
+    protected $casts = [
+        'is_locked' => 'boolean',
+        'defrag_only' => 'boolean',
+        'downloads_count' => 'integer',
+        'meta' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(DownloadCategory::class, 'category_id');
+    }
+
+    public function files()
+    {
+        return $this->hasMany(DownloadFile::class)
+            ->where('kind', DownloadFile::KIND_FILE)
+            ->orderBy('position');
+    }
+
+    public function screenshots()
+    {
+        return $this->hasMany(DownloadFile::class)
+            ->where('kind', DownloadFile::KIND_SCREENSHOT)
+            ->orderBy('position');
+    }
+
+    /**
+     * Every attachment regardless of kind. Used when deleting an entry, where
+     * the files() / screenshots() filters would leave orphans behind.
+     */
+    public function allFiles()
+    {
+        return $this->hasMany(DownloadFile::class);
+    }
+
+    public function scopePublished($query)
+    {
+        return $query->where('status', self::STATUS_PUBLISHED);
+    }
+
+    /**
+     * The YouTube video id pulled out of whatever URL form the uploader
+     * pasted (watch?v=, youtu.be/, /embed/, /shorts/). Null when the URL is
+     * empty or is not a YouTube link we recognise, in which case the detail
+     * page simply renders no player.
+     */
+    public function getYoutubeIdAttribute(): ?string
+    {
+        if (! $this->youtube_url) {
+            return null;
+        }
+
+        $patterns = [
+            '~youtube\.com/watch\?(?:.*&)?v=([\w-]{11})~i',
+            '~youtu\.be/([\w-]{11})~i',
+            '~youtube\.com/embed/([\w-]{11})~i',
+            '~youtube\.com/shorts/([\w-]{11})~i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $this->youtube_url, $m)) {
+                return $m[1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Models/DownloadCategory.php
+++ b/app/Models/DownloadCategory.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DownloadCategory extends Model
+{
+    use HasFactory;
+
+    /**
+     * Categories fed by a sync command instead of by people.
+     */
+    public const SOURCE_DEFRAG_MOD = 'defrag_mod';
+    public const SOURCE_SERVER_BUNDLE = 'server_bundle';
+    public const SOURCE_FAMILY_FRIENDLY = 'family_friendly';
+
+    protected $fillable = [
+        'parent_id',
+        'name',
+        'slug',
+        'description',
+        'icon',
+        'position',
+        'is_locked',
+        'auto_source',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'is_locked' => 'boolean',
+    ];
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children()
+    {
+        return $this->hasMany(self::class, 'parent_id')->orderBy('position')->orderBy('name');
+    }
+
+    public function downloads()
+    {
+        return $this->hasMany(Download::class, 'category_id');
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function scopeRoots($query)
+    {
+        return $query->whereNull('parent_id');
+    }
+
+    /**
+     * This category's id plus every descendant's, so a listing for a parent
+     * also shows what sits in its subcategories. The tree is capped at three
+     * levels, so a recursive walk stays cheap.
+     */
+    public function descendantIds(): array
+    {
+        $ids = [$this->id];
+
+        foreach ($this->children as $child) {
+            $ids = array_merge($ids, $child->descendantIds());
+        }
+
+        return $ids;
+    }
+}

--- a/app/Models/DownloadFile.php
+++ b/app/Models/DownloadFile.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+class DownloadFile extends Model
+{
+    use HasFactory;
+
+    public const KIND_FILE = 'file';
+    public const KIND_SCREENSHOT = 'screenshot';
+
+    protected $fillable = [
+        'download_id',
+        'kind',
+        'disk',
+        'path',
+        'original_name',
+        'size',
+        'extension',
+        'position',
+    ];
+
+    protected $casts = [
+        'size' => 'integer',
+    ];
+
+    public function download()
+    {
+        return $this->belongsTo(Download::class);
+    }
+
+    /**
+     * A viewable link for this file, used by the screenshot gallery.
+     *
+     * On S3 that is a time-limited signed URL, because the community bucket is
+     * private and a plain public URL would 401. A local disk can sign nothing
+     * and exposes no public URL, so dev falls back to the app's own file
+     * route, which streams the bytes.
+     */
+    public function viewUrl(int $minutes = 60): string
+    {
+        if (config("filesystems.disks.{$this->disk}.driver") === 's3') {
+            return Storage::disk($this->disk)->temporaryUrl($this->path, now()->addMinutes($minutes));
+        }
+
+        return route('downloads.file', $this);
+    }
+}

--- a/app/Services/DefragReleaseScraper.php
+++ b/app/Services/DefragReleaseScraper.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Reads the DeFRaG mod release listing off q3defrag.org.
+ *
+ * The site serves a plain Apache directory index, so the releases are parsed
+ * out of the listing markup rather than an API.
+ */
+class DefragReleaseScraper
+{
+    public const STABLE_URL = 'https://q3defrag.org/files/defrag/';
+    public const BETA_URL = 'https://q3defrag.org/files/defrag/beta/';
+
+    /**
+     * @return array<int, array{filename: string, date: string, size: string, version: string, url: string}>
+     *         Oldest first.
+     */
+    public function scrape(string $url): array
+    {
+        $response = Http::withOptions(['verify' => false])->timeout(15)->get($url);
+
+        if (! $response->successful()) {
+            throw new \RuntimeException("HTTP {$response->status()} from {$url}");
+        }
+
+        $files = [];
+
+        preg_match_all(
+            '/<a href="(defrag_[\d.]+\.zip)">[^<]+<\/a>\s+([\d]+-\w+-[\d]+\s+[\d:]+)\s+(\d+)/i',
+            $response->body(),
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($matches as $match) {
+            $files[] = [
+                'filename' => $match[1],
+                'date' => trim($match[2]),
+                'size' => trim($match[3]),
+                'version' => $this->extractVersion($match[1]),
+                'url' => $url . $match[1],
+            ];
+        }
+
+        usort($files, fn ($a, $b) => version_compare($a['version'], $b['version']));
+
+        return $files;
+    }
+
+    public function stable(): array
+    {
+        return $this->scrape(self::STABLE_URL);
+    }
+
+    public function beta(): array
+    {
+        return $this->scrape(self::BETA_URL);
+    }
+
+    public function extractVersion(string $filename): string
+    {
+        if (preg_match('/defrag_([\d.]+)\.zip/', $filename, $m)) {
+            return $m[1];
+        }
+
+        return '0.0.0';
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -78,6 +78,27 @@ return [
                 'throw'      => true,
             ],
 
+        // Community downloads hub uploads. Its own B2 bucket + its own
+        // bucket-scoped key, so it never touches the demo credentials.
+        // The bucket is private: links come from temporaryUrl(), never a
+        // public URL, hence no 'url' key here. Local dev runs on disk.
+        'community' => env('COMMUNITY_DISK_DRIVER', 's3') === 'local'
+            ? [
+                'driver' => 'local',
+                'root'   => storage_path('app/community-local'),
+                'throw'  => true,
+            ]
+            : [
+                'driver'   => 's3',
+                'key'      => env('B2_COMMUNITY_KEY_ID'),
+                'secret'   => env('B2_COMMUNITY_APP_KEY'),
+                'region'   => env('B2_COMMUNITY_REGION', 'eu-central-003'),
+                'bucket'   => env('B2_COMMUNITY_BUCKET', 'defrag-community'),
+                'endpoint' => env('B2_COMMUNITY_ENDPOINT', 'https://s3.eu-central-003.backblazeb2.com'),
+                'use_path_style_endpoint' => false,
+                'throw'    => true,
+            ],
+
         // Serverdemo storage on the same VPS — read-only view of
         // /var/lib/serverdemos/<sftp_user>/ where the ingest daemon
         // parks .dm_68 uploads. Reuses the dlbrowser key + host since

--- a/database/migrations/2026_07_15_184710_create_download_categories_table.php
+++ b/database/migrations/2026_07_15_184710_create_download_categories_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('download_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('parent_id')->nullable()->constrained('download_categories')->nullOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->text('description')->nullable();
+            $table->string('icon')->nullable();
+            $table->unsignedInteger('position')->default(0);
+
+            // Locked categories are fed by a sync command: users cannot upload
+            // into them and the tree editor refuses to rename or move them.
+            $table->boolean('is_locked')->default(false);
+
+            // 'defrag_mod' | 'server_bundle'. Null for ordinary categories.
+            $table->string('auto_source')->nullable();
+
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['parent_id', 'slug']);
+            $table->index(['parent_id', 'position']);
+            $table->index('auto_source');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('download_categories');
+    }
+};

--- a/database/migrations/2026_07_15_184711_create_downloads_table.php
+++ b/database/migrations/2026_07_15_184711_create_downloads_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('downloads', function (Blueprint $table) {
+            $table->id();
+
+            // Null for entries created by a sync command rather than a person.
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            // restrict, not cascade: cascading a category delete would drop
+            // user uploads at the DB level, past every purge hook, leaving
+            // their objects orphaned in the bucket forever.
+            $table->foreignId('category_id')->constrained('download_categories')->restrictOnDelete();
+
+            $table->string('name');
+            $table->string('slug');
+            $table->text('description')->nullable();
+            $table->string('youtube_url')->nullable();
+
+            // Set when the entry only points elsewhere (q3defrag.org, a repo)
+            // instead of owning files in download_files.
+            $table->string('external_url')->nullable();
+
+            // Identifies an auto-synced entry so a re-sync updates instead of
+            // duplicating it, e.g. 'defrag_mod:1.91'.
+            $table->string('source_key')->nullable()->unique();
+
+            $table->boolean('is_locked')->default(false);
+            $table->string('status')->default('published'); // published | hidden | rejected
+
+            // Marks assets that only make sense under the DeFRaG mod (HUDs,
+            // configs) so the listing can filter them out for baseq3 users.
+            $table->boolean('defrag_only')->default(false);
+
+            $table->unsignedBigInteger('downloads_count')->default(0);
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->index(['category_id', 'status']);
+            $table->index(['status', 'created_at']);
+            $table->index('user_id');
+            $table->index('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('downloads');
+    }
+};

--- a/database/migrations/2026_07_15_184712_create_download_files_table.php
+++ b/database/migrations/2026_07_15_184712_create_download_files_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('download_files', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('download_id')->constrained('downloads')->cascadeOnDelete();
+
+            // 'file' is a downloadable asset, 'screenshot' is gallery imagery.
+            $table->string('kind')->default('file');
+
+            // Which filesystem disk `path` lives on. Community uploads land on
+            // 'community'; the locked categories point at 'dl_storage' files.
+            $table->string('disk')->default('community');
+            $table->string('path');
+
+            $table->string('original_name');
+            $table->unsignedBigInteger('size')->default(0);
+            $table->string('extension', 32)->nullable();
+            $table->unsignedInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->index(['download_id', 'kind', 'position']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('download_files');
+    }
+};

--- a/database/migrations/2026_07_15_194502_add_meta_to_downloads_table.php
+++ b/database/migrations/2026_07_15_194502_add_meta_to_downloads_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('downloads', function (Blueprint $table) {
+            // Free-form details for auto-synced entries: version, release date,
+            // remote size, filename. Those files live on someone else's host,
+            // so there is no download_files row to carry them.
+            $table->json('meta')->nullable()->after('source_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('downloads', function (Blueprint $table) {
+            $table->dropColumn('meta');
+        });
+    }
+};

--- a/database/seeders/DownloadCategorySeeder.php
+++ b/database/seeders/DownloadCategorySeeder.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Download;
+use App\Models\DownloadCategory;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+/**
+ * The default category tree.
+ *
+ * A .pk3 is a zip that the engine merges into one virtual filesystem rooted at
+ * the game folder, so assets are found by path convention (textures/, models/,
+ * sound/, ...) rather than by which pk3 they came from. Anything at one of
+ * those paths can be overridden by a custom pk3, which is why the tree mirrors
+ * the real layout of pak0-pak8 and every node names the path it maps to.
+ *
+ * Three areas are deliberately absent because the site already covers them and
+ * a second home would only split the content:
+ *   - playable maps            -> /maps
+ *   - player models and skins  -> /models (category player)
+ *   - weapon models            -> /models (category weapon)
+ * Demos (demos/) have their own section too, and vm/*.qvm is compiled game
+ * code rather than an asset, which the DeFRaG mod category covers.
+ *
+ * Safe to re-run: nodes are matched on (parent, slug) and updated in place, so
+ * existing uploads keep their category. Nothing is ever deleted here.
+ */
+class DownloadCategorySeeder extends Seeder
+{
+    /**
+     * (parent_id, slug) pairs this run is responsible for, collected while
+     * walking the tree so the prune below knows what belongs.
+     */
+    private array $seeded = [];
+
+    public function run(): void
+    {
+        foreach ($this->tree() as $position => $node) {
+            $this->createNode($node, null, $position);
+        }
+
+        $this->prune();
+    }
+
+    /**
+     * Drops default categories that the tree no longer defines, which is what
+     * happens when a node gets renamed and its slug changes. Only ever touches
+     * a category that is all of: not in the tree above, empty across its whole
+     * subtree, and not created by a person (created_by is null). So renaming a
+     * node cleans up after itself, while admin-made categories and anything
+     * holding uploads survive untouched.
+     */
+    private function prune(): void
+    {
+        // "Bundles and repacks" is seeded as an empty shell and filled in by
+        // downloads:migrate-bundles, so its children are legitimately absent
+        // from the tree above. Without this they would survive only as long as
+        // they held uploads, and emptying one would quietly delete it.
+        $protectedRoots = DownloadCategory::whereNull('parent_id')
+            ->whereIn('slug', ['bundles-and-repacks'])
+            ->pluck('id')
+            ->all();
+
+        $stale = DownloadCategory::whereNull('created_by')
+            ->get()
+            ->reject(fn ($c) => in_array([$c->parent_id, $c->slug], $this->seeded, true))
+            ->reject(fn ($c) => in_array($c->parent_id, $protectedRoots, true));
+
+        foreach ($stale as $category) {
+            if (! DownloadCategory::find($category->id)) {
+                continue; // already removed as part of an ancestor's subtree
+            }
+
+            $ids = $category->descendantIds();
+
+            if (Download::whereIn('category_id', $ids)->exists()) {
+                continue;
+            }
+
+            // The created_by guard above only vetted the subtree ROOT; an
+            // admin-made child nested under a renamed seeded node would
+            // otherwise be deleted with it.
+            if (DownloadCategory::whereIn('id', $ids)->whereNotNull('created_by')->exists()) {
+                continue;
+            }
+
+            // Children first: parent_id is a real foreign key.
+            DownloadCategory::whereIn('id', array_reverse($ids))->delete();
+        }
+    }
+
+    private function createNode(array $node, ?int $parentId, int $position): void
+    {
+        $category = DownloadCategory::updateOrCreate(
+            [
+                'parent_id' => $parentId,
+                'slug' => $node['slug'],
+            ],
+            [
+                'name' => $node['name'],
+                'description' => $node['description'] ?? null,
+                'position' => $position,
+                'is_locked' => $node['is_locked'] ?? false,
+                'auto_source' => $node['auto_source'] ?? null,
+            ]
+        );
+
+        $this->seeded[] = [$parentId, $node['slug']];
+
+        foreach ($node['children'] ?? [] as $childPosition => $child) {
+            $this->createNode($child, $category->id, $childPosition);
+        }
+    }
+
+    private function node(string $name, string $description, array $children = [], array $extra = []): array
+    {
+        return array_merge([
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'description' => $description,
+            'children' => $children,
+        ], $extra);
+    }
+
+    private function tree(): array
+    {
+        return [
+            $this->node('Textures', 'Surface images applied to map geometry (textures/*.tga, *.jpg).', [
+                $this->node('World and architecture', 'Walls, floors, trims and lights. The base and gothic sets (textures/base_*, textures/gothic_*).'),
+                $this->node('Effects and SFX', 'Glows, flares, decals and animated surfaces (textures/sfx/, textures/effects/).'),
+                $this->node('Liquids', 'Water, slime and lava surfaces (textures/liquids/).'),
+                $this->node('Skies and environment', 'Skybox faces and environment maps (textures/skies/, env/).'),
+                $this->node('Nature and stone', 'Organic, stone and terrain surfaces (textures/organics/, textures/stone/).'),
+                $this->node('CTF', 'Red and blue team surfaces (textures/ctf/).'),
+                $this->node('Common and editor', 'Caulk, clip, trigger and hint. Compile-time surfaces (textures/common/).'),
+            ]),
+
+            $this->node('Shaders', 'Scripts defining how a surface renders: blending, transparency, scroll, deform, sky (scripts/*.shader).'),
+
+            $this->node('Mapping', 'Resources for building maps rather than the finished maps themselves. Playable maps live in the Maps section.', [
+                $this->node('Map models and prefabs', 'Decorative meshes placed in maps, and reusable prefab pieces (models/mapobjects/).'),
+                $this->node('Map templates and sources', 'Editable .map sources and starter templates to build on.'),
+                $this->node('Levelshots', 'Loading-screen preview images (levelshots/<map>.jpg).'),
+                $this->node('Bot navigation', 'Bot routing data for maps that ship without it (maps/*.aas).'),
+                $this->node('Arena files', 'Map metadata shown in menus: longname, gametype, bots (scripts/*.arena).'),
+                $this->node('Editor and compiler', 'Radiant configs, compiler settings and mapping tools.'),
+            ]),
+
+            $this->node('Models', 'In-game meshes. Player and weapon models have their own home in the Models section.', [
+                $this->node('Item and pickup models', 'Health, armor, ammo, powerups and flags (models/powerups/, models/ammo/, models/flags/).'),
+                $this->node('Gibs and impact effects', 'Gore chunks and weapon impact meshes (models/gibs/, models/weaphits/).'),
+                $this->node('Misc models', 'Everything else under models/misc/.'),
+            ]),
+
+            $this->node('Sounds and music', 'Everything audible (sound/*.wav, *.ogg, music/).', [
+                $this->node('Player sounds', 'Pain, jump, taunt and death per model (sound/player/).'),
+                $this->node('Weapon sounds', 'Fire, impact and explosion (sound/weapons/).'),
+                $this->node('World and movers', 'Doors, platforms, teleporters and ambient loops (sound/world/, sound/movers/).'),
+                $this->node('Item sounds', 'Pickup and powerup cues (sound/items/).'),
+                $this->node('Announcer and feedback', 'Countdown, timer and checkpoint cues (sound/feedback/).'),
+                $this->node('Teamplay', 'Team orders and callouts (sound/teamplay/).'),
+                $this->node('Music', 'Background tracks for maps and menus (music/).'),
+            ]),
+
+            $this->node('HUDs and configs', 'The in-game interface and cvar setups. DeFRaG physics is compiled into the mod and no pk3 can change it, so only its display and cvars are configurable here.', [
+                $this->node('Defrag HUDs', 'HUD configs driving the timer, speed meter, checkpoints and CGaZ or snap overlays.'),
+                $this->node('HUD graphics', 'Speed bars, timer backgrounds and accel overlays referenced by a HUD.'),
+                $this->node('Player configs', 'autoexec.cfg, sensitivity, video and network settings.'),
+                $this->node('Binds and scripts', 'Shareable bind scripts and movement helpers.'),
+            ]),
+
+            $this->node('Menus and UI', 'The out-of-game front end and text rendering.', [
+                $this->node('Menu art', 'Menu backgrounds, widgets and screens (menu/art/).'),
+                $this->node('Medals and awards', 'Award icons shown after a match (menu/medals/).'),
+                $this->node('Fonts', 'Bitmap fonts and glyph metrics used by menus and the HUD.'),
+            ]),
+
+            $this->node('GFX and 2D', 'Flat screen-space imagery not tied to world geometry (gfx/).', [
+                $this->node('Crosshairs', 'Selectable crosshair images (gfx/2d/crosshair*.tga).'),
+                $this->node('Screen overlays', 'Damage flash, vignette, HUD frame art and numbers (gfx/2d/, gfx/damage/).'),
+                $this->node('Icons', 'Weapon, item and ammo pickup icons (icons/).'),
+                $this->node('Sprites and explosions', 'Animated sprite sheets for effects (sprites/).'),
+                $this->node('Colors and misc', 'Palette strips and leftover 2D art (gfx/colors/, gfx/misc/).'),
+            ]),
+
+            $this->node('Botfiles', 'Bot AI behavior, weights, chats and rosters (botfiles/, botfiles/bots/).'),
+
+            $this->node('Videos', 'In-game cinematics and end-of-match videos (video/*.RoQ).'),
+
+            // Home for the pre-hub downloads. They are curated collections
+            // rather than asset types (a repack holds maps, textures and
+            // shaders at once), so they keep their own branch instead of
+            // being torn apart across the tree above. Children are attached
+            // by downloads:migrate-bundles.
+            $this->node('Bundles and repacks', 'Curated collections that bundle many assets into a single pk3 or archive.'),
+
+            // The two locked categories. Neither is a listing: each renders as
+            // its own article that keeps itself up to date, so they have no
+            // subcategories and no upload button. Their entries come from
+            // downloads:sync-defrag-mod and downloads:sync-server-bundle.
+            $this->node('DeFRaG mod', 'Official DeFRaG mod releases, mirrored automatically from q3defrag.org.', [], [
+                'is_locked' => true,
+                'auto_source' => DownloadCategory::SOURCE_DEFRAG_MOD,
+            ]),
+
+            $this->node('DeFRaG server bundle', 'Everything needed to run a DeFRaG server, built automatically from the latest engine and mod.', [], [
+                'is_locked' => true,
+                'auto_source' => DownloadCategory::SOURCE_SERVER_BUNDLE,
+            ]),
+
+            $this->node('Family-Friendly defrag', 'Replaces the gore and adult artwork with safe alternatives, for streaming, work and younger players.', [], [
+                'is_locked' => true,
+                'auto_source' => DownloadCategory::SOURCE_FAMILY_FRIENDLY,
+            ]),
+        ];
+    }
+}

--- a/resources/js/Components/DownloadCategoryNode.vue
+++ b/resources/js/Components/DownloadCategoryNode.vue
@@ -1,0 +1,89 @@
+<script setup>
+import { ref, computed, watch } from 'vue';
+import { Link } from '@inertiajs/vue3';
+
+// Self-referencing component: the tree nests up to three levels, so the node
+// renders itself for its children.
+defineOptions({ name: 'DownloadCategoryNode' });
+
+const props = defineProps({
+    node: Object,
+    currentId: Number,
+    openIds: Array,
+    depth: { type: Number, default: 0 },
+});
+
+const isActive = computed(() => props.currentId === props.node.id);
+const hasChildren = computed(() => props.node.children?.length > 0);
+
+// A branch starts open when the selected category lives inside it, so landing
+// on a subcategory reveals where you are instead of a collapsed tree.
+const open = ref(props.openIds.includes(props.node.id));
+
+watch(() => props.openIds, (ids) => {
+    if (ids.includes(props.node.id)) {
+        open.value = true;
+    }
+});
+
+const url = computed(() => `/downloads/${props.node.id}/${props.node.slug}`);
+</script>
+
+<template>
+    <div>
+        <div
+            class="group flex items-center border-l-2 transition-all"
+            :class="isActive
+                ? 'bg-cyan-500/10 border-cyan-400'
+                : 'border-transparent hover:bg-cyan-500/5 hover:border-cyan-500/20'">
+
+            <button
+                v-if="hasChildren"
+                @click="open = !open"
+                class="flex-shrink-0 p-1 ml-1 text-gray-600 hover:text-cyan-300 transition-colors"
+                :aria-label="open ? 'Collapse' : 'Expand'">
+                <svg class="w-3 h-3 transition-transform" :class="open ? 'rotate-90' : ''"
+                     fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                </svg>
+            </button>
+            <span v-else class="flex-shrink-0 w-5"></span>
+
+            <Link
+                :href="url"
+                class="flex-1 flex items-center justify-between min-w-0 py-2 pr-3"
+                :style="{ paddingLeft: `${depth * 10}px` }">
+                <span class="flex items-center gap-1.5 min-w-0">
+                    <svg v-if="node.is_locked" class="w-3 h-3 flex-shrink-0 text-amber-500/70"
+                         fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                    </svg>
+                    <span
+                        class="text-sm truncate transition-colors"
+                        :class="[
+                            isActive ? 'text-cyan-300 font-medium' : 'text-gray-400 group-hover:text-white',
+                            depth === 0 ? 'font-medium' : '',
+                        ]">
+                        {{ node.name }}
+                    </span>
+                </span>
+                <span
+                    class="text-[10px] font-bold px-1.5 py-0.5 rounded-full ml-2 flex-shrink-0"
+                    :class="isActive ? 'bg-cyan-500/20 text-cyan-300' : 'bg-white/5 text-gray-600'">
+                    {{ node.count }}
+                </span>
+            </Link>
+        </div>
+
+        <div v-if="hasChildren && open">
+            <DownloadCategoryNode
+                v-for="child in node.children"
+                :key="child.id"
+                :node="child"
+                :current-id="currentId"
+                :open-ids="openIds"
+                :depth="depth + 1" />
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Downloads/CategorySelect.vue
+++ b/resources/js/Components/Downloads/CategorySelect.vue
@@ -1,0 +1,168 @@
+<script setup>
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
+
+/**
+ * Category picker for the upload form.
+ *
+ * A native <select> is drawn by the OS, so the dark styling never reaches its
+ * popup and it comes out light grey. This renders its own panel instead, and
+ * a flat list of 40 paths needs a filter and grouping to be usable anyway.
+ */
+const props = defineProps({
+    modelValue: [Number, String],
+    categories: Array,
+    hasError: Boolean,
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const open = ref(false);
+const search = ref('');
+const root = ref(null);
+const searchInput = ref(null);
+const activeIndex = ref(0);
+
+const selected = computed(() => props.categories.find((c) => c.id === props.modelValue) ?? null);
+
+const matches = computed(() => {
+    const q = search.value.trim().toLowerCase();
+
+    if (!q) return props.categories;
+
+    return props.categories.filter((c) => c.path.toLowerCase().includes(q));
+});
+
+// Grouped under their top-level branch, so "Music" reads as part of "Sounds
+// and music" rather than floating on its own.
+const groups = computed(() => {
+    const out = [];
+
+    for (const c of matches.value) {
+        const rootName = c.path.split(' / ')[0];
+        let group = out.find((g) => g.name === rootName);
+
+        if (!group) {
+            group = { name: rootName, items: [] };
+            out.push(group);
+        }
+
+        group.items.push(c);
+    }
+
+    return out;
+});
+
+// Flattened again for arrow-key movement, in the same order as rendered.
+const flat = computed(() => groups.value.flatMap((g) => g.items));
+
+const pick = (category) => {
+    emit('update:modelValue', category.id);
+    open.value = false;
+    search.value = '';
+};
+
+const toggle = async () => {
+    open.value = !open.value;
+
+    if (open.value) {
+        activeIndex.value = Math.max(0, flat.value.findIndex((c) => c.id === props.modelValue));
+        await nextTick();
+        searchInput.value?.focus();
+    }
+};
+
+const move = (step) => {
+    if (!flat.value.length) return;
+    activeIndex.value = (activeIndex.value + step + flat.value.length) % flat.value.length;
+};
+
+const onEnter = () => {
+    const item = flat.value[activeIndex.value];
+    if (item) pick(item);
+};
+
+watch(search, () => { activeIndex.value = 0; });
+
+const onClickOutside = (e) => {
+    if (open.value && root.value && !root.value.contains(e.target)) {
+        open.value = false;
+    }
+};
+
+onMounted(() => document.addEventListener('mousedown', onClickOutside));
+onUnmounted(() => document.removeEventListener('mousedown', onClickOutside));
+</script>
+
+<template>
+    <div ref="root" class="relative">
+        <button
+            type="button"
+            @click="toggle"
+            @keydown.down.prevent="!open ? toggle() : move(1)"
+            class="w-full flex items-center justify-between gap-2 bg-black/40 border rounded-lg px-3 py-2 text-sm text-left transition-colors"
+            :class="[
+                hasError ? 'border-red-500/50' : 'border-white/10 hover:border-white/20',
+                open ? 'border-cyan-500/50' : '',
+            ]">
+            <span v-if="selected" class="truncate">
+                <span class="text-gray-600">{{ selected.path.split(' / ').slice(0, -1).join(' / ') }}</span>
+                <span v-if="selected.depth > 0" class="text-gray-700"> / </span>
+                <span class="text-white">{{ selected.name }}</span>
+            </span>
+            <span v-else class="text-gray-600">Pick a category...</span>
+
+            <svg class="w-4 h-4 flex-shrink-0 text-gray-600 transition-transform" :class="open ? 'rotate-180' : ''"
+                 fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+        </button>
+
+        <div v-if="open"
+             class="absolute z-50 mt-1 w-full bg-gray-950/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-2xl overflow-hidden">
+
+            <div class="p-2 border-b border-white/5">
+                <input
+                    ref="searchInput"
+                    v-model="search"
+                    type="text"
+                    placeholder="Filter..."
+                    @keydown.down.prevent="move(1)"
+                    @keydown.up.prevent="move(-1)"
+                    @keydown.enter.prevent="onEnter"
+                    @keydown.esc="open = false"
+                    class="w-full bg-black/50 border border-white/10 rounded-lg px-2.5 py-1.5 text-sm text-white placeholder-gray-600 focus:border-cyan-500/50 focus:ring-0 transition-colors" />
+            </div>
+
+            <div class="max-h-72 overflow-y-auto py-1">
+                <template v-for="group in groups" :key="group.name">
+                    <div class="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-gray-600 font-bold">
+                        {{ group.name }}
+                    </div>
+
+                    <button
+                        v-for="item in group.items"
+                        :key="item.id"
+                        type="button"
+                        @click="pick(item)"
+                        @mouseenter="activeIndex = flat.indexOf(item)"
+                        class="w-full text-left px-3 py-1.5 text-sm transition-colors flex items-center justify-between gap-2"
+                        :class="[
+                            item.id === modelValue ? 'text-cyan-300' : 'text-gray-400',
+                            flat[activeIndex]?.id === item.id ? 'bg-cyan-500/10' : '',
+                        ]"
+                        :style="{ paddingLeft: `${12 + item.depth * 14}px` }">
+                        <span class="truncate">{{ item.name }}</span>
+                        <svg v-if="item.id === modelValue" class="w-3.5 h-3.5 flex-shrink-0"
+                             fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                        </svg>
+                    </button>
+                </template>
+
+                <p v-if="!flat.length" class="px-3 py-4 text-sm text-gray-600 text-center">
+                    Nothing matches "{{ search }}".
+                </p>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Downloads/DefragModPanel.vue
+++ b/resources/js/Components/Downloads/DefragModPanel.vue
@@ -1,0 +1,150 @@
+<script setup>
+import { Link } from '@inertiajs/vue3';
+
+defineProps({
+    panel: Object,
+});
+
+const formatSize = (bytes) => {
+    if (!bytes) return '-';
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    if (bytes >= 1024) return Math.round(bytes / 1024) + ' KB';
+    return bytes + ' B';
+};
+</script>
+
+<template>
+    <div class="space-y-3">
+
+        <!-- Intro + latest -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+            <div class="flex items-start justify-between gap-4 flex-wrap">
+                <div class="max-w-2xl">
+                    <p class="text-sm text-gray-400 leading-relaxed">
+                        Official DeFRaG mod releases, mirrored from
+                        <a :href="panel.source_url" target="_blank" rel="noopener"
+                           class="text-cyan-400 hover:text-cyan-300 transition-colors">q3defrag.org</a>.
+                        This page updates itself, so it always shows every release that is actually out there.
+                    </p>
+                </div>
+
+                <div v-if="panel.latest"
+                     class="flex-shrink-0 bg-gradient-to-br from-cyan-500/15 to-cyan-500/5 border border-cyan-500/30 rounded-xl px-4 py-3 min-w-[190px]">
+                    <div class="text-[10px] uppercase tracking-wider text-cyan-500/80 font-bold mb-1">Latest stable</div>
+                    <div class="flex items-baseline gap-2">
+                        <span class="text-2xl font-black text-white">{{ panel.latest.version }}</span>
+                        <span class="text-[11px] text-gray-500">{{ panel.latest.date }}</span>
+                    </div>
+                    <a :href="panel.latest.url" target="_blank" rel="noopener"
+                       class="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-cyan-500/20 border border-cyan-500/40 text-xs font-bold text-cyan-300 hover:bg-cyan-500/30 transition-all">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                        </svg>
+                        Download {{ formatSize(panel.latest.size) }}
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Stable -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+            <div class="px-4 py-3 border-b border-white/5">
+                <h2 class="text-sm font-black text-white">Stable releases</h2>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="text-left text-[11px] uppercase tracking-wider text-gray-500 bg-white/[0.03]">
+                            <th class="font-semibold px-4 py-2.5">Version</th>
+                            <th class="font-semibold px-3 py-2.5 hidden sm:table-cell">Date</th>
+                            <th class="font-semibold px-3 py-2.5 text-right">Size</th>
+                            <th class="font-semibold px-3 py-2.5">Download</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="r in panel.stable" :key="r.id"
+                            class="border-t border-white/5 hover:bg-cyan-500/[0.04] transition-colors">
+                            <td class="px-4 py-2.5">
+                                <span class="font-bold text-gray-200">{{ r.version }}</span>
+                                <span v-if="r.is_latest"
+                                      class="ml-2 text-[9px] font-black px-1.5 py-0.5 rounded bg-green-500 text-black">
+                                    LATEST
+                                </span>
+                            </td>
+                            <td class="px-3 py-2.5 hidden sm:table-cell text-xs text-gray-500 whitespace-nowrap">{{ r.date }}</td>
+                            <td class="px-3 py-2.5 text-right text-xs text-gray-500 whitespace-nowrap">{{ formatSize(r.size) }}</td>
+                            <td class="px-3 py-2.5">
+                                <a :href="r.url" target="_blank" rel="noopener"
+                                   class="text-xs text-cyan-400 hover:text-cyan-300 hover:underline transition-colors break-all">
+                                    {{ r.filename }}
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Beta -->
+        <div v-if="panel.beta.length > 0"
+             class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+            <div class="px-4 py-3 border-b border-white/5">
+                <h2 class="text-sm font-black text-white">Beta / unstable releases</h2>
+                <p class="text-xs text-gray-500 mt-0.5">
+                    Experimental builds with new features. Not recommended for competitive play.
+                </p>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="text-left text-[11px] uppercase tracking-wider text-gray-500 bg-white/[0.03]">
+                            <th class="font-semibold px-4 py-2.5">Version</th>
+                            <th class="font-semibold px-3 py-2.5 hidden sm:table-cell">Date</th>
+                            <th class="font-semibold px-3 py-2.5 text-right">Size</th>
+                            <th class="font-semibold px-3 py-2.5">Download</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="r in panel.beta" :key="r.id"
+                            class="border-t border-white/5 hover:bg-amber-500/[0.04] transition-colors">
+                            <td class="px-4 py-2.5">
+                                <span class="font-bold text-gray-300">{{ r.version }}</span>
+                                <span class="ml-2 text-[9px] font-black px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 border border-amber-500/30">
+                                    BETA
+                                </span>
+                            </td>
+                            <td class="px-3 py-2.5 hidden sm:table-cell text-xs text-gray-500 whitespace-nowrap">{{ r.date }}</td>
+                            <td class="px-3 py-2.5 text-right text-xs text-gray-500 whitespace-nowrap">{{ formatSize(r.size) }}</td>
+                            <td class="px-3 py-2.5">
+                                <a :href="r.url" target="_blank" rel="noopener"
+                                   class="text-xs text-amber-400/90 hover:text-amber-300 hover:underline transition-colors break-all">
+                                    {{ r.filename }}
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Install -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+            <h2 class="text-sm font-black text-white mb-2">Installation</h2>
+            <p class="text-sm text-gray-400 leading-relaxed">
+                Download the latest .zip and extract the
+                <code class="bg-black/60 text-cyan-300 px-1.5 py-0.5 rounded text-xs">defrag</code>
+                folder into your Quake III Arena directory, next to
+                <code class="bg-black/60 text-cyan-300 px-1.5 py-0.5 rounded text-xs">baseq3</code>,
+                <strong class="text-gray-200">not inside it</strong>.
+                See the
+                <Link href="/wiki/installation" class="text-cyan-400 hover:text-cyan-300 transition-colors">
+                    Installation &amp; Setup
+                </Link>
+                guide for the full walkthrough.
+            </p>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Downloads/FamilyFriendlyPanel.vue
+++ b/resources/js/Components/Downloads/FamilyFriendlyPanel.vue
@@ -1,0 +1,80 @@
+<script setup>
+defineProps({
+    panel: Object,
+});
+
+const formatSize = (bytes) => {
+    if (!bytes) return '-';
+    if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(2) + ' GB';
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    if (bytes >= 1024) return Math.round(bytes / 1024) + ' KB';
+    return bytes + ' B';
+};
+
+const formatDate = (value) => {
+    if (!value) return null;
+    return new Date(value).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+};
+</script>
+
+<template>
+    <div class="space-y-3">
+
+        <!-- Intro -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+            <p class="text-sm text-gray-400 leading-relaxed max-w-3xl">
+                Quake III ships with gore and adult artwork. These pk3s swap it for clean alternatives,
+                which is what you want when you stream, play at work, or hand the game to a kid. Physics,
+                timing and records are untouched, so anything you run with these is still a valid demo.
+            </p>
+        </div>
+
+        <!-- Files -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+            <div class="px-4 py-3 border-b border-white/5">
+                <h2 class="text-sm font-black text-white">The pack</h2>
+            </div>
+
+            <div v-if="panel.files.length > 0">
+                <div v-for="f in panel.files" :key="f.id"
+                     class="flex items-start justify-between gap-4 px-4 py-3.5 border-t border-white/5 first:border-t-0 hover:bg-cyan-500/[0.04] transition-colors flex-wrap">
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2 flex-wrap">
+                            <span class="text-sm font-bold text-gray-200">{{ f.name }}</span>
+                            <code class="text-[11px] text-cyan-400/80 bg-black/50 px-1.5 py-0.5 rounded">{{ f.filename }}</code>
+                            <span class="text-[11px] text-gray-500">{{ formatSize(f.size) }}</span>
+                            <span v-if="f.updated_at" class="text-[11px] text-gray-600">
+                                updated {{ formatDate(f.updated_at) }}
+                            </span>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1 max-w-2xl leading-relaxed">{{ f.description }}</p>
+                    </div>
+                    <a :href="f.url" target="_blank" rel="noopener"
+                       class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-cyan-500/15 border border-cyan-500/30 text-xs font-bold text-cyan-300 hover:bg-cyan-500/25 transition-all">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                        </svg>
+                        Download
+                    </a>
+                </div>
+            </div>
+
+            <p v-else class="px-4 py-6 text-sm text-gray-600">Nothing published yet.</p>
+        </div>
+
+        <!-- Install -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+            <h2 class="text-sm font-black text-white mb-2">Installation</h2>
+            <p class="text-sm text-gray-400 leading-relaxed">
+                Drop the .pk3 files into your
+                <code class="bg-black/60 text-cyan-300 px-1.5 py-0.5 rounded text-xs">baseq3</code>
+                folder. Quake loads pk3s in alphabetical order and the last one wins, so the
+                <code class="bg-black/60 text-cyan-300 px-1.5 py-0.5 rounded text-xs">zzz</code>
+                prefix is what lets them override the stock artwork.
+                <strong class="text-gray-200">Do not rename them.</strong>
+                To undo it, delete the files again.
+            </p>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Downloads/ServerBundlePanel.vue
+++ b/resources/js/Components/Downloads/ServerBundlePanel.vue
@@ -1,0 +1,106 @@
+<script setup>
+defineProps({
+    panel: Object,
+});
+
+const formatSize = (bytes) => {
+    if (!bytes) return '-';
+    if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + ' GB';
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    if (bytes >= 1024) return Math.round(bytes / 1024) + ' KB';
+    return bytes + ' B';
+};
+
+const formatDate = (value) => {
+    if (!value) return null;
+    return new Date(value).toLocaleString('en-GB', {
+        day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+};
+</script>
+
+<template>
+    <div class="space-y-3">
+
+        <!-- Intro + build state -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+            <div class="flex items-start justify-between gap-4 flex-wrap">
+                <div class="max-w-2xl">
+                    <p class="text-sm text-gray-400 leading-relaxed">
+                        Everything needed to run a DeFRaG server on Linux: the oDFe dedicated engine, the
+                        DeFRaG mod, the record system modules and the stock Quake III paks. The core archive
+                        rebuilds itself whenever a new engine build or mod release lands, so a fresh install
+                        is always current.
+                    </p>
+                </div>
+
+                <div v-if="panel.built_at"
+                     class="flex-shrink-0 bg-gradient-to-br from-cyan-500/15 to-cyan-500/5 border border-cyan-500/30 rounded-xl px-4 py-3 min-w-[210px]">
+                    <div class="text-[10px] uppercase tracking-wider text-cyan-500/80 font-bold mb-1">Last built</div>
+                    <div class="text-sm font-bold text-white">{{ formatDate(panel.built_at) }}</div>
+                    <dl class="mt-2 space-y-0.5 text-[11px]">
+                        <div v-if="panel.mod" class="flex justify-between gap-3">
+                            <dt class="text-gray-500">Mod</dt>
+                            <dd class="text-gray-300 font-medium">{{ panel.mod }}</dd>
+                        </div>
+                        <div v-if="panel.engine" class="flex justify-between gap-3">
+                            <dt class="text-gray-500">Engine</dt>
+                            <dd class="text-gray-300 font-medium">{{ panel.engine.slice(0, 10) }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+
+        <!-- Quick install -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+            <h2 class="text-sm font-black text-white mb-1">Quick install</h2>
+            <p class="text-xs text-gray-500 mb-3">
+                The installer pulls the core archive every time and the baseq3 assets only when they are missing.
+            </p>
+            <pre class="bg-black/60 border border-white/5 rounded-lg p-3 overflow-x-auto text-xs text-gray-300"><code>git clone {{ panel.repo_url }}
+cd defrag-server-bundle
+./download_defrag.sh</code></pre>
+            <a :href="panel.repo_url" target="_blank" rel="noopener"
+               class="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-cyan-400 hover:text-cyan-300 transition-colors">
+                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 .3a12 12 0 00-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 0-.8.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.2.5-2.3 1.3-3.1-.2-.4-.6-1.6.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 016 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.8.1 3.2.8.8 1.3 1.9 1.3 3.2 0 4.6-2.8 5.6-5.5 5.9.5.4.9 1.1.9 2.3v3.3c0 .3.1.7.8.6A12 12 0 0012 .3" />
+                </svg>
+                Setup guide and full instructions on GitHub
+            </a>
+        </div>
+
+        <!-- Archives -->
+        <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+            <div class="px-4 py-3 border-b border-white/5">
+                <h2 class="text-sm font-black text-white">Archives</h2>
+            </div>
+
+            <div v-if="panel.archives.length > 0">
+                <div v-for="a in panel.archives" :key="a.id"
+                     class="flex items-start justify-between gap-4 px-4 py-3.5 border-t border-white/5 first:border-t-0 hover:bg-cyan-500/[0.04] transition-colors flex-wrap">
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2 flex-wrap">
+                            <span class="text-sm font-bold text-gray-200">{{ a.name }}</span>
+                            <code class="text-[11px] text-cyan-400/80 bg-black/50 px-1.5 py-0.5 rounded">{{ a.filename }}</code>
+                            <span class="text-[11px] text-gray-500">{{ formatSize(a.size) }}</span>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1 max-w-2xl leading-relaxed">{{ a.description }}</p>
+                    </div>
+                    <a :href="a.url" target="_blank" rel="noopener"
+                       class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-cyan-500/15 border border-cyan-500/30 text-xs font-bold text-cyan-300 hover:bg-cyan-500/25 transition-all">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                        </svg>
+                        Download
+                    </a>
+                </div>
+            </div>
+
+            <p v-else class="px-4 py-6 text-sm text-gray-600">
+                No archives published yet. They appear once the bundle has been built.
+            </p>
+        </div>
+    </div>
+</template>

--- a/resources/js/Layouts/HomeLayout.vue
+++ b/resources/js/Layouts/HomeLayout.vue
@@ -192,8 +192,8 @@
                                     <DropdownLink :href="route('demos.index')">
                                         Demos
                                     </DropdownLink>
-                                    <DropdownLink :href="route('bundles')">
-                                        Bundles
+                                    <DropdownLink :href="route('downloads')">
+                                        Downloads
                                     </DropdownLink>
                                     <DropdownLink :href="route('clans.index')">
                                         Clans
@@ -335,7 +335,7 @@
 
                                             <!-- Bundles -->
                                             <div v-if="bundles?.length > 0 && searchCategory == 'bundles'" @click="closeSearch">
-                                                <Link v-for="bundle in bundles" :key="bundle.id" :href="route('bundles', bundle.id)" class="group flex items-center gap-4 cursor-pointer rounded-xl hover:bg-white/5 p-3 transition-all border border-transparent hover:border-yellow-500/30 hover:shadow-lg hover:shadow-yellow-500/5">
+                                                <Link v-for="bundle in bundles" :key="bundle.id" :href="bundle.url" class="group flex items-center gap-4 cursor-pointer rounded-xl hover:bg-white/5 p-3 transition-all border border-transparent hover:border-yellow-500/30 hover:shadow-lg hover:shadow-yellow-500/5">
                                                     <!-- Icon -->
                                                     <div class="shrink-0 flex items-center justify-center w-12 h-12 rounded-lg bg-yellow-500/20 ring-2 ring-white/10 group-hover:ring-yellow-500/50 transition-all">
                                                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6 text-yellow-400">
@@ -346,7 +346,7 @@
                                                     <!-- Bundle Info -->
                                                     <div class="flex-1 min-w-0">
                                                         <div class="text-base font-black text-white group-hover:text-yellow-400 transition-colors truncate mb-0.5">{{ bundle.name }}</div>
-                                                        <div class="text-xs text-gray-400 font-semibold">{{ bundle.maps_count }} maps</div>
+                                                        <div class="text-xs text-gray-400 font-semibold">{{ bundle.category }}</div>
                                                     </div>
 
                                                     <!-- Arrow -->
@@ -468,7 +468,7 @@
                                 <DropdownLink :href="route('demos.index')">
                                     Demos
                                 </DropdownLink>
-                                <DropdownLink :href="route('bundles')">
+                                <DropdownLink :href="route('downloads')">
                                     Bundles
                                 </DropdownLink>
                                 <DropdownLink :href="route('clans.index')">

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -45,7 +45,7 @@
             challenges: route().current('headhunter.*') || route().current('marketplace.*') || route().current('community.tasks') || route().current('defraglive.*'),
             tournaments: route().current('tournaments.*'),
             wiki: route().current('wiki.*'),
-            bundles: route().current('bundles'),
+            bundles: route().current('downloads'),
             // Sub-items
             records: route().current('records'),
             clans: route().current('clans.*'),
@@ -872,7 +872,7 @@
 
                         <!-- 9. Downloads - visible from xl -->
                         <div class="hidden xl:inline-flex">
-                            <NavLink :href="route('bundles')" :active="navActive.bundles">
+                            <NavLink :href="route('downloads')" :active="navActive.bundles">
                                 Downloads
                             </NavLink>
                         </div>
@@ -925,7 +925,7 @@
                                     <DropdownLink :href="route('maplists.index')" :active="navActive.maplists">Maplists</DropdownLink>
                                     <DropdownLink :href="route('tournaments.index')" :active="navActive.tournaments">Tournaments</DropdownLink>
                                     <DropdownLink :href="route('wiki.index')" :active="navActive.wiki">Wiki</DropdownLink>
-                                    <DropdownLink :href="route('bundles')" :active="navActive.bundles">Downloads</DropdownLink>
+                                    <DropdownLink :href="route('downloads')" :active="navActive.bundles">Downloads</DropdownLink>
                                     <DropdownLink href="/test-map-viewer.html?map=pornstar-cpmrun">Beta</DropdownLink>
                                 </template>
                             </Dropdown>

--- a/resources/js/Pages/Downloads/Index.vue
+++ b/resources/js/Pages/Downloads/Index.vue
@@ -1,0 +1,344 @@
+<script setup>
+import { ref, computed, watch, getCurrentInstance, onBeforeUnmount } from 'vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import DownloadCategoryNode from '@/Components/DownloadCategoryNode.vue';
+import DefragModPanel from '@/Components/Downloads/DefragModPanel.vue';
+import ServerBundlePanel from '@/Components/Downloads/ServerBundlePanel.vue';
+import FamilyFriendlyPanel from '@/Components/Downloads/FamilyFriendlyPanel.vue';
+
+const { proxy } = getCurrentInstance();
+const q3tohtml = proxy.q3tohtml;
+
+const props = defineProps({
+    tree: Array,
+    current: Object,
+    // Set only for a locked category, which renders as an article instead of
+    // a listing. When present, `downloads` is null.
+    panel: Object,
+    downloads: Object,
+    filters: Object,
+    totalCount: Number,
+});
+
+const search = ref(props.filters.q ?? '');
+const sort = ref(props.filters.sort ?? 'newest');
+
+// Ancestors of the selected category, so its branch renders already expanded.
+const openIds = computed(() => (props.current?.breadcrumb ?? []).map((c) => c.id));
+
+const baseUrl = computed(() =>
+    props.current ? `/downloads/${props.current.id}/${props.current.slug}` : '/downloads'
+);
+
+const reload = () => {
+    router.get(
+        baseUrl.value,
+        {
+            q: search.value || undefined,
+            sort: sort.value !== 'newest' ? sort.value : undefined,
+            defrag: props.filters.defrag || undefined,
+        },
+        { preserveState: true, preserveScroll: true, replace: true }
+    );
+};
+
+let timer;
+watch(search, () => {
+    clearTimeout(timer);
+    timer = setTimeout(reload, 300);
+});
+watch(sort, reload);
+
+// A pending debounce firing after navigation would yank the user back to
+// this page's URL; category and pagination Links remount the component.
+onBeforeUnmount(() => clearTimeout(timer));
+
+const toggleDefrag = () => {
+    router.get(
+        baseUrl.value,
+        {
+            q: search.value || undefined,
+            sort: sort.value !== 'newest' ? sort.value : undefined,
+            defrag: props.filters.defrag ? undefined : 1,
+        },
+        { preserveState: true, preserveScroll: true, replace: true }
+    );
+};
+
+const formatSize = (bytes) => {
+    if (!bytes) return '-';
+    if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + ' GB';
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    if (bytes >= 1024) return Math.round(bytes / 1024) + ' KB';
+    return bytes + ' B';
+};
+
+const formatDate = (value) => {
+    if (!value) return '-';
+    return new Date(value).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+};
+
+const formatCount = (n) => (n >= 1000 ? (n / 1000).toFixed(1) + 'k' : n ?? 0);
+
+const entryUrl = (d) => `/downloads/entry/${d.id}/${d.slug}`;
+
+// External entries (the mod, repacks, the setup repo) link straight out; owned
+// uploads go through the file route, which signs a link and counts the hit.
+const downloadUrl = (d) => (d.external_url ? d.external_url : entryUrl(d));
+
+const isNew = (d) => {
+    if (!d.created_at) return false;
+    return (Date.now() - new Date(d.created_at).getTime()) < 14 * 86400000;
+};
+</script>
+
+<template>
+    <div>
+        <Head title="Downloads" />
+
+        <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
+            <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">
+                <div class="flex flex-wrap items-end justify-between gap-4">
+                    <div>
+                        <h1 class="text-4xl md:text-5xl font-black text-gray-300/90 mb-2">Downloads</h1>
+                        <p class="text-sm text-gray-400">
+                            {{ totalCount }} files shared by the community
+                        </p>
+                    </div>
+                    <Link
+                        v-if="$page.props.auth?.user"
+                        href="/downloads/upload"
+                        class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-cyan-500/15 border border-cyan-500/30 text-cyan-300 text-sm font-semibold hover:bg-cyan-500/25 transition-all">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
+                        </svg>
+                        Upload
+                    </Link>
+                </div>
+            </div>
+        </div>
+
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 relative z-10" style="margin-top: -22rem;">
+            <div class="flex flex-col lg:flex-row gap-4">
+
+                <!-- Category tree -->
+                <div class="lg:w-64 flex-shrink-0">
+                    <div class="bg-black/45 backdrop-blur-xl rounded-xl overflow-hidden border border-white/[0.08] sticky top-[120px]">
+                        <Link
+                            href="/downloads"
+                            class="flex items-center justify-between px-3 py-2.5 border-l-2 transition-all"
+                            :class="!current
+                                ? 'bg-cyan-500/10 border-cyan-400 text-cyan-300'
+                                : 'border-transparent text-gray-400 hover:bg-cyan-500/5 hover:text-white'">
+                            <span class="text-sm font-semibold">All downloads</span>
+                            <span class="text-[10px] font-bold px-1.5 py-0.5 rounded-full"
+                                  :class="!current ? 'bg-cyan-500/20 text-cyan-300' : 'bg-white/5 text-gray-600'">
+                                {{ totalCount }}
+                            </span>
+                        </Link>
+
+                        <div class="border-t border-white/5 max-h-[70vh] overflow-y-auto py-1">
+                            <DownloadCategoryNode
+                                v-for="node in tree"
+                                :key="node.id"
+                                :node="node"
+                                :current-id="current?.id"
+                                :open-ids="openIds" />
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Listing -->
+                <div class="flex-1 min-w-0">
+
+                    <!-- Toolbar. Hidden for a locked category: an article has
+                         nothing to search, sort or filter. -->
+                    <div v-if="!panel" class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-3 mb-3">
+                        <div class="flex flex-col sm:flex-row gap-2">
+                            <div class="relative flex-1">
+                                <svg class="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-600"
+                                     fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                          d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+                                </svg>
+                                <input
+                                    v-model="search"
+                                    type="text"
+                                    placeholder="Search downloads..."
+                                    class="w-full bg-black/40 border border-white/10 rounded-lg pl-9 pr-3 py-2 text-sm text-white placeholder-gray-600 focus:border-cyan-500/50 focus:ring-0 transition-colors" />
+                            </div>
+
+                            <button
+                                @click="toggleDefrag"
+                                class="px-3 py-2 rounded-lg text-xs font-semibold border transition-all whitespace-nowrap"
+                                :class="filters.defrag
+                                    ? 'bg-cyan-500/15 border-cyan-500/40 text-cyan-300'
+                                    : 'bg-black/40 border-white/10 text-gray-500 hover:text-white'">
+                                DeFRaG only
+                            </button>
+
+                            <select
+                                v-model="sort"
+                                class="bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-gray-300 focus:border-cyan-500/50 focus:ring-0 transition-colors">
+                                <!-- The popup is drawn by the OS and ignores the
+                                     wrapper's styling, so the options carry
+                                     their own dark background. -->
+                                <option class="bg-gray-900" value="newest">Newest</option>
+                                <option class="bg-gray-900" value="popular">Most downloaded</option>
+                                <option class="bg-gray-900" value="name">Name</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <!-- Category header -->
+                    <div v-if="current" class="mb-3">
+                        <div class="flex items-center gap-2 text-xs text-gray-500 mb-1">
+                            <Link href="/downloads" class="hover:text-cyan-400 transition-colors">Downloads</Link>
+                            <template v-for="crumb in current.breadcrumb" :key="crumb.id">
+                                <span class="text-gray-700">/</span>
+                                <Link :href="`/downloads/${crumb.id}/${crumb.slug}`" class="hover:text-cyan-400 transition-colors">
+                                    {{ crumb.name }}
+                                </Link>
+                            </template>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <h2 class="text-lg font-black text-white">{{ current.name }}</h2>
+                            <span v-if="current.is_locked"
+                                  class="text-[10px] font-bold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">
+                                AUTO
+                            </span>
+                        </div>
+                        <p v-if="current.description" class="text-xs text-gray-500 mt-1 max-w-3xl">
+                            {{ current.description }}
+                        </p>
+                    </div>
+
+                    <!-- Locked category: a self-updating article, not a listing. -->
+                    <DefragModPanel v-if="panel?.type === 'defrag_mod'" :panel="panel" />
+                    <ServerBundlePanel v-else-if="panel?.type === 'server_bundle'" :panel="panel" />
+                    <FamilyFriendlyPanel v-else-if="panel?.type === 'family_friendly'" :panel="panel" />
+
+                    <!-- Table -->
+                    <div v-else-if="downloads?.data.length > 0"
+                         class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="text-left text-[11px] uppercase tracking-wider text-gray-500 bg-white/[0.03]">
+                                        <th class="font-semibold px-4 py-2.5">Name</th>
+                                        <th class="font-semibold px-3 py-2.5 hidden md:table-cell">Category</th>
+                                        <th class="font-semibold px-3 py-2.5 hidden lg:table-cell">Author</th>
+                                        <th class="font-semibold px-3 py-2.5 hidden sm:table-cell text-right">Size</th>
+                                        <th class="font-semibold px-3 py-2.5 hidden lg:table-cell text-right">Date</th>
+                                        <th class="font-semibold px-3 py-2.5 text-right">DL</th>
+                                        <th class="px-3 py-2.5"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr
+                                        v-for="d in downloads.data"
+                                        :key="d.id"
+                                        class="border-t border-white/5 hover:bg-cyan-500/[0.04] transition-colors group">
+
+                                        <td class="px-4 py-2.5 max-w-md">
+                                            <Link :href="entryUrl(d)" class="flex items-center gap-2 min-w-0">
+                                                <span class="text-gray-200 group-hover:text-cyan-300 transition-colors truncate font-medium">
+                                                    {{ d.name }}
+                                                </span>
+                                                <span v-if="isNew(d)"
+                                                      class="flex-shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">
+                                                    NEW
+                                                </span>
+                                                <svg v-if="d.is_locked" class="w-3 h-3 flex-shrink-0 text-amber-500/60"
+                                                     fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                          d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                                                </svg>
+                                            </Link>
+                                            <p v-if="d.description" class="text-xs text-gray-600 truncate mt-0.5">
+                                                {{ d.description }}
+                                            </p>
+                                        </td>
+
+                                        <td class="px-3 py-2.5 hidden md:table-cell">
+                                            <Link v-if="d.category"
+                                                  :href="`/downloads/${d.category.id}/${d.category.slug}`"
+                                                  class="text-xs text-gray-500 hover:text-cyan-400 transition-colors">
+                                                {{ d.category.name }}
+                                            </Link>
+                                        </td>
+
+                                        <td class="px-3 py-2.5 hidden lg:table-cell">
+                                            <Link v-if="d.user" :href="`/profile/${d.user.id}`"
+                                                  class="text-xs text-gray-500 hover:text-white transition-colors"
+                                                  v-html="q3tohtml(d.user.name)"></Link>
+                                            <span v-else class="text-xs text-gray-700">system</span>
+                                        </td>
+
+                                        <td class="px-3 py-2.5 hidden sm:table-cell text-right text-xs text-gray-500 whitespace-nowrap">
+                                            {{ formatSize(d.total_size) }}
+                                        </td>
+
+                                        <td class="px-3 py-2.5 hidden lg:table-cell text-right text-xs text-gray-500 whitespace-nowrap">
+                                            {{ formatDate(d.created_at) }}
+                                        </td>
+
+                                        <td class="px-3 py-2.5 text-right text-xs text-gray-500 whitespace-nowrap">
+                                            {{ formatCount(d.downloads_count) }}
+                                        </td>
+
+                                        <td class="px-3 py-2.5 text-right">
+                                            <a
+                                                :href="downloadUrl(d)"
+                                                :target="d.external_url ? '_blank' : '_self'"
+                                                rel="noopener"
+                                                class="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/5 border border-white/10 text-xs font-semibold text-gray-400 hover:bg-cyan-500/15 hover:border-cyan-500/40 hover:text-cyan-300 transition-all whitespace-nowrap">
+                                                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                                                </svg>
+                                                Get
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <!-- Empty -->
+                    <div v-else class="bg-black/40 backdrop-blur-sm rounded-xl border border-white/5 p-12 text-center">
+                        <svg class="w-12 h-12 mx-auto text-gray-600 mb-3" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                  d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
+                        </svg>
+                        <p class="text-sm text-gray-500">
+                            {{ filters.q ? `Nothing matches "${filters.q}".` : 'Nothing here yet.' }}
+                        </p>
+                    </div>
+
+                    <!-- Pagination -->
+                    <div v-if="downloads && downloads.last_page > 1" class="flex flex-wrap justify-center gap-1 mt-3">
+                        <template v-for="(link, i) in downloads.links" :key="i">
+                            <Link
+                                v-if="link.url"
+                                :href="link.url"
+                                preserve-scroll
+                                class="px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all"
+                                :class="link.active
+                                    ? 'bg-cyan-500/15 border-cyan-500/40 text-cyan-300'
+                                    : 'bg-black/40 border-white/10 text-gray-500 hover:text-white'"
+                                v-html="link.label" />
+                            <span v-else
+                                  class="px-3 py-1.5 rounded-lg text-xs font-semibold border border-white/5 text-gray-700"
+                                  v-html="link.label" />
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="h-4"></div>
+    </div>
+</template>

--- a/resources/js/Pages/Downloads/Show.vue
+++ b/resources/js/Pages/Downloads/Show.vue
@@ -1,0 +1,197 @@
+<script setup>
+import { ref, getCurrentInstance } from 'vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+const { proxy } = getCurrentInstance();
+const q3tohtml = proxy.q3tohtml;
+
+const props = defineProps({
+    download: Object,
+    canModerate: Boolean,
+});
+
+const lightbox = ref(null);
+
+const formatSize = (bytes) => {
+    if (!bytes) return '-';
+    if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + ' GB';
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    if (bytes >= 1024) return Math.round(bytes / 1024) + ' KB';
+    return bytes + ' B';
+};
+
+const formatDate = (value) =>
+    value ? new Date(value).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' }) : '-';
+</script>
+
+<template>
+    <div>
+        <Head :title="download.name" />
+
+        <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
+            <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">
+                <div class="flex items-center gap-2 text-xs text-gray-400 mb-2 flex-wrap">
+                    <Link href="/downloads" class="hover:text-cyan-400 transition-colors">Downloads</Link>
+                    <template v-for="crumb in download.category?.breadcrumb ?? []" :key="crumb.id">
+                        <span class="text-gray-700">/</span>
+                        <Link :href="`/downloads/${crumb.id}/${crumb.slug}`" class="hover:text-cyan-400 transition-colors">
+                            {{ crumb.name }}
+                        </Link>
+                    </template>
+                </div>
+                <h1 class="text-3xl md:text-4xl font-black text-gray-300/90">{{ download.name }}</h1>
+            </div>
+        </div>
+
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 relative z-10" style="margin-top: -22rem;">
+            <div class="flex flex-col lg:flex-row gap-4">
+
+                <!-- Main -->
+                <div class="flex-1 min-w-0 space-y-3">
+
+                    <div v-if="download.status !== 'published'"
+                         class="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-2.5 text-xs text-amber-300">
+                        This entry is <strong>{{ download.status }}</strong> and is not publicly listed.
+                    </div>
+
+                    <!-- Description -->
+                    <div v-if="download.description"
+                         class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+                        <p class="text-sm text-gray-300 leading-relaxed whitespace-pre-line">{{ download.description }}</p>
+                    </div>
+
+                    <!-- YouTube -->
+                    <div v-if="download.youtube_id"
+                         class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+                        <div class="relative w-full" style="padding-bottom: 56.25%;">
+                            <iframe
+                                class="absolute inset-0 w-full h-full"
+                                :src="`https://www.youtube-nocookie.com/embed/${download.youtube_id}`"
+                                title="YouTube video"
+                                frameborder="0"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                allowfullscreen></iframe>
+                        </div>
+                    </div>
+
+                    <!-- Screenshots -->
+                    <div v-if="download.screenshots.length > 0"
+                         class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-4">
+                        <h2 class="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-3">Screenshots</h2>
+                        <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+                            <button
+                                v-for="shot in download.screenshots"
+                                :key="shot.id"
+                                @click="lightbox = shot.url"
+                                class="group relative aspect-video rounded-lg overflow-hidden border border-white/10 hover:border-cyan-500/50 transition-all">
+                                <img :src="shot.url" alt="" loading="lazy"
+                                     class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" />
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Files -->
+                    <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] overflow-hidden">
+                        <h2 class="text-xs uppercase tracking-wider text-gray-500 font-semibold px-4 py-3 border-b border-white/5">
+                            Files
+                        </h2>
+
+                        <table v-if="download.files.length > 0" class="w-full text-sm">
+                            <tbody>
+                                <tr v-for="file in download.files" :key="file.id"
+                                    class="border-b border-white/5 last:border-0 hover:bg-cyan-500/[0.04] transition-colors">
+                                    <td class="px-4 py-3">
+                                        <span class="text-gray-200 font-medium break-all">{{ file.original_name }}</span>
+                                    </td>
+                                    <td class="px-3 py-3 text-right text-xs text-gray-500 whitespace-nowrap">
+                                        {{ formatSize(file.size) }}
+                                    </td>
+                                    <td class="px-3 py-3 text-right">
+                                        <a :href="file.url"
+                                           class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-cyan-500/15 border border-cyan-500/30 text-xs font-semibold text-cyan-300 hover:bg-cyan-500/25 transition-all whitespace-nowrap">
+                                            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round"
+                                                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                                            </svg>
+                                            Download
+                                        </a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <!-- Entries that only point elsewhere carry no files of their own. -->
+                        <div v-else-if="download.external_url" class="p-4">
+                            <a :href="download.external_url" target="_blank" rel="noopener"
+                               class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-cyan-500/15 border border-cyan-500/30 text-sm font-semibold text-cyan-300 hover:bg-cyan-500/25 transition-all">
+                                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                          d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                                </svg>
+                                Download
+                            </a>
+                            <p class="text-xs text-gray-600 mt-2 break-all">{{ download.external_url }}</p>
+                        </div>
+
+                        <p v-else class="p-4 text-sm text-gray-600">No files attached.</p>
+                    </div>
+                </div>
+
+                <!-- Meta sidebar -->
+                <div class="lg:w-64 flex-shrink-0">
+                    <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-4 sticky top-[120px] space-y-3">
+                        <div>
+                            <div class="text-[10px] uppercase tracking-wider text-gray-600 font-semibold mb-1">Author</div>
+                            <Link v-if="download.user" :href="`/profile/${download.user.id}`"
+                                  class="text-sm text-gray-300 hover:text-cyan-400 transition-colors"
+                                  v-html="q3tohtml(download.user.name)"></Link>
+                            <span v-else class="text-sm text-gray-600">system</span>
+                        </div>
+
+                        <div v-if="download.category">
+                            <div class="text-[10px] uppercase tracking-wider text-gray-600 font-semibold mb-1">Category</div>
+                            <Link :href="`/downloads/${download.category.id}/${download.category.slug}`"
+                                  class="text-sm text-gray-300 hover:text-cyan-400 transition-colors">
+                                {{ download.category.name }}
+                            </Link>
+                        </div>
+
+                        <div>
+                            <div class="text-[10px] uppercase tracking-wider text-gray-600 font-semibold mb-1">Added</div>
+                            <div class="text-sm text-gray-300">{{ formatDate(download.created_at) }}</div>
+                        </div>
+
+                        <div>
+                            <div class="text-[10px] uppercase tracking-wider text-gray-600 font-semibold mb-1">Downloads</div>
+                            <div class="text-sm text-gray-300">{{ download.downloads_count ?? 0 }}</div>
+                        </div>
+
+                        <div v-if="download.defrag_only || download.is_locked" class="flex flex-wrap gap-1.5 pt-1">
+                            <span v-if="download.defrag_only"
+                                  class="text-[10px] font-bold px-2 py-0.5 rounded bg-cyan-500/15 text-cyan-400 border border-cyan-500/30">
+                                DeFRaG only
+                            </span>
+                            <span v-if="download.is_locked"
+                                  class="text-[10px] font-bold px-2 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">
+                                AUTO
+                            </span>
+                        </div>
+
+                        <a v-if="canModerate" :href="`/admin/downloads/${download.id}/edit`"
+                           class="block w-full text-center px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-xs font-semibold text-gray-400 hover:text-white transition-all">
+                            Edit in admin
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Lightbox -->
+        <div v-if="lightbox" @click="lightbox = null"
+             class="fixed inset-0 z-[100] bg-black/90 backdrop-blur-sm flex items-center justify-center p-6 cursor-zoom-out">
+            <img :src="lightbox" alt="" class="max-w-full max-h-full rounded-lg" />
+        </div>
+
+        <div class="h-4"></div>
+    </div>
+</template>

--- a/resources/js/Pages/Downloads/Upload.vue
+++ b/resources/js/Pages/Downloads/Upload.vue
@@ -1,0 +1,238 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import CategorySelect from '@/Components/Downloads/CategorySelect.vue';
+
+const props = defineProps({
+    categories: Array,
+    maxFileMb: Number,
+    maxTotalMb: Number,
+    allowedExtensions: Array,
+});
+
+const form = useForm({
+    name: '',
+    category_id: '',
+    description: '',
+    youtube_url: '',
+    defrag_only: false,
+    files: [],
+    screenshots: [],
+});
+
+const fileInput = ref(null);
+const shotInput = ref(null);
+
+const pickFiles = (e) => { form.files = Array.from(e.target.files); };
+const pickShots = (e) => { form.screenshots = Array.from(e.target.files); };
+
+const dropFile = (i) => {
+    form.files = form.files.filter((_, idx) => idx !== i);
+    if (fileInput.value) fileInput.value.value = '';
+};
+const dropShot = (i) => {
+    form.screenshots = form.screenshots.filter((_, idx) => idx !== i);
+    if (shotInput.value) shotInput.value.value = '';
+};
+
+const formatSize = (bytes) => {
+    if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+    if (bytes >= 1024) return Math.round(bytes / 1024) + ' KB';
+    return bytes + ' B';
+};
+
+const totalBytes = computed(() =>
+    [...form.files, ...form.screenshots].reduce((sum, f) => sum + f.size, 0)
+);
+
+// The whole POST has to fit under post_max_size, so warn before the server
+// silently drops an oversized request rather than after.
+const overTotal = computed(() => totalBytes.value > props.maxTotalMb * 1024 * 1024);
+
+const accept = computed(() => props.allowedExtensions.map((e) => '.' + e).join(','));
+
+// Laravel keys per-item failures as files.0, files.1, screenshots.2, ... -
+// collect every key under its block so no error renders invisibly.
+const errorsFor = (prefix) =>
+    Object.entries(form.errors)
+        .filter(([key]) => key === prefix || key.startsWith(prefix + '.'))
+        .map(([, message]) => message);
+
+const submit = () => {
+    form.post('/downloads/upload', { forceFormData: true });
+};
+</script>
+
+<template>
+    <div>
+        <Head title="Upload" />
+
+        <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
+            <div class="max-w-4xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">
+                <div class="flex items-center gap-2 text-xs text-gray-400 mb-2">
+                    <Link href="/downloads" class="hover:text-cyan-400 transition-colors">Downloads</Link>
+                    <span class="text-gray-700">/</span>
+                    <span class="text-gray-500">Upload</span>
+                </div>
+                <h1 class="text-3xl md:text-4xl font-black text-gray-300/90">Upload</h1>
+            </div>
+        </div>
+
+        <div class="max-w-4xl mx-auto px-4 md:px-6 lg:px-8 relative z-10" style="margin-top: -22rem;">
+            <form @submit.prevent="submit" class="space-y-3">
+
+                <!-- Basics -->
+                <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5 space-y-4">
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-500 font-semibold mb-1.5">Name</label>
+                        <input
+                            v-model="form.name"
+                            type="text"
+                            maxlength="150"
+                            placeholder="What is it?"
+                            class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-cyan-500/50 focus:ring-0 transition-colors" />
+                        <p v-if="form.errors.name" class="text-xs text-red-400 mt-1">{{ form.errors.name }}</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-500 font-semibold mb-1.5">Category</label>
+                        <CategorySelect
+                            v-model="form.category_id"
+                            :categories="categories"
+                            :has-error="!!form.errors.category_id" />
+                        <p v-if="form.errors.category_id" class="text-xs text-red-400 mt-1">{{ form.errors.category_id }}</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-500 font-semibold mb-1.5">
+                            Description <span class="text-gray-700 normal-case tracking-normal">(optional)</span>
+                        </label>
+                        <textarea
+                            v-model="form.description"
+                            rows="5"
+                            maxlength="5000"
+                            placeholder="What it does, how to install it, who made it..."
+                            class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-cyan-500/50 focus:ring-0 transition-colors resize-y"></textarea>
+                        <p class="text-[11px] text-gray-600 mt-1">{{ form.description.length }} / 5000</p>
+                        <p v-if="form.errors.description" class="text-xs text-red-400 mt-1">{{ form.errors.description }}</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-500 font-semibold mb-1.5">
+                            YouTube URL <span class="text-gray-700 normal-case tracking-normal">(optional)</span>
+                        </label>
+                        <input
+                            v-model="form.youtube_url"
+                            type="url"
+                            placeholder="https://www.youtube.com/watch?v=..."
+                            class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-cyan-500/50 focus:ring-0 transition-colors" />
+                        <p class="text-[11px] text-gray-600 mt-1">Embeds a player on the detail page.</p>
+                        <p v-if="form.errors.youtube_url" class="text-xs text-red-400 mt-1">{{ form.errors.youtube_url }}</p>
+                    </div>
+
+                    <label class="flex items-center gap-2 cursor-pointer">
+                        <input v-model="form.defrag_only" type="checkbox"
+                               class="rounded bg-black/40 border-white/20 text-cyan-500 focus:ring-0 focus:ring-offset-0" />
+                        <span class="text-sm text-gray-400">Only works with the DeFRaG mod</span>
+                    </label>
+                </div>
+
+                <!-- Files -->
+                <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5 space-y-3">
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-500 font-semibold mb-1.5">Files</label>
+                        <input
+                            ref="fileInput"
+                            type="file"
+                            multiple
+                            :accept="accept"
+                            @change="pickFiles"
+                            class="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border file:border-cyan-500/30 file:text-xs file:font-semibold file:bg-cyan-500/15 file:text-cyan-300 hover:file:bg-cyan-500/25 file:cursor-pointer" />
+                        <p class="text-[11px] text-gray-600 mt-1.5">
+                            Up to 10 files, {{ maxFileMb }} MB each, {{ maxTotalMb }} MB in total.
+                            Allowed: {{ allowedExtensions.join(', ') }}
+                        </p>
+                        <p v-for="(msg, i) in errorsFor('files')" :key="'fe' + i" class="text-xs text-red-400 mt-1">{{ msg }}</p>
+                    </div>
+
+                    <ul v-if="form.files.length" class="space-y-1">
+                        <li v-for="(f, i) in form.files" :key="i"
+                            class="flex items-center justify-between gap-3 bg-black/40 border border-white/5 rounded-lg px-3 py-2">
+                            <span class="text-xs text-gray-300 truncate">{{ f.name }}</span>
+                            <span class="flex items-center gap-2 flex-shrink-0">
+                                <span class="text-[11px] text-gray-600">{{ formatSize(f.size) }}</span>
+                                <button type="button" @click="dropFile(i)"
+                                        class="text-gray-600 hover:text-red-400 transition-colors text-xs">remove</button>
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Screenshots -->
+                <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5 space-y-3">
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-500 font-semibold mb-1.5">
+                            Screenshots <span class="text-gray-700 normal-case tracking-normal">(optional)</span>
+                        </label>
+                        <input
+                            ref="shotInput"
+                            type="file"
+                            multiple
+                            accept=".jpg,.jpeg,.png,.webp,.gif"
+                            @change="pickShots"
+                            class="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border file:border-white/10 file:text-xs file:font-semibold file:bg-white/5 file:text-gray-400 hover:file:bg-white/10 file:cursor-pointer" />
+                        <p class="text-[11px] text-gray-600 mt-1.5">Up to 6 images, 5 MB each.</p>
+                        <p v-for="(msg, i) in errorsFor('screenshots')" :key="'se' + i" class="text-xs text-red-400 mt-1">{{ msg }}</p>
+                    </div>
+
+                    <ul v-if="form.screenshots.length" class="space-y-1">
+                        <li v-for="(f, i) in form.screenshots" :key="i"
+                            class="flex items-center justify-between gap-3 bg-black/40 border border-white/5 rounded-lg px-3 py-2">
+                            <span class="text-xs text-gray-300 truncate">{{ f.name }}</span>
+                            <span class="flex items-center gap-2 flex-shrink-0">
+                                <span class="text-[11px] text-gray-600">{{ formatSize(f.size) }}</span>
+                                <button type="button" @click="dropShot(i)"
+                                        class="text-gray-600 hover:text-red-400 transition-colors text-xs">remove</button>
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Submit -->
+                <div class="bg-black/45 backdrop-blur-xl rounded-xl border border-white/[0.08] p-5">
+                    <div v-if="overTotal"
+                         class="mb-3 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2 text-xs text-red-300">
+                        Total is {{ formatSize(totalBytes) }}, over the {{ maxTotalMb }} MB limit. Remove something first.
+                    </div>
+
+                    <div v-if="form.progress" class="mb-3">
+                        <div class="h-1.5 bg-white/5 rounded-full overflow-hidden">
+                            <div class="h-full bg-cyan-500 transition-all" :style="{ width: form.progress.percentage + '%' }"></div>
+                        </div>
+                        <p class="text-[11px] text-gray-500 mt-1">Uploading {{ form.progress.percentage }}%</p>
+                    </div>
+
+                    <div class="flex items-center justify-between gap-3 flex-wrap">
+                        <p class="text-xs text-gray-600">
+                            <span v-if="totalBytes">{{ formatSize(totalBytes) }} total</span>
+                        </p>
+                        <div class="flex items-center gap-2">
+                            <Link href="/downloads"
+                                  class="px-4 py-2 rounded-lg text-sm font-semibold text-gray-500 hover:text-white transition-colors">
+                                Cancel
+                            </Link>
+                            <button
+                                type="submit"
+                                :disabled="form.processing || overTotal || !form.files.length"
+                                class="px-5 py-2 rounded-lg bg-cyan-500/15 border border-cyan-500/30 text-sm font-bold text-cyan-300 hover:bg-cyan-500/25 transition-all disabled:opacity-40 disabled:cursor-not-allowed">
+                                {{ form.processing ? 'Uploading...' : 'Publish' }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        <div class="h-4"></div>
+    </div>
+</template>

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -476,7 +476,7 @@
 
                     <!-- Download -->
                     <div class="flex gap-2 items-stretch">
-                        <Link :href="route('bundles')" :class="['flex-1 backdrop-blur-sm rounded-xl border p-5 transition-all group', downloadChecked ? 'bg-green-500/10 border-green-500/30' : 'bg-black/40 border-white/10 hover:border-blue-500/50']">
+                        <Link :href="route('downloads')" :class="['flex-1 backdrop-blur-sm rounded-xl border p-5 transition-all group', downloadChecked ? 'bg-green-500/10 border-green-500/30' : 'bg-black/40 border-white/10 hover:border-blue-500/50']">
                             <div class="flex items-center gap-4">
                                 <div :class="['p-3 rounded-lg shrink-0', downloadChecked ? 'bg-green-500/20' : 'bg-blue-500/20']">
                                     <svg :class="['w-6 h-6', downloadChecked ? 'text-green-400' : 'text-blue-400']" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" /></svg>

--- a/resources/views/filament/pages/server-bundle.blade.php
+++ b/resources/views/filament/pages/server-bundle.blade.php
@@ -1,0 +1,99 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+
+        <x-filament::section>
+            <x-slot name="heading">Last generated</x-slot>
+            <x-slot name="description">The core bundle is rebuilt daily and whenever you press Rebuild now.</x-slot>
+
+            @if ($this->marker)
+                <dl class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                    <div>
+                        <dt class="text-sm text-gray-500 dark:text-gray-400">Built</dt>
+                        <dd class="text-base font-medium">
+                            {{ \Illuminate\Support\Carbon::parse($this->marker['built_at'])->diffForHumans() }}
+                            <span class="block text-xs text-gray-400">
+                                {{ \Illuminate\Support\Carbon::parse($this->marker['built_at'])->toDayDateTimeString() }}
+                            </span>
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="text-sm text-gray-500 dark:text-gray-400">Engine build</dt>
+                        <dd class="text-base font-medium">{{ $this->marker['engine'] ?? '-' }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-sm text-gray-500 dark:text-gray-400">DeFRaG mod</dt>
+                        <dd class="text-base font-medium">{{ $this->marker['mod'] ?? '-' }}</dd>
+                    </div>
+                </dl>
+            @else
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                    Never built yet. Press <strong>Rebuild now</strong> to generate the first
+                    <code>dfsv-core.tar</code>.
+                </p>
+            @endif
+        </x-filament::section>
+
+        <x-filament::section>
+            <x-slot name="heading">Archives on /www/downloads</x-slot>
+
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="text-left text-gray-500 dark:text-gray-400">
+                            <th class="py-2 pr-4">File</th>
+                            <th class="py-2 pr-4">Status</th>
+                            <th class="py-2 pr-4">Size</th>
+                            <th class="py-2">Link</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($this->files as $file)
+                            <tr class="border-t border-gray-100 dark:border-gray-800">
+                                <td class="py-2 pr-4">
+                                    <span class="font-mono">{{ $file['name'] }}</span>
+                                    <span class="block text-xs text-gray-400">{{ $file['desc'] }}</span>
+                                </td>
+                                <td class="py-2 pr-4">
+                                    @if ($file['exists'])
+                                        <span class="text-success-600 dark:text-success-400">present</span>
+                                    @else
+                                        <span class="text-danger-600 dark:text-danger-400">missing</span>
+                                    @endif
+                                </td>
+                                <td class="py-2 pr-4">{{ $this->formatBytes($file['size']) }}</td>
+                                <td class="py-2">
+                                    @if ($file['exists'])
+                                        <a href="{{ $file['url'] }}" target="_blank" rel="noopener"
+                                           class="text-primary-600 hover:underline dark:text-primary-400">download</a>
+                                    @else
+                                        <span class="text-gray-400">-</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </x-filament::section>
+
+        <div wire:poll.3s>
+            @if ($this->status)
+                <x-filament::section>
+                    <x-slot name="heading">
+                        Build status:
+                        @if ($this->status === 'running')
+                            <span class="text-warning-600 dark:text-warning-400">running...</span>
+                        @elseif ($this->status === 'done')
+                            <span class="text-success-600 dark:text-success-400">done</span>
+                        @else
+                            <span class="text-danger-600 dark:text-danger-400">error</span>
+                        @endif
+                    </x-slot>
+
+                    <pre class="overflow-x-auto rounded-lg bg-gray-950 p-4 text-xs text-gray-100">{{ implode("\n", $this->log) }}</pre>
+                </x-filament::section>
+            @endif
+        </div>
+
+    </div>
+</x-filament-panels::page>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WebController;
 use App\Http\Controllers\MapsController;
 use App\Http\Controllers\MapStatsController;
-use App\Http\Controllers\BundlesController;
+use App\Http\Controllers\DownloadsController;
 use App\Http\Controllers\SearchController;
 use App\Http\Controllers\ServersController;
 use App\Http\Controllers\RecordsController;
@@ -107,7 +107,13 @@ Route::post('/api/rendered-videos/{id}/report', [RenderRequestController::class,
 
 Route::get('/records', [RecordsController::class, 'index'])->name('records');
 
-Route::get('/downloads/{id?}/{slug?}', [BundlesController::class, 'index'])->name('bundles');
+// Community downloads hub. The specific segments must stay above the catch-all
+// index route, whose optional {id}/{slug} would otherwise swallow them.
+Route::get('/downloads/upload', [DownloadsController::class, 'create'])->middleware(['auth', 'verified'])->name('downloads.create');
+Route::post('/downloads/upload', [DownloadsController::class, 'store'])->middleware(['auth', 'verified'])->name('downloads.store');
+Route::get('/downloads/entry/{download}/{slug?}', [DownloadsController::class, 'show'])->name('downloads.show');
+Route::get('/downloads/file/{file}', [DownloadsController::class, 'file'])->name('downloads.file');
+Route::get('/downloads/{id?}/{slug?}', [DownloadsController::class, 'index'])->name('downloads');
 
 // Models routes
 Route::get('/models', [ModelsController::class, 'index'])->name('models.index');


### PR DESCRIPTION
Replaces the Bundles page with a community downloads hub at /downloads. New 3-level category tree seeded from the real contents of pak0-pak8 (maps, player models and weapon models intentionally excluded - they have their own sections). Authenticated uploads to a dedicated private B2 bucket (per-user folders, presigned downloads, streaming writes), detail pages with galleries and YouTube embeds, search + sort + defrag-only filter. Three locked self-updating articles: DeFRaG mod (q3defrag.org scrape), server bundle (dfsv-core marker), Family-Friendly pack. Filament moderation with bucket purge on delete, global search integration, legacy bundles migrated idempotently, old /downloads/{id}/{slug} links still resolve. Upload validation uses the extensions rule because binary Quake formats sniff as octet-stream and mimes would reject them.