### PR TITLE
Make rendered videos searchable by demo filename

### DIFF
--- a/app/Filament/Resources/RenderedVideoResource.php
+++ b/app/Filament/Resources/RenderedVideoResource.php
@@ -224,6 +224,13 @@ class RenderedVideoResource extends Resource
                     })
                     ->sortable(),
 
+                Tables\Columns\TextColumn::make('demo_filename')
+                    ->label('Demo file')
+                    ->searchable()
+                    ->limit(30)
+                    ->tooltip(fn ($record) => $record->demo_filename)
+                    ->toggleable(isToggledHiddenByDefault: true),
+
                 Tables\Columns\TextColumn::make('youtube_url')
                     ->label('YT')
                     ->url(fn ($record) => $record->youtube_url)


### PR DESCRIPTION
The admin table search only covered map_name, player_name and requested_by, so searching by a run time (e.g. 19.22.688, the way filenames are named) found nothing and failed items looked missing. The demo filename contains map, time and player, so one searchable (hidden by default) column covers all of those at once.