### PR TITLE
Serverhosting: prefill rcon + country in Add server, hyphen in country labels

### DIFF
--- a/app/Support/Countries.php
+++ b/app/Support/Countries.php
@@ -48,7 +48,7 @@ class Countries
                 $name = function_exists('locale_get_display_region')
                     ? locale_get_display_region('-' . $code, 'en')
                     : $code;
-                $out[$code] = $name && $name !== $code ? "{$code} — {$name}" : $code;
+                $out[$code] = $name && $name !== $code ? "{$code} - {$name}" : $code;
             }
             asort($out, SORT_NATURAL);
             return $out;

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -16,7 +16,7 @@ const props = defineProps({
     countries: { type: Object, default: () => ({}) },
 });
 
-// Backend ships countries as { "CZ": "CZ — Czechia", ... } already sorted.
+// Backend ships countries as { "CZ": "CZ - Czechia", ... } already sorted.
 // Convert to an array of {code,label} for v-for stability.
 const countryOptions = computed(() =>
     Object.entries(props.countries).map(([code, label]) => ({ code, label }))
@@ -173,9 +173,9 @@ const submittedServerInfoString = computed(() => {
 const gametypeLabel = (value) => GAMETYPES.find(g => g.value === value)?.label ?? value;
 
 // Add-server form (one shared form; addServerOpenId tracks which
-// credential's card has it open). Pre-fills IP from that credential's
-// most-recent declared server so the common "another port on the same
-// box" case is one click — they only tweak port + gametype.
+// credential's card has it open). Pre-fills IP, rcon and country from
+// that credential's most-recent declared server so the common "another
+// port on the same box" case is one click — they only tweak port + gametype.
 const addServerOpenId = ref(null);
 
 const existingIpsFor = (cred) =>
@@ -193,7 +193,10 @@ const addServerForm = useForm({
 const openAddServer = (cred) => {
     addServerForm.reset();
     addServerForm.credential_id = cred.id;
-    addServerForm.ip = existingIpsFor(cred)[0] ?? '';
+    const last = (cred.servers || []).filter(s => s && s.ip).at(-1) ?? {};
+    addServerForm.ip = last.ip ?? existingIpsFor(cred)[0] ?? '';
+    addServerForm.rcon = last.rcon ?? '';
+    addServerForm.location = last.location ?? '';
     addServerOpenId.value = cred.id;
 };
 


### PR DESCRIPTION
Country option labels now use a plain ASCII hyphen (CA - Canada) instead of an em-dash
"Register another server" prefills rcon and country from the credential's most recently declared server, on top of the existing IP prefill - the common "same box, next port" flow only needs port (+ gametype)
No backend validation changes; fields remain editable before submit