### PR TITLE
Encode pk3 filenames in download URLs ('#' maps were unloadable)

### DIFF
--- a/app/Console/Commands/ExtractLevelshots.php
+++ b/app/Console/Commands/ExtractLevelshots.php
@@ -49,7 +49,9 @@ class ExtractLevelshots extends Command
             $processed++;
             $this->info("[{$processed}/{$maps->count()}] Processing: {$map->name}");
 
-            $pk3Url = "https://dl.defrag.racing/downloads/maps/" . $map->pk3;
+            // The downloads/maps pool is flat (no maps/<letter>/ sharding like
+            // the pk3 column) and names can contain URL-special characters.
+            $pk3Url = "https://dl.defrag.racing/downloads/maps/" . rawurlencode(basename($map->pk3));
 
             // Check file exists and get size
             $ch = curl_init($pk3Url);

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -253,7 +253,9 @@ class WebController extends Controller
             $parts = explode('/', $map->pk3);
             $filename = end($parts);
 
-            $url = "https://dl.defrag.racing/downloads/maps/" . $filename;
+            // Names can contain URL-special characters ('#' would truncate
+            // the redirect target as a fragment, e.g. gu3#12-rawr.pk3).
+            $url = "https://dl.defrag.racing/downloads/maps/" . rawurlencode($filename);
 
             return redirect($url);
         }

--- a/resources/js/Components/MapCard.vue
+++ b/resources/js/Components/MapCard.vue
@@ -166,7 +166,7 @@
                         <a
                             @click.stop
                             target="_blank"
-                            :href="'https://dl.defrag.racing/downloads/maps/' + map?.pk3?.split('/').pop()"
+                            :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')"
                             class="p-0.5 text-gray-400 hover:text-blue-400 rounded transition-colors"
                             title="Download"
                         >

--- a/resources/js/Components/MapCardLine.vue
+++ b/resources/js/Components/MapCardLine.vue
@@ -153,7 +153,7 @@
                     <div v-for="func in functionsList" :title="func" :class="`sprite-items sprite-${func} w-5 h-5 mr-1 flex-shrink-0 mb-1`"></div>
                 </div>
     
-                <a target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + map?.pk3?.split('/').pop()">
+                <a target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
                     <div class="flex justify-center text-gray-400 bg-blackop-50 hover:bg-blackop-80 py-1 px-2 rounded-md cursor-pointer" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" />

--- a/resources/js/Components/MapCardLineSmall.vue
+++ b/resources/js/Components/MapCardLineSmall.vue
@@ -118,7 +118,7 @@
                     <div v-for="func in functionsList" :title="func" :class="`sprite-items sprite-${func} w-5 h-5 mr-1 flex-shrink-0 mb-1`"></div>
                 </div>
     
-                <a target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + map?.pk3?.split('/').pop()">
+                <a target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
                     <div class="flex justify-center text-gray-400 bg-blackop-50 hover:bg-blackop-80 py-1 px-2 rounded-md cursor-pointer" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" />

--- a/resources/js/Components/Rounds/RoundPart.vue
+++ b/resources/js/Components/Rounds/RoundPart.vue
@@ -173,7 +173,7 @@
                                     <Link :href="`/maps/${encodeURIComponent(pk3.name)}`" class="text-blue-400 hover:text-blue-300 transition">
                                         {{ pk3.name }}
                                     </Link>
-                                    <a :download="pk3.download_name" :href="'https://dl.defrag.racing/downloads/maps/' + pk3.pk3.split('/').pop()" class="text-blue-400 hover:text-blue-300 transition">
+                                    <a :download="pk3.download_name" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(pk3.pk3.split('/').pop())" class="text-blue-400 hover:text-blue-300 transition">
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
                                         </svg>


### PR DESCRIPTION
Map names with URL-special characters (gu3#12-rawr etc.) broke every download path: the /maps/download redirect emitted a raw '#' in the Location header, the map-card and round download buttons built raw hrefs (the browser cuts them at the fragment), and ExtractLevelshots glued the full sharded pk3 column onto the flat downloads/maps pool. All six sites now rawurlencode/encodeURIComponent the flat filename.
