### PR TITLE
deploy: rebuild dfsv-core.tar at the end of every deploy

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -110,6 +110,14 @@ def pipeline_cmds(name):
         'echo "  - https://defrag.racing$url"; '
         'curl -s -o /dev/null --max-time 30 -w "    HTTP %{http_code}  in %{time_total}s\\n" "https://defrag.racing$url" || echo "    (failed, continuing)"; '
         'done',
+        # Republish dfsv-core.tar from the freshly deployed builder code.
+        # --force skips the engine/mod-unchanged no-op, so a deploy that only
+        # changed the builder itself still refreshes the tar (the nightly
+        # schedule keeps picking up engine/mod updates between deploys). A
+        # failure (GitHub or q3defrag.org down) only flags the deploy log -
+        # rerun `php artisan bundle:build-server --force` by hand then.
+        'echo "==> Rebuilding dfsv-core.tar..."',
+        "php artisan bundle:build-server --force",
     ]
 
     return cmds


### PR DESCRIPTION
The bundle builder only ran from the nightly schedule, so a deployed builder fix did not take effect until midnight (and the engine/mod no-op marker could skip it entirely). Every deploy now finishes with bundle:build-server --force; failures only flag the deploy log.