### PR TITLE
Server hosting: multiple SFTP credentials per user (one per VPS)

### DIFF
--- a/app/Filament/Resources/ServerOwnerApplicationResource.php
+++ b/app/Filament/Resources/ServerOwnerApplicationResource.php
@@ -107,6 +107,10 @@ class ServerOwnerApplicationResource extends Resource
                             ->helperText('lowercase, starts with a letter, 3–32 chars, [a-z0-9_-]')
                             ->default(fn ($record) => StorageVpsProvisioner::suggestUsername($record->user->username ?? $record->user->name ?? 'user' . $record->user_id))
                             ->unique('sftp_credentials', 'sftp_username'),
+                        \Filament\Forms\Components\TextInput::make('label')
+                            ->label('Credential label (optional)')
+                            ->maxLength(40)
+                            ->helperText('Users can hold one credential per VPS — the label tells them apart, e.g. "USA VPS".'),
                         \Filament\Forms\Components\Textarea::make('review_note')
                             ->label('Note to applicant (optional)')
                             ->rows(2),
@@ -135,6 +139,7 @@ class ServerOwnerApplicationResource extends Resource
                                 $credential = SftpCredential::create([
                                     'user_id'          => $record->user_id,
                                     'application_id'   => $record->id,
+                                    'label'            => $data['label'] ?? null,
                                     'sftp_username'    => $response['username'],
                                     'host'             => $response['host'],
                                     'port'             => $response['port'],

--- a/app/Filament/Resources/SftpCredentialResource.php
+++ b/app/Filament/Resources/SftpCredentialResource.php
@@ -36,6 +36,11 @@ class SftpCredentialResource extends Resource
                     ->searchable()
                     ->formatStateUsing(fn (string $state): string => UserResource::q3tohtml($state))->html()
                     ->url(fn ($record) => "/profile/{$record->user_id}"),
+                Tables\Columns\TextInputColumn::make('label')
+                    ->label('Label')
+                    ->placeholder('e.g. USA VPS')
+                    ->rules(['nullable', 'string', 'max:40'])
+                    ->searchable(),
                 Tables\Columns\TextColumn::make('sftp_username')
                     ->label('SFTP user')
                     ->searchable()

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\ServerOwnerApplication;
 use App\Models\SftpCredential;
 use App\Services\StorageVpsProvisioner;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
@@ -13,11 +14,14 @@ use RuntimeException;
 
 class ServerHostingController extends Controller
 {
+    /** Hard cap of active credentials per user — one per VPS is the intent. */
+    private const MAX_CREDENTIALS = 8;
+
     /**
      * Show the applicant's current state — one of:
      *   - no application yet (show form)
      *   - latest application pending / rejected
-     *   - active credential issued (show host/user/path)
+     *   - one or more active credentials issued (show each host/user/path)
      *   - revoked credential (show "apply again" hint)
      */
     public function index(Request $request)
@@ -28,43 +32,49 @@ class ServerHostingController extends Controller
             ->latest()
             ->first();
 
-        $credential = SftpCredential::where('user_id', $user->id)
+        // A user can hold several credentials — typically one per VPS —
+        // each with its own SFTP account, password and declared servers.
+        $credentials = SftpCredential::where('user_id', $user->id)
             ->active()
-            ->latest()
-            ->first();
+            ->orderBy('id')
+            ->get()
+            ->map(function (SftpCredential $credential) {
+                $payload = $credential->only(['id', 'label', 'sftp_username', 'host', 'port', 'remote_path', 'status', 'servers']);
+                // admin_note is admin-only metadata; never leak it to the user.
+                $payload['servers'] = array_map(
+                    fn ($s) => collect($s)->except('admin_note')->all(),
+                    $payload['servers'] ?? []
+                );
+                // 'encrypted' cast auto-decrypts on read. Surface to the
+                // page once — the front-end will POST to acknowledge once
+                // the user confirms they've copied it, which nulls the DB.
+                try {
+                    $payload['pending_password'] = $credential->password_pending;
+                } catch (DecryptException) {
+                    // Row encrypted under a different APP_KEY (key rotation,
+                    // prod dump in local dev) — treat as "no pending password"
+                    // instead of 500ing the whole page.
+                    $payload['pending_password'] = null;
+                }
 
-        $pendingPassword = null;
-        if ($credential && $credential->password_pending) {
-            // 'encrypted' cast auto-decrypts on read. Surface to the
-            // page once — the front-end will POST to acknowledge once
-            // the user confirms they've copied it, which nulls the DB.
-            $pendingPassword = $credential->password_pending;
-        }
-
-        $credentialPayload = null;
-        if ($credential) {
-            $credentialPayload = $credential->only(['id', 'sftp_username', 'host', 'port', 'remote_path', 'status', 'servers']);
-            // admin_note is admin-only metadata; never leak it to the user.
-            $credentialPayload['servers'] = array_map(
-                fn ($s) => collect($s)->except('admin_note')->all(),
-                $credentialPayload['servers'] ?? []
-            );
-        }
+                return $payload;
+            })
+            ->values();
 
         return Inertia::render('ServerHosting', [
-            'application'     => $application,
-            'credential'      => $credentialPayload,
-            'pendingPassword' => $pendingPassword,
-            'countries'       => \App\Support\Countries::options(),
+            'application' => $application,
+            'credentials' => $credentials,
+            'countries'   => \App\Support\Countries::options(),
         ]);
     }
 
     public function acknowledgePassword(Request $request)
     {
-        $credential = SftpCredential::where('user_id', $request->user()->id)
-            ->active()
-            ->latest()
-            ->firstOrFail();
+        $request->validate([
+            'credential_id' => ['required', 'integer'],
+        ]);
+
+        $credential = $this->ownedActiveCredential($request);
 
         $credential->update(['password_pending' => null]);
 
@@ -78,22 +88,22 @@ class ServerHostingController extends Controller
      */
     public function resetPassword(Request $request)
     {
-        $user = $request->user();
+        $request->validate([
+            'credential_id' => ['required', 'integer'],
+        ]);
 
-        $credential = SftpCredential::where('user_id', $user->id)
-            ->active()
-            ->latest()
-            ->firstOrFail();
+        $user = $request->user();
+        $credential = $this->ownedActiveCredential($request);
 
         $rateKey = 'sftp-reset:' . $user->id;
-        if (RateLimiter::tooManyAttempts($rateKey, 3)) {
+        if (RateLimiter::tooManyAttempts($rateKey, 6)) {
             $retry = RateLimiter::availableIn($rateKey);
             return back()->with(
                 'danger',
                 "Too many reset attempts. Try again in {$retry} seconds."
             );
         }
-        RateLimiter::hit($rateKey, 3600); // 3 per hour
+        RateLimiter::hit($rateKey, 3600); // 6 per hour, shared across credentials
 
         try {
             $response = app(StorageVpsProvisioner::class)
@@ -143,7 +153,7 @@ class ServerHostingController extends Controller
             return back()->withErrors([
                 'message' => match ($existing->status) {
                     'pending'  => 'You already have an application pending review.',
-                    'approved' => 'You already have an approved application. Use your existing credentials.',
+                    'approved' => 'You already have an approved application. Use your existing credentials, or add another VPS credential from this page.',
                     default    => 'Application already exists.',
                 },
             ]);
@@ -160,8 +170,8 @@ class ServerHostingController extends Controller
     }
 
     /**
-     * Append a new server entry to an already-approved user's credential.
-     * Does NOT touch SFTP provisioning — the user reuses their existing
+     * Append a new server entry to one of an approved user's credentials.
+     * Does NOT touch SFTP provisioning — the user reuses that credential's
      * account on the storage VPS. Only the per-server metadata
      * (gametype/ip/port/rcon/location) grows. rs_code is left null and
      * admins fill it in from Filament after light review.
@@ -169,23 +179,16 @@ class ServerHostingController extends Controller
     public function addServer(Request $request)
     {
         $request->validate([
-            'gametype' => ['required', 'string', 'in:mixed,cpm,vq3,teamruns,fastcaps,freestyle'],
-            'ip'       => ['required', 'string', 'max:255'],
-            'port'     => ['required', 'integer', 'between:1,65535'],
-            'rcon'     => ['required', 'string', 'max:255'],
-            'location' => ['nullable', 'string', 'size:2', 'alpha', \Illuminate\Validation\Rule::in(\App\Support\Countries::CODES)],
+            'credential_id' => ['required', 'integer'],
+            'gametype'      => ['required', 'string', 'in:mixed,cpm,vq3,teamruns,fastcaps,freestyle'],
+            'ip'            => ['required', 'string', 'max:255'],
+            'port'          => ['required', 'integer', 'between:1,65535'],
+            'rcon'          => ['required', 'string', 'max:255'],
+            'location'      => ['nullable', 'string', 'size:2', 'alpha', \Illuminate\Validation\Rule::in(\App\Support\Countries::CODES)],
         ]);
 
         $user = $request->user();
-
-        $credential = SftpCredential::where('user_id', $user->id)
-            ->active()
-            ->latest()
-            ->first();
-
-        if (!$credential) {
-            return back()->with('danger', 'No active credential — you must be an approved server owner to add servers.');
-        }
+        $credential = $this->ownedActiveCredential($request);
 
         $rateKey = 'sftp-add-server:' . $user->id;
         if (RateLimiter::tooManyAttempts($rateKey, 10)) {
@@ -194,19 +197,23 @@ class ServerHostingController extends Controller
         }
         RateLimiter::hit($rateKey, 3600);
 
-        $servers = $credential->servers ?? [];
-
         $ip   = trim($request->input('ip'));
         $port = (int) $request->input('port');
 
-        foreach ($servers as $existing) {
-            if (($existing['ip'] ?? null) === $ip && (int) ($existing['port'] ?? 0) === $port) {
-                return back()->withErrors([
-                    'ip' => "You already have a server registered at {$ip}:{$port}.",
-                ]);
+        // A server can only ship demos through one credential — dedupe
+        // across ALL of the user's active credentials, not just this one.
+        $siblings = SftpCredential::where('user_id', $user->id)->active()->get();
+        foreach ($siblings as $sibling) {
+            foreach ($sibling->servers ?? [] as $existing) {
+                if (($existing['ip'] ?? null) === $ip && (int) ($existing['port'] ?? 0) === $port) {
+                    return back()->withErrors([
+                        'ip' => "You already have a server registered at {$ip}:{$port}.",
+                    ]);
+                }
             }
         }
 
+        $servers   = $credential->servers ?? [];
         $servers[] = [
             'gametype' => $request->input('gametype'),
             'ip'       => $ip,
@@ -219,5 +226,119 @@ class ServerHostingController extends Controller
         $credential->update(['servers' => $servers]);
 
         return back()->with('success', 'Server added. Admin will assign an RS code shortly.');
+    }
+
+    /**
+     * Self-service provisioning of an ADDITIONAL credential for an already
+     * approved server owner — one per VPS, so each box gets its own SFTP
+     * login and a compromise/rotation on one doesn't touch the others.
+     * The first credential still comes from admin approval; this only
+     * works when at least one active credential already exists.
+     */
+    public function requestCredential(Request $request)
+    {
+        $request->validate([
+            'label' => ['required', 'string', 'min:2', 'max:40'],
+        ]);
+
+        $user = $request->user();
+
+        $active = SftpCredential::where('user_id', $user->id)->active()->get();
+
+        if ($active->isEmpty()) {
+            return back()->with('danger', 'No active credential — you must be an approved server owner before adding more.');
+        }
+
+        if ($active->count() >= self::MAX_CREDENTIALS) {
+            return back()->with('danger', 'Credential limit reached (' . self::MAX_CREDENTIALS . '). Ask an admin if you really need more.');
+        }
+
+        $rateKey = 'sftp-new-credential:' . $user->id;
+        if (RateLimiter::tooManyAttempts($rateKey, 3)) {
+            $retry = RateLimiter::availableIn($rateKey);
+            return back()->with('danger', "Too many new credentials. Try again in {$retry} seconds.");
+        }
+        RateLimiter::hit($rateKey, 3600); // 3 per hour
+
+        $label    = trim($request->input('label'));
+        $username = $this->uniqueUsername($user, $label);
+
+        try {
+            $response = app(StorageVpsProvisioner::class)->create($username);
+
+            SftpCredential::create([
+                'user_id'          => $user->id,
+                'application_id'   => ServerOwnerApplication::where('user_id', $user->id)
+                    ->where('status', 'approved')->latest()->value('id'),
+                'label'            => $label,
+                'sftp_username'    => $response['username'],
+                'host'             => $response['host'],
+                'port'             => $response['port'],
+                'remote_path'      => $response['remote_path'],
+                'password_pending' => $response['password'],
+                'servers'          => [],
+                'status'           => 'active',
+                'provisioned_at'   => now(),
+                'provisioned_by'   => null, // self-service, not admin-issued
+            ]);
+
+            return back()->with('success', "New SFTP account \"{$label}\" provisioned. Copy its password now — it is shown only once.");
+        } catch (RuntimeException $e) {
+            Log::error('Self-service SFTP credential provisioning failed', [
+                'user_id' => $user->id,
+                'label'   => $label,
+                'error'   => $e->getMessage(),
+            ]);
+
+            return back()->with(
+                'danger',
+                'Provisioning failed on the storage VPS. Please ask an admin to investigate.'
+            );
+        }
+    }
+
+    /**
+     * Resolve the credential_id from the request to a credential that is
+     * active AND owned by the requesting user — 404s otherwise so users
+     * can never act on someone else's credential.
+     */
+    private function ownedActiveCredential(Request $request): SftpCredential
+    {
+        return SftpCredential::where('user_id', $request->user()->id)
+            ->active()
+            ->where('id', (int) $request->input('credential_id'))
+            ->firstOrFail();
+    }
+
+    /**
+     * Derive a unique SFTP username from the user's name plus the
+     * credential label, e.g. "neyo-usa". Falls back to numeric suffixes
+     * on collision. Result always satisfies the provisioner's
+     * ^[a-z][a-z0-9_-]{2,31}$ contract.
+     */
+    private function uniqueUsername($user, string $label): string
+    {
+        $base = StorageVpsProvisioner::suggestUsername(
+            $user->username ?? $user->name ?? 'user' . $user->id
+        );
+
+        $slug = substr(trim(preg_replace('/[^a-z0-9-]+/', '-', strtolower($label)), '-'), 0, 12);
+        $slug = trim($slug, '-');
+
+        $candidate = $slug !== '' ? "{$base}-{$slug}" : $base;
+        $candidate = rtrim(substr($candidate, 0, 32), '-_');
+
+        if (!preg_match('/^[a-z][a-z0-9_-]{2,31}$/', $candidate)) {
+            $candidate = $base;
+        }
+
+        $username = $candidate;
+        $suffix   = 2;
+        while (SftpCredential::where('sftp_username', $username)->exists()) {
+            $tail     = '-' . $suffix++;
+            $username = rtrim(substr($candidate, 0, 32 - strlen($tail)), '-_') . $tail;
+        }
+
+        return $username;
     }
 }

--- a/app/Models/SftpCredential.php
+++ b/app/Models/SftpCredential.php
@@ -9,6 +9,7 @@ class SftpCredential extends Model
     protected $fillable = [
         'user_id',
         'application_id',
+        'label',
         'sftp_username',
         'host',
         'port',

--- a/database/migrations/2026_07_24_000001_add_label_to_sftp_credentials_table.php
+++ b/database/migrations/2026_07_24_000001_add_label_to_sftp_credentials_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sftp_credentials', function (Blueprint $table) {
+            // Owners can hold several credentials (one per VPS); the label
+            // is how they tell them apart on /server-hosting ("USA box",
+            // "Canada"). Null = provisioned before multi-credential support.
+            $table->string('label', 40)->nullable()->after('application_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sftp_credentials', function (Blueprint $table) {
+            $table->dropColumn('label');
+        });
+    }
+};

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -12,8 +12,7 @@ import { computed, ref } from 'vue';
 
 const props = defineProps({
     application: Object,
-    credential: Object,
-    pendingPassword: { type: String, default: null },
+    credentials: { type: Array, default: () => [] },
     countries: { type: Object, default: () => ({}) },
 });
 
@@ -27,11 +26,13 @@ const page = usePage();
 const successMsg = computed(() => page.props.success);
 const dangerMsg = computed(() => page.props.danger);
 
-const passwordRevealed = ref(false);
-const passwordCopied = ref(false);
+// Per-credential UI state, keyed by credential id — a user can hold
+// several credentials (one per VPS), each with its own pending password.
+const passwordRevealed = ref({});
+const passwordCopied = ref({});
 
-const ackForm = useForm({});
-const resetForm = useForm({});
+const ackForm = useForm({ credential_id: null });
+const resetForm = useForm({ credential_id: null });
 
 // Single styled confirm modal, driven by state. Replaces native
 // browser confirm() — same blocking semantics via the .onConfirm cb.
@@ -71,13 +72,16 @@ const toneClasses = {
     blue:    'bg-blue-500/20   hover:bg-blue-500/30   border-blue-500/40   text-blue-200',
 };
 
-const requestReset = () => {
+const credentialTitle = (cred) => cred.label || cred.sftp_username;
+
+const requestReset = (cred) => {
     openConfirm({
-        title: 'Generate a new password?',
-        body: 'Your current one will stop working immediately. The new password is shown only once on this page — make sure you can save it.',
+        title: `Generate a new password for "${credentialTitle(cred)}"?`,
+        body: 'The current one will stop working immediately. The new password is shown only once on this page — make sure you can save it. Your other credentials are not affected.',
         confirmLabel: 'Generate new password',
         confirmTone: 'amber',
         onConfirm: () => {
+            resetForm.credential_id = cred.id;
             resetForm.post(route('server-hosting.reset-password'), {
                 preserveScroll: true,
             });
@@ -85,26 +89,27 @@ const requestReset = () => {
     });
 };
 
-const copyPassword = async () => {
-    if (!props.pendingPassword) return;
+const copyPassword = async (cred) => {
+    if (!cred.pending_password) return;
     try {
-        await navigator.clipboard.writeText(props.pendingPassword);
-        passwordCopied.value = true;
-        setTimeout(() => { passwordCopied.value = false; }, 2500);
+        await navigator.clipboard.writeText(cred.pending_password);
+        passwordCopied.value[cred.id] = true;
+        setTimeout(() => { passwordCopied.value[cred.id] = false; }, 2500);
     } catch (e) {
         // Fallback for non-https contexts: just leave the value visible
         // so the user can select+copy manually.
-        passwordRevealed.value = true;
+        passwordRevealed.value[cred.id] = true;
     }
 };
 
-const acknowledgePassword = () => {
+const acknowledgePassword = (cred) => {
     openConfirm({
         title: 'Wipe the password from this page?',
         body: "Make sure you've saved it somewhere safe — after confirming, it cannot be shown again. You'd need to generate a new one (or ask an admin to rotate).",
         confirmLabel: "Yes, I've saved it",
         confirmTone: 'emerald',
         onConfirm: () => {
+            ackForm.credential_id = cred.id;
             ackForm.post(route('server-hosting.acknowledge-password'), {
                 preserveScroll: true,
             });
@@ -147,7 +152,7 @@ const submit = () => {
 };
 
 const state = computed(() => {
-    if (props.credential) return 'active';
+    if (props.credentials.length) return 'active';
     if (!props.application) return 'none';
     return props.application.status;
 });
@@ -167,17 +172,17 @@ const submittedServerInfoString = computed(() => {
 
 const gametypeLabel = (value) => GAMETYPES.find(g => g.value === value)?.label ?? value;
 
-// Add-server form (only shown when state === 'active'). Pre-fills IP from
-// the user's most-recent declared server so the common "another port on
-// the same box" case is one click — they only tweak port + gametype.
-const addServerOpen = ref(false);
+// Add-server form (one shared form; addServerOpenId tracks which
+// credential's card has it open). Pre-fills IP from that credential's
+// most-recent declared server so the common "another port on the same
+// box" case is one click — they only tweak port + gametype.
+const addServerOpenId = ref(null);
 
-const existingIps = computed(() => {
-    const list = props.credential?.servers || [];
-    return [...new Set(list.map(s => s.ip).filter(Boolean))];
-});
+const existingIpsFor = (cred) =>
+    [...new Set((cred.servers || []).map(s => s.ip).filter(Boolean))];
 
 const addServerForm = useForm({
+    credential_id: null,
     gametype: 'mixed',
     ip: '',
     port: 27960,
@@ -185,18 +190,37 @@ const addServerForm = useForm({
     location: '',
 });
 
-const openAddServer = () => {
+const openAddServer = (cred) => {
     addServerForm.reset();
-    addServerForm.ip = existingIps.value[0] ?? '';
-    addServerOpen.value = true;
+    addServerForm.credential_id = cred.id;
+    addServerForm.ip = existingIpsFor(cred)[0] ?? '';
+    addServerOpenId.value = cred.id;
 };
 
 const submitAddServer = () => {
     addServerForm.post(route('server-hosting.add-server'), {
         preserveScroll: true,
         onSuccess: () => {
-            addServerOpen.value = false;
+            addServerOpenId.value = null;
             addServerForm.reset();
+        },
+    });
+};
+
+// Additional-credential form — approved owners provision one SFTP account
+// per VPS so every box gets its own password.
+const newCredOpen = ref(false);
+
+const newCredForm = useForm({
+    label: '',
+});
+
+const submitNewCred = () => {
+    newCredForm.post(route('server-hosting.request-credential'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            newCredOpen.value = false;
+            newCredForm.reset();
         },
     });
 };
@@ -219,7 +243,8 @@ const submitAddServer = () => {
         </p>
         <p class="text-xs text-gray-500 mb-8">
             Install the bundle on your defrag host first, then plug your SFTP credentials into
-            <code>sv.conf</code> — we'll give them to you after approval.
+            <code>sv.conf</code> — we'll give them to you after approval. Running servers on
+            several machines? Add one credential per VPS so each box has its own login.
         </p>
 
         <div v-if="successMsg"
@@ -231,225 +256,280 @@ const submitAddServer = () => {
             {{ dangerMsg }}
         </div>
 
-        <!-- STATE: ACTIVE CREDENTIAL --------------------------------------- -->
-        <section v-if="state === 'active'"
-                 class="rounded-xl border border-emerald-500/30 bg-black/40 backdrop-blur-sm p-6 shadow-2xl">
-            <div class="flex items-center gap-2 mb-4">
-                <span class="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
-                <h2 class="text-lg font-semibold text-emerald-300">Active SFTP credentials</h2>
-            </div>
-
-            <p class="text-sm text-gray-400 mb-4">
-                Use these in your <code>sv.conf</code>. The password is shown <strong class="text-emerald-300">only once</strong>
-                — copy it now, or ask an admin to reset it later if you lose it.
-            </p>
-
-            <!-- One-time password reveal box (only when pending) -->
-            <div v-if="pendingPassword"
-                 class="mb-6 rounded-lg border border-yellow-400/40 bg-yellow-500/5 p-4">
-                <div class="flex items-start gap-3">
-                    <span class="text-yellow-300 text-xl leading-none">⚠</span>
-                    <div class="flex-1 min-w-0">
-                        <div class="text-sm font-semibold text-yellow-200 mb-1">Save your password now</div>
-                        <p class="text-xs text-gray-400 mb-3">
-                            This is the only time you'll see it. After clicking "I've saved it", we wipe it from our DB —
-                            it lives only on the storage VPS in hashed form. If you lose it, ask an admin to rotate.
-                        </p>
-
-                        <div class="flex items-center gap-2 mb-3">
-                            <code class="flex-1 px-3 py-2 bg-black/60 border border-white/10 rounded-lg text-sm font-mono text-emerald-200 select-all break-all">
-                                <span v-if="passwordRevealed">{{ pendingPassword }}</span>
-                                <span v-else class="text-gray-500">●●●●●●●●●●●●●●●●●●●●●●●●</span>
-                            </code>
-                            <button type="button"
-                                    @click="passwordRevealed = !passwordRevealed"
-                                    class="px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-gray-300 transition whitespace-nowrap">
-                                {{ passwordRevealed ? 'Hide' : 'Reveal' }}
-                            </button>
-                            <button type="button"
-                                    @click="copyPassword"
-                                    class="px-3 py-2 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/30 text-xs text-blue-200 transition whitespace-nowrap">
-                                {{ passwordCopied ? 'Copied ✓' : 'Copy' }}
-                            </button>
-                        </div>
-
-                        <button type="button"
-                                @click="acknowledgePassword"
-                                :disabled="ackForm.processing"
-                                class="px-3 py-2 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-500/30 text-xs text-emerald-200 transition disabled:opacity-50">
-                            ✓ I've saved it — wipe from this page
-                        </button>
+        <!-- STATE: ACTIVE CREDENTIALS (one card per VPS) --------------------- -->
+        <template v-if="state === 'active'">
+            <section v-for="cred in credentials" :key="cred.id"
+                     class="rounded-xl border border-emerald-500/30 bg-black/40 backdrop-blur-sm p-6 shadow-2xl mb-6">
+                <div class="flex items-center justify-between gap-2 mb-4">
+                    <div class="flex items-center gap-2 min-w-0">
+                        <span class="inline-block h-2 w-2 rounded-full bg-emerald-400 shrink-0"></span>
+                        <h2 class="text-lg font-semibold text-emerald-300 truncate">{{ credentialTitle(cred) }}</h2>
                     </div>
+                    <span v-if="cred.label" class="text-xs text-gray-500 font-mono shrink-0">{{ cred.sftp_username }}</span>
                 </div>
-            </div>
 
-            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
-                <div>
-                    <dt class="text-gray-500">Host</dt>
-                    <dd class="text-gray-200 font-mono">{{ credential.host }}</dd>
-                </div>
-                <div>
-                    <dt class="text-gray-500">Port</dt>
-                    <dd class="text-gray-200 font-mono">{{ credential.port }}</dd>
-                </div>
-                <div>
-                    <dt class="text-gray-500">Username</dt>
-                    <dd class="text-gray-200 font-mono">{{ credential.sftp_username }}</dd>
-                </div>
-                <div>
-                    <dt class="text-gray-500">Remote path</dt>
-                    <dd class="text-gray-200 font-mono">{{ credential.remote_path }}</dd>
-                </div>
-                <div v-if="!pendingPassword" class="sm:col-span-2">
-                    <dt class="text-gray-500">Password</dt>
-                    <dd class="flex items-center gap-3 flex-wrap">
-                        <span class="text-gray-400 italic">no longer shown</span>
-                        <button type="button"
-                                @click="requestReset"
-                                :disabled="resetForm.processing"
-                                class="px-3 py-1 rounded-lg bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/30 text-xs text-amber-200 transition disabled:opacity-50">
-                            {{ resetForm.processing ? 'Resetting…' : 'Generate new password' }}
-                        </button>
-                        <span class="text-xs text-gray-500">(rate-limited — max 3/hour)</span>
-                    </dd>
-                </div>
-            </dl>
-
-            <!-- Per-server RS codes (filled in by admin after approval) -->
-            <div v-if="credential.servers && credential.servers.length" class="mt-6">
-                <div class="text-xs uppercase tracking-wide text-gray-500 mb-2">Your servers</div>
-                <div class="rounded-lg border border-white/10 overflow-hidden">
-                    <table class="w-full text-sm">
-                        <thead class="bg-white/5 text-xs uppercase tracking-wide text-gray-500">
-                            <tr>
-                                <th class="px-3 py-2 text-left">Gametype</th>
-                                <th class="px-3 py-2 text-left">IP : Port</th>
-                                <th class="px-3 py-2 text-left">Location</th>
-                                <th class="px-3 py-2 text-left">RS code</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-white/5">
-                            <tr v-for="(s, i) in credential.servers" :key="i">
-                                <td class="px-3 py-2 font-medium text-emerald-200/80">{{ (s.gametype || '').toUpperCase() }}</td>
-                                <td class="px-3 py-2 font-mono text-gray-300">{{ s.ip }}:{{ s.port }}</td>
-                                <td class="px-3 py-2 font-mono text-gray-300">
-                                    <span v-if="s.location" class="inline-flex items-center gap-1.5">
-                                        <img :src="`/images/flags/${s.location}.png`" class="w-4 h-3 rounded shadow-sm" :alt="s.location" onerror="this.style.display='none'">
-                                        {{ s.location }}
-                                    </span>
-                                    <span v-else class="text-gray-500 italic">not set</span>
-                                </td>
-                                <td class="px-3 py-2 font-mono">
-                                    <span v-if="s.rs_code" class="text-emerald-200">{{ s.rs_code }}</span>
-                                    <span v-else class="text-gray-500 italic">awaiting admin</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <p class="text-xs text-gray-500 mt-2">
-                    Put each RS code into <code>sv.conf</code> as <code>rs&lt;PORT&gt;=&lt;rs_code&gt;</code> (set <code>MDD_ENABLED=1</code> too).
+                <p class="text-sm text-gray-400 mb-4">
+                    Use these in the <code>sv.conf</code> on this VPS. The password is shown <strong class="text-emerald-300">only once</strong>
+                    — copy it now, or generate a new one later if you lose it.
                 </p>
 
-                <!-- Add another server (reuses existing SFTP credential) -->
-                <div class="mt-4">
-                    <button v-if="!addServerOpen"
-                            type="button"
-                            @click="openAddServer"
-                            class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 text-sm transition">
-                        <span class="text-base leading-none">+</span> Add another server
-                    </button>
+                <!-- One-time password reveal box (only when pending) -->
+                <div v-if="cred.pending_password"
+                     class="mb-6 rounded-lg border border-yellow-400/40 bg-yellow-500/5 p-4">
+                    <div class="flex items-start gap-3">
+                        <span class="text-yellow-300 text-xl leading-none">⚠</span>
+                        <div class="flex-1 min-w-0">
+                            <div class="text-sm font-semibold text-yellow-200 mb-1">Save your password now</div>
+                            <p class="text-xs text-gray-400 mb-3">
+                                This is the only time you'll see it. After clicking "I've saved it", we wipe it from our DB —
+                                it lives only on the storage VPS in hashed form. If you lose it, generate a new one below.
+                            </p>
 
-                    <form v-else
-                          @submit.prevent="submitAddServer"
-                          class="rounded-lg border border-emerald-500/20 bg-black/30 p-4 space-y-3">
-                        <div class="flex items-center justify-between">
-                            <h4 class="text-sm font-semibold text-emerald-200">Register another server</h4>
-                            <p class="text-xs text-gray-500">Reuses your existing SFTP credentials — no new password.</p>
-                        </div>
+                            <div class="flex items-center gap-2 mb-3">
+                                <code class="flex-1 px-3 py-2 bg-black/60 border border-white/10 rounded-lg text-sm font-mono text-emerald-200 select-all break-all">
+                                    <span v-if="passwordRevealed[cred.id]">{{ cred.pending_password }}</span>
+                                    <span v-else class="text-gray-500">●●●●●●●●●●●●●●●●●●●●●●●●</span>
+                                </code>
+                                <button type="button"
+                                        @click="passwordRevealed[cred.id] = !passwordRevealed[cred.id]"
+                                        class="px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-gray-300 transition whitespace-nowrap">
+                                    {{ passwordRevealed[cred.id] ? 'Hide' : 'Reveal' }}
+                                </button>
+                                <button type="button"
+                                        @click="copyPassword(cred)"
+                                        class="px-3 py-2 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/30 text-xs text-blue-200 transition whitespace-nowrap">
+                                    {{ passwordCopied[cred.id] ? 'Copied ✓' : 'Copy' }}
+                                </button>
+                            </div>
 
-                        <div class="grid grid-cols-12 gap-2 items-start">
-                            <div class="col-span-2">
-                                <label class="block text-xs text-gray-500 mb-1">Gametype</label>
-                                <select v-model="addServerForm.gametype"
-                                        class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
-                                               bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
-                                               bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
-                                    <option v-for="g in GAMETYPES" :key="g.value" :value="g.value"
-                                            class="bg-slate-900 text-gray-200">{{ g.label }}</option>
-                                </select>
-                            </div>
-                            <div class="col-span-3">
-                                <label class="block text-xs text-gray-500 mb-1">IP</label>
-                                <input v-model="addServerForm.ip"
-                                       :list="existingIps.length ? 'existing-ips' : null"
-                                       type="text" placeholder="123.45.67.89"
-                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
-                                <datalist v-if="existingIps.length" id="existing-ips">
-                                    <option v-for="ip in existingIps" :key="ip" :value="ip" />
-                                </datalist>
-                                <p v-if="addServerForm.errors.ip" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.ip }}</p>
-                            </div>
-                            <div class="col-span-2">
-                                <label class="block text-xs text-gray-500 mb-1">Port</label>
-                                <input v-model.number="addServerForm.port"
-                                       type="number" min="1" max="65535" placeholder="27960"
-                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
-                                <p v-if="addServerForm.errors.port" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.port }}</p>
-                            </div>
-                            <div class="col-span-2">
-                                <label class="block text-xs text-gray-500 mb-1">Rcon</label>
-                                <input v-model="addServerForm.rcon"
-                                       type="text" placeholder="rcon"
-                                       class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
-                                <p v-if="addServerForm.errors.rcon" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.rcon }}</p>
-                            </div>
-                            <div class="col-span-3">
-                                <label class="block text-xs text-gray-500 mb-1">Country</label>
-                                <select v-model="addServerForm.location"
-                                        class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
-                                               bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
-                                               bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
-                                    <option value="" class="bg-slate-900 text-gray-400">— flag —</option>
-                                    <option v-for="c in countryOptions" :key="c.code" :value="c.code"
-                                            class="bg-slate-900 text-gray-200">{{ c.label }}</option>
-                                </select>
-                                <p v-if="addServerForm.errors.location" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.location }}</p>
-                            </div>
-                        </div>
-
-                        <div class="flex justify-end gap-2 pt-1">
                             <button type="button"
-                                    @click="addServerOpen = false"
-                                    class="px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-gray-300 transition">
-                                Cancel
-                            </button>
-                            <button type="submit"
-                                    :disabled="addServerForm.processing"
-                                    class="px-3 py-1.5 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-500/30 text-xs text-emerald-200 transition disabled:opacity-50">
-                                {{ addServerForm.processing ? 'Adding…' : 'Add server' }}
+                                    @click="acknowledgePassword(cred)"
+                                    :disabled="ackForm.processing"
+                                    class="px-3 py-2 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-500/30 text-xs text-emerald-200 transition disabled:opacity-50">
+                                ✓ I've saved it — wipe from this page
                             </button>
                         </div>
-                    </form>
+                    </div>
                 </div>
-            </div>
 
-            <details class="mt-6 group">
-                <summary class="cursor-pointer text-sm text-emerald-300 hover:text-emerald-200 select-none">
-                    Example <code>sv.conf</code> snippet
-                </summary>
-                <pre class="mt-3 text-xs bg-black/60 border border-white/10 rounded-lg p-4 overflow-x-auto text-gray-300"
+                <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+                    <div>
+                        <dt class="text-gray-500">Host</dt>
+                        <dd class="text-gray-200 font-mono">{{ cred.host }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-gray-500">Port</dt>
+                        <dd class="text-gray-200 font-mono">{{ cred.port }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-gray-500">Username</dt>
+                        <dd class="text-gray-200 font-mono">{{ cred.sftp_username }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-gray-500">Remote path</dt>
+                        <dd class="text-gray-200 font-mono">{{ cred.remote_path }}</dd>
+                    </div>
+                    <div v-if="!cred.pending_password" class="sm:col-span-2">
+                        <dt class="text-gray-500">Password</dt>
+                        <dd class="flex items-center gap-3 flex-wrap">
+                            <span class="text-gray-400 italic">no longer shown</span>
+                            <button type="button"
+                                    @click="requestReset(cred)"
+                                    :disabled="resetForm.processing"
+                                    class="px-3 py-1 rounded-lg bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/30 text-xs text-amber-200 transition disabled:opacity-50">
+                                {{ resetForm.processing && resetForm.credential_id === cred.id ? 'Resetting…' : 'Generate new password' }}
+                            </button>
+                            <span class="text-xs text-gray-500">(rate-limited — max 6/hour)</span>
+                        </dd>
+                    </div>
+                </dl>
+
+                <!-- Per-server RS codes (filled in by admin after approval) -->
+                <div class="mt-6">
+                    <div v-if="cred.servers && cred.servers.length">
+                        <div class="text-xs uppercase tracking-wide text-gray-500 mb-2">Servers on this credential</div>
+                        <div class="rounded-lg border border-white/10 overflow-hidden">
+                            <table class="w-full text-sm">
+                                <thead class="bg-white/5 text-xs uppercase tracking-wide text-gray-500">
+                                    <tr>
+                                        <th class="px-3 py-2 text-left">Gametype</th>
+                                        <th class="px-3 py-2 text-left">IP : Port</th>
+                                        <th class="px-3 py-2 text-left">Location</th>
+                                        <th class="px-3 py-2 text-left">RS code</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-white/5">
+                                    <tr v-for="(s, i) in cred.servers" :key="i">
+                                        <td class="px-3 py-2 font-medium text-emerald-200/80">{{ (s.gametype || '').toUpperCase() }}</td>
+                                        <td class="px-3 py-2 font-mono text-gray-300">{{ s.ip }}:{{ s.port }}</td>
+                                        <td class="px-3 py-2 font-mono text-gray-300">
+                                            <span v-if="s.location" class="inline-flex items-center gap-1.5">
+                                                <img :src="`/images/flags/${s.location}.png`" class="w-4 h-3 rounded shadow-sm" :alt="s.location" onerror="this.style.display='none'">
+                                                {{ s.location }}
+                                            </span>
+                                            <span v-else class="text-gray-500 italic">not set</span>
+                                        </td>
+                                        <td class="px-3 py-2 font-mono">
+                                            <span v-if="s.rs_code" class="text-emerald-200">{{ s.rs_code }}</span>
+                                            <span v-else class="text-gray-500 italic">awaiting admin</span>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-2">
+                            Put each RS code into <code>sv.conf</code> as <code>rs&lt;PORT&gt;=&lt;rs_code&gt;</code> (set <code>MDD_ENABLED=1</code> too).
+                        </p>
+                    </div>
+                    <p v-else class="text-xs text-gray-500">
+                        No servers declared on this credential yet — add the ones running on this VPS below.
+                    </p>
+
+                    <!-- Add another server (reuses this credential) -->
+                    <div class="mt-4">
+                        <button v-if="addServerOpenId !== cred.id"
+                                type="button"
+                                @click="openAddServer(cred)"
+                                class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 text-sm transition">
+                            <span class="text-base leading-none">+</span> Add another server
+                        </button>
+
+                        <form v-else
+                              @submit.prevent="submitAddServer"
+                              class="rounded-lg border border-emerald-500/20 bg-black/30 p-4 space-y-3">
+                            <div class="flex items-center justify-between">
+                                <h4 class="text-sm font-semibold text-emerald-200">Register another server</h4>
+                                <p class="text-xs text-gray-500">Reuses this credential — no new password.</p>
+                            </div>
+
+                            <div class="grid grid-cols-12 gap-2 items-start">
+                                <div class="col-span-2">
+                                    <label class="block text-xs text-gray-500 mb-1">Gametype</label>
+                                    <select v-model="addServerForm.gametype"
+                                            class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
+                                                   bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
+                                                   bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
+                                        <option v-for="g in GAMETYPES" :key="g.value" :value="g.value"
+                                                class="bg-slate-900 text-gray-200">{{ g.label }}</option>
+                                    </select>
+                                </div>
+                                <div class="col-span-3">
+                                    <label class="block text-xs text-gray-500 mb-1">IP</label>
+                                    <input v-model="addServerForm.ip"
+                                           :list="existingIpsFor(cred).length ? `existing-ips-${cred.id}` : null"
+                                           type="text" placeholder="123.45.67.89"
+                                           class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
+                                    <datalist v-if="existingIpsFor(cred).length" :id="`existing-ips-${cred.id}`">
+                                        <option v-for="ip in existingIpsFor(cred)" :key="ip" :value="ip" />
+                                    </datalist>
+                                    <p v-if="addServerForm.errors.ip" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.ip }}</p>
+                                </div>
+                                <div class="col-span-2">
+                                    <label class="block text-xs text-gray-500 mb-1">Port</label>
+                                    <input v-model.number="addServerForm.port"
+                                           type="number" min="1" max="65535" placeholder="27960"
+                                           class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
+                                    <p v-if="addServerForm.errors.port" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.port }}</p>
+                                </div>
+                                <div class="col-span-2">
+                                    <label class="block text-xs text-gray-500 mb-1">Rcon</label>
+                                    <input v-model="addServerForm.rcon"
+                                           type="text" placeholder="rcon"
+                                           class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 font-mono focus:border-blue-500 focus:ring-0 transition" />
+                                    <p v-if="addServerForm.errors.rcon" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.rcon }}</p>
+                                </div>
+                                <div class="col-span-3">
+                                    <label class="block text-xs text-gray-500 mb-1">Country</label>
+                                    <select v-model="addServerForm.location"
+                                            class="w-full bg-black/50 border border-white/10 rounded-lg px-2 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition appearance-none cursor-pointer
+                                                   bg-[url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22%23a1a1aa%22><path d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22/></svg>')]
+                                                   bg-no-repeat bg-[right_0.5rem_center] bg-[length:1rem] pr-8">
+                                        <option value="" class="bg-slate-900 text-gray-400">— flag —</option>
+                                        <option v-for="c in countryOptions" :key="c.code" :value="c.code"
+                                                class="bg-slate-900 text-gray-200">{{ c.label }}</option>
+                                    </select>
+                                    <p v-if="addServerForm.errors.location" class="text-xs text-red-400 mt-1">{{ addServerForm.errors.location }}</p>
+                                </div>
+                            </div>
+
+                            <div class="flex justify-end gap-2 pt-1">
+                                <button type="button"
+                                        @click="addServerOpenId = null"
+                                        class="px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-gray-300 transition">
+                                    Cancel
+                                </button>
+                                <button type="submit"
+                                        :disabled="addServerForm.processing"
+                                        class="px-3 py-1.5 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-500/30 text-xs text-emerald-200 transition disabled:opacity-50">
+                                    {{ addServerForm.processing ? 'Adding…' : 'Add server' }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <details class="mt-6 group">
+                    <summary class="cursor-pointer text-sm text-emerald-300 hover:text-emerald-200 select-none">
+                        Example <code>sv.conf</code> snippet
+                    </summary>
+                    <pre class="mt-3 text-xs bg-black/60 border border-white/10 rounded-lg p-4 overflow-x-auto text-gray-300"
 ><code>MDD_ENABLED=1
-<template v-for="s in (credential.servers || [])" :key="s.port">rs{{ s.port }}={{ s.rs_code || '0' }}
+<template v-for="s in (cred.servers || [])" :key="s.port">rs{{ s.port }}={{ s.rs_code || '0' }}
 </template>
 DEMO_SFTP_ENABLED=1
-DEMO_SFTP_HOST={{ credential.host }}
-DEMO_SFTP_PORT={{ credential.port }}
-DEMO_SFTP_USER={{ credential.sftp_username }}
-DEMO_SFTP_PASS={{ pendingPassword || '<your password>' }}
-DEMO_SFTP_REMOTEDIR={{ credential.remote_path }}</code></pre>
-            </details>
-        </section>
+DEMO_SFTP_HOST={{ cred.host }}
+DEMO_SFTP_PORT={{ cred.port }}
+DEMO_SFTP_USER={{ cred.sftp_username }}
+DEMO_SFTP_PASS={{ cred.pending_password || '<your password>' }}
+DEMO_SFTP_REMOTEDIR={{ cred.remote_path }}</code></pre>
+                </details>
+            </section>
+
+            <!-- Add another VPS credential (separate SFTP account) -->
+            <section class="rounded-xl border border-white/10 bg-black/40 backdrop-blur-sm p-6 shadow-2xl">
+                <button v-if="!newCredOpen"
+                        type="button"
+                        @click="newCredOpen = true"
+                        class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/30 text-blue-300 text-sm transition">
+                    <span class="text-base leading-none">+</span> Add another VPS credential
+                </button>
+                <p v-if="!newCredOpen" class="text-xs text-gray-500 mt-2">
+                    Hosting on more than one machine? Provision a separate SFTP account per VPS —
+                    each gets its own username and password, so rotating or revoking one never
+                    breaks the others.
+                </p>
+
+                <form v-if="newCredOpen"
+                      @submit.prevent="submitNewCred"
+                      class="space-y-3">
+                    <div>
+                        <h4 class="text-sm font-semibold text-blue-200 mb-1">New SFTP account</h4>
+                        <p class="text-xs text-gray-500">
+                            Creates a fresh account on the storage VPS with its own password (shown once).
+                            Name it after the machine it's for.
+                        </p>
+                    </div>
+                    <div class="flex items-start gap-2">
+                        <div class="flex-1">
+                            <input v-model="newCredForm.label"
+                                   type="text" maxlength="40" placeholder='e.g. "USA VPS" or "Canada box"'
+                                   class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-sm text-gray-200 focus:border-blue-500 focus:ring-0 transition" />
+                            <p v-if="newCredForm.errors.label" class="text-xs text-red-400 mt-1">{{ newCredForm.errors.label }}</p>
+                        </div>
+                        <button type="button"
+                                @click="newCredOpen = false"
+                                class="px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-gray-300 transition">
+                            Cancel
+                        </button>
+                        <button type="submit"
+                                :disabled="newCredForm.processing || newCredForm.label.trim().length < 2"
+                                class="px-3 py-2 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/30 text-xs text-blue-200 transition disabled:opacity-50">
+                            {{ newCredForm.processing ? 'Provisioning…' : 'Create account' }}
+                        </button>
+                    </div>
+                </form>
+            </section>
+        </template>
 
         <!-- STATE: PENDING APPLICATION -------------------------------------- -->
         <section v-else-if="state === 'pending'"

--- a/routes/web.php
+++ b/routes/web.php
@@ -335,6 +335,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/server-hosting/acknowledge-password', [\App\Http\Controllers\ServerHostingController::class, 'acknowledgePassword'])->name('server-hosting.acknowledge-password');
     Route::post('/server-hosting/reset-password', [\App\Http\Controllers\ServerHostingController::class, 'resetPassword'])->name('server-hosting.reset-password');
     Route::post('/server-hosting/add-server', [\App\Http\Controllers\ServerHostingController::class, 'addServer'])->name('server-hosting.add-server');
+    Route::post('/server-hosting/request-credential', [\App\Http\Controllers\ServerHostingController::class, 'requestCredential'])->name('server-hosting.request-credential');
 });
 
 


### PR DESCRIPTION
## Problem
The /server-hosting flow assumed one active SFTP credential per user. Owners
running defrag servers on several VPSes had to share a single login across all
machines - rotating the password on one box broke every other box.

## Changes
- `sftp_credentials.label` column (nullable) so credentials can be told apart
- /server-hosting renders one card per active credential; password
  reveal/reset/acknowledge and add-server now target a `credential_id`
  (ownership-checked, 404 otherwise)
- Self-service "Add another VPS credential" for already-approved owners:
  max 8 active, 3/hour rate limit, username derived from the label
  (e.g. `neyo-usa`), provisioned through the existing restricted SSH wrapper
- add-server dedupes ip:port across ALL of the user's credentials
- Filament: inline-editable Label column, optional label on approve
- Password reset limit bumped 3 -> 6/hour (now shared across credentials)
- `index()` no longer 500s when `password_pending` was encrypted under a
  different APP_KEY (key rotation / prod dump) - degrades to null

## Deploy notes
Requires `php artisan migrate --force` (adds the `label` column).
Existing credentials and VPS accounts are untouched.