### PR TITLE
Serverdemos: SFTP upload monitoring + account health checks

### DIFF
--- a/app/Console/Commands/SyncServerdemoStats.php
+++ b/app/Console/Commands/SyncServerdemoStats.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\SftpCredential;
+use App\Services\StorageVpsProvisioner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class SyncServerdemoStats extends Command
+{
+    protected $signature = 'serverdemos:sync-stats';
+
+    protected $description = 'Pull per-account demo upload stats from the storage VPS into sftp_credentials (last_upload_at, demo_count)';
+
+    public function handle(StorageVpsProvisioner $provisioner): int
+    {
+        try {
+            $stats = $provisioner->stats();
+        } catch (Throwable $e) {
+            Log::error('serverdemos:sync-stats failed to reach storage VPS', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->error('Storage VPS unreachable: ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $byUsername = collect($stats)->keyBy('username');
+        $updated = 0;
+
+        SftpCredential::query()
+            ->whereIn('sftp_username', $byUsername->keys())
+            ->get()
+            ->each(function (SftpCredential $credential) use ($byUsername, &$updated) {
+                $row = $byUsername[$credential->sftp_username];
+
+                $credential->update([
+                    'demo_count'     => (int) ($row['demo_count'] ?? 0),
+                    'last_upload_at' => isset($row['last_upload']) && $row['last_upload'] !== null
+                        ? Carbon::createFromTimestampUTC((int) $row['last_upload'])
+                        : null,
+                ]);
+                $updated++;
+            });
+
+        $this->info("Synced upload stats for {$updated} credential(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -97,6 +97,11 @@ class Kernel extends ConsoleKernel
         // overwrites existing coordinates.
         $schedule->command('servers:geolocate')->withoutOverlapping()->daily();
 
+        // Serverdemos upload monitoring: pulls per-SFTP-account demo counts
+        // and newest-upload timestamps from the storage VPS ingest tree into
+        // sftp_credentials, driving the health badge in Filament.
+        $schedule->command('serverdemos:sync-stats')->withoutOverlapping()->hourly();
+
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();
 

--- a/app/Filament/Resources/ServerOwnerApplicationResource.php
+++ b/app/Filament/Resources/ServerOwnerApplicationResource.php
@@ -177,6 +177,21 @@ class ServerOwnerApplicationResource extends Resource
                                 ))
                                 ->persistent()
                                 ->send();
+
+                            // Immediately verify the freshly provisioned
+                            // account actually works (chroot, perms, test
+                            // write). Never throws; quiet on success -
+                            // the admin only hears about problems.
+                            $check = app(\App\Services\SftpCredentialChecker::class)
+                                ->check($result['credential']);
+                            if (! $check['ok']) {
+                                Notification::make()
+                                    ->danger()
+                                    ->title('Account provisioned but health check FAILED')
+                                    ->body(implode("\n", $check['problems']))
+                                    ->persistent()
+                                    ->send();
+                            }
                         } catch (RuntimeException $e) {
                             Log::error('Approve failed', [
                                 'application_id' => $record->id,

--- a/app/Filament/Resources/SftpCredentialResource.php
+++ b/app/Filament/Resources/SftpCredentialResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\SftpCredentialResource\Pages;
 use App\Models\SftpCredential;
+use App\Services\SftpCredentialChecker;
 use App\Services\StorageVpsProvisioner;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
@@ -90,6 +91,50 @@ class SftpCredentialResource extends Resource
 
                         return $missing ? 'Missing location: '.implode(', ', $missing) : 'All servers located';
                     }),
+                Tables\Columns\TextColumn::make('last_upload_at')
+                    ->label('Last demo')
+                    ->badge()
+                    ->sortable()
+                    ->getStateUsing(fn ($record) => $record->last_upload_at
+                        ? $record->last_upload_at->diffForHumans()
+                        : 'never')
+                    ->color(function ($record): string {
+                        if (! $record->last_upload_at) {
+                            return 'danger';
+                        }
+                        if ($record->last_upload_at->gt(now()->subDay())) {
+                            return 'success';
+                        }
+                        if ($record->last_upload_at->gt(now()->subWeek())) {
+                            return 'warning';
+                        }
+
+                        return 'danger';
+                    })
+                    ->tooltip(fn ($record) => sprintf(
+                        '%s demo(s) ingested%s - synced hourly from the storage VPS',
+                        number_format((int) ($record->demo_count ?? 0)),
+                        $record->last_upload_at
+                            ? ', newest ' . $record->last_upload_at->toDateTimeString() . ' UTC'
+                            : ''
+                    )),
+                Tables\Columns\TextColumn::make('check_status')
+                    ->label('Check')
+                    ->badge()
+                    ->placeholder('not checked')
+                    ->color(fn (?string $state): string => match ($state) {
+                        'ok'     => 'success',
+                        'failed' => 'danger',
+                        'error'  => 'warning',
+                        default  => 'gray',
+                    })
+                    ->tooltip(fn ($record) => $record->last_checked_at
+                        ? trim(
+                            'Checked ' . $record->last_checked_at->diffForHumans()
+                            . ($record->check_message ? "\n" . $record->check_message : '')
+                        )
+                        : 'Never checked')
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('provisioned_at')
                     ->dateTime()
                     ->sortable(),
@@ -210,6 +255,29 @@ class SftpCredentialResource extends Resource
                             ->success()
                             ->title('Servers updated')
                             ->send();
+                    }),
+                Tables\Actions\Action::make('checkSftp')
+                    ->label('Check SFTP')
+                    ->icon('heroicon-o-shield-check')
+                    ->color('gray')
+                    ->visible(fn ($record) => $record->status === 'active')
+                    ->action(function ($record) {
+                        $result = app(SftpCredentialChecker::class)->check($record);
+
+                        if ($result['ok']) {
+                            Notification::make()
+                                ->success()
+                                ->title('SFTP account healthy')
+                                ->body("Account '{$record->sftp_username}' passed all checks (group, shell, chroot, test write, ingest).")
+                                ->send();
+                        } else {
+                            Notification::make()
+                                ->danger()
+                                ->title("SFTP check failed for '{$record->sftp_username}'")
+                                ->body(implode("\n", $result['problems']))
+                                ->persistent()
+                                ->send();
+                        }
                     }),
                 Tables\Actions\Action::make('resetPassword')
                     ->icon('heroicon-o-arrow-path')

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -138,6 +138,9 @@ class ServerHostingController extends Controller
             'servers.*.port'          => ['required', 'integer', 'between:1,65535'],
             'servers.*.rcon'          => ['required', 'string', 'max:255'],
             'servers.*.location'      => ['nullable', 'string', 'size:2', 'alpha', \Illuminate\Validation\Rule::in(\App\Support\Countries::CODES)],
+            // Consent to the server hosting rules shown on the page is
+            // a hard requirement - the timestamp is stored on the row.
+            'rules_accepted'          => ['required', 'accepted'],
         ]);
 
         $user = $request->user();
@@ -160,10 +163,11 @@ class ServerHostingController extends Controller
         }
 
         ServerOwnerApplication::create([
-            'user_id'     => $user->id,
-            'message'     => $request->input('message'),
-            'server_info' => $request->input('servers'),
-            'status'      => 'pending',
+            'user_id'           => $user->id,
+            'message'           => $request->input('message'),
+            'server_info'       => $request->input('servers'),
+            'rules_accepted_at' => now(),
+            'status'            => 'pending',
         ]);
 
         return back()->with('success', 'Application submitted. Admins will review it shortly.');

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -266,7 +266,7 @@ class ServerHostingController extends Controller
         try {
             $response = app(StorageVpsProvisioner::class)->create($username);
 
-            SftpCredential::create([
+            $credential = SftpCredential::create([
                 'user_id'          => $user->id,
                 'application_id'   => ServerOwnerApplication::where('user_id', $user->id)
                     ->where('status', 'approved')->latest()->value('id'),
@@ -281,6 +281,12 @@ class ServerHostingController extends Controller
                 'provisioned_at'   => now(),
                 'provisioned_by'   => null, // self-service, not admin-issued
             ]);
+
+            // Verify the account end-to-end right away. Never throws;
+            // a failure lands as check_status='failed' on the row (red
+            // badge in Filament) plus a warning in the log - the user
+            // still gets their password either way.
+            app(\App\Services\SftpCredentialChecker::class)->check($credential);
 
             return back()->with('success', "New SFTP account \"{$label}\" provisioned. Copy its password now — it is shown only once.");
         } catch (RuntimeException $e) {

--- a/app/Models/ServerOwnerApplication.php
+++ b/app/Models/ServerOwnerApplication.php
@@ -10,6 +10,7 @@ class ServerOwnerApplication extends Model
         'user_id',
         'message',
         'server_info',
+        'rules_accepted_at',
         'status',
         'reviewed_by',
         'reviewed_at',
@@ -17,7 +18,8 @@ class ServerOwnerApplication extends Model
     ];
 
     protected $casts = [
-        'reviewed_at' => 'datetime',
+        'reviewed_at'       => 'datetime',
+        'rules_accepted_at' => 'datetime',
         // server_info stores a structured list of the applicant's defrag
         // servers — see ServerHostingController::apply() for the shape.
         'server_info' => 'array',

--- a/app/Models/SftpCredential.php
+++ b/app/Models/SftpCredential.php
@@ -20,11 +20,18 @@ class SftpCredential extends Model
         'provisioned_at',
         'revoked_at',
         'provisioned_by',
+        'last_upload_at',
+        'demo_count',
+        'last_checked_at',
+        'check_status',
+        'check_message',
     ];
 
     protected $casts = [
         'provisioned_at'   => 'datetime',
         'revoked_at'       => 'datetime',
+        'last_upload_at'   => 'datetime',
+        'last_checked_at'  => 'datetime',
         // Encrypted-at-rest; written by Approve / Reset, nulled by the
         // user's "I've copied it" acknowledgement.
         'password_pending' => 'encrypted',

--- a/app/Services/SftpCredentialChecker.php
+++ b/app/Services/SftpCredentialChecker.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SftpCredential;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Runs the storage-VPS `check <username>` health check for a credential
+ * and persists the outcome onto the row (check_status, check_message,
+ * last_checked_at, plus the demo stats the check returns for free).
+ *
+ * Never throws - provisioning flows call this right after creating an
+ * account, and a broken *check* must not roll back or mask a successful
+ * *provision*. A check that could not run is recorded as 'error'.
+ */
+class SftpCredentialChecker
+{
+    public function __construct(
+        private readonly StorageVpsProvisioner $provisioner,
+    ) {
+    }
+
+    /**
+     * @return array{ok: bool, problems: array<int, string>}
+     */
+    public function check(SftpCredential $credential): array
+    {
+        try {
+            $result = $this->provisioner->check($credential->sftp_username);
+        } catch (Throwable $e) {
+            Log::error('SFTP credential check failed to run', [
+                'credential_id' => $credential->id,
+                'sftp_username' => $credential->sftp_username,
+                'error'         => $e->getMessage(),
+            ]);
+
+            $credential->update([
+                'last_checked_at' => now(),
+                'check_status'    => 'error',
+                'check_message'   => 'Check could not run: ' . $e->getMessage(),
+            ]);
+
+            return ['ok' => false, 'problems' => ['check could not run: ' . $e->getMessage()]];
+        }
+
+        $ok       = (bool) ($result['ok'] ?? false);
+        $problems = array_values((array) ($result['problems'] ?? []));
+
+        $credential->update([
+            'last_checked_at' => now(),
+            'check_status'    => $ok ? 'ok' : 'failed',
+            'check_message'   => $ok ? null : implode("\n", $problems),
+            'demo_count'      => $result['demo_count'] ?? $credential->demo_count,
+            'last_upload_at'  => isset($result['last_upload']) && $result['last_upload'] !== null
+                ? \Illuminate\Support\Carbon::createFromTimestampUTC((int) $result['last_upload'])
+                : $credential->last_upload_at,
+        ]);
+
+        if (!$ok) {
+            Log::warning('SFTP credential check found problems', [
+                'credential_id' => $credential->id,
+                'sftp_username' => $credential->sftp_username,
+                'problems'      => $problems,
+            ]);
+        }
+
+        return ['ok' => $ok, 'problems' => $problems];
+    }
+}

--- a/app/Services/StorageVpsProvisioner.php
+++ b/app/Services/StorageVpsProvisioner.php
@@ -12,8 +12,8 @@ use Symfony\Component\Process\Process;
  * The remote side is restricted by `command=` in authorized_keys to a
  * single binary (`df-sftp-provision-wrap`), so the only attack surface
  * here is whatever the wrapper itself accepts. The wrapper rejects any
- * subcommand outside `create|reset-password|revoke|info|list` and any
- * argument that isn't `[a-zA-Z0-9_-]+`, but we still validate
+ * subcommand outside `create|reset-password|revoke|info|list|stats|check`
+ * and any argument that isn't `[a-zA-Z0-9_-]+`, but we still validate
  * client-side — defense in depth.
  *
  * All methods return the decoded JSON array from the remote command.
@@ -51,6 +51,27 @@ class StorageVpsProvisioner
     public function list(): array
     {
         return $this->call('list', []);
+    }
+
+    /**
+     * Passive per-user upload stats read from the ingest tree.
+     *
+     * @return array<int, array{username: string, demo_count: int, last_upload: int|null}>
+     */
+    public function stats(): array
+    {
+        return $this->call('stats', []);
+    }
+
+    /**
+     * End-to-end account health check (group, shell, chroot perms, test
+     * write as the user, ingest dir, ingest daemon).
+     *
+     * @return array{username: string, ok: bool, problems: array<int, string>, demo_count: int, last_upload: int|null}
+     */
+    public function check(string $username): array
+    {
+        return $this->call('check', [$username]);
     }
 
     /**

--- a/database/migrations/2026_07_25_000001_add_monitoring_to_sftp_credentials_table.php
+++ b/database/migrations/2026_07_25_000001_add_monitoring_to_sftp_credentials_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sftp_credentials', function (Blueprint $table) {
+            // Filled hourly by serverdemos:sync-stats from the storage
+            // VPS ingest tree - passive "are demos arriving" monitoring.
+            $table->timestamp('last_upload_at')->nullable()->after('servers');
+            $table->unsignedInteger('demo_count')->nullable()->after('last_upload_at');
+
+            // Filled by the on-demand / post-provision account check.
+            $table->timestamp('last_checked_at')->nullable()->after('demo_count');
+            $table->string('check_status', 10)->nullable()->after('last_checked_at');
+            $table->text('check_message')->nullable()->after('check_status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sftp_credentials', function (Blueprint $table) {
+            $table->dropColumn([
+                'last_upload_at',
+                'demo_count',
+                'last_checked_at',
+                'check_status',
+                'check_message',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_07_25_000002_add_rules_accepted_at_to_server_owner_applications_table.php
+++ b/database/migrations/2026_07_25_000002_add_rules_accepted_at_to_server_owner_applications_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('server_owner_applications', function (Blueprint $table) {
+            // When the applicant ticked "I agree to the server hosting
+            // rules" on /server-hosting. Nullable: pre-existing
+            // applications predate the rules checkbox.
+            $table->timestamp('rules_accepted_at')->nullable()->after('server_info');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('server_owner_applications', function (Blueprint $table) {
+            $table->dropColumn('rules_accepted_at');
+        });
+    }
+};

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -137,6 +137,7 @@ const blankServer = () => ({
 const form = useForm({
     message: '',
     servers: [blankServer()],
+    rules_accepted: false,
 });
 
 const addServer = () => form.servers.push(blankServer());
@@ -249,6 +250,71 @@ const submitNewCred = () => {
             <code>sv.conf</code> — we'll give them to you after approval. Running servers on
             several machines? Add one credential per VPS so each box has its own login.
         </p>
+
+        <!-- SERVER HOSTING RULES - open for applicants, collapsed for active owners -->
+        <details :open="state !== 'active'"
+                 class="mb-8 rounded-xl border border-blue-500/30 bg-black/40 backdrop-blur-sm shadow-2xl group">
+            <summary class="cursor-pointer select-none px-6 py-4 text-base font-semibold text-blue-300 hover:text-blue-200 transition">
+                Server hosting rules
+                <span class="text-xs font-normal text-gray-500 ml-2">- required reading for every server admin</span>
+            </summary>
+            <div class="px-6 pb-6 space-y-4 text-sm text-gray-300">
+                <ol class="space-y-4 list-none">
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">1. Registration and activation</div>
+                        <p class="text-gray-400">Every server must be registered through defrag.racing server hosting
+                        before going public. Servers are activated only after they meet all the requirements below.
+                        Unregistered or non-compliant servers will not be listed on defrag.racing.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">2. Server demos are mandatory</div>
+                        <p class="text-gray-400">All servers must run with server-side demo recording enabled
+                        (serverdemos). Demos are <strong class="text-gray-200">not public and never will be</strong> -
+                        they are stored privately on defrag.racing infrastructure and are only reviewed by staff if a
+                        player report is filed and its validity is confirmed. They exist purely as an integrity/review
+                        mechanism.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">3. SFTP demo upload connection is mandatory</div>
+                        <p class="text-gray-400">Every server must be connected to the defrag.racing storage via the
+                        provided SFTP account (automatic demo upload in the server bundle:
+                        <code>DEMO_SFTP_ENABLED=1</code> + the credentials you receive from neyo during registration).
+                        Servers that are not connected, or whose upload stops working for an extended period, will not
+                        be activated - and already active servers will be deactivated until the connection is
+                        restored.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">4. Keep your server up to date</div>
+                        <p class="text-gray-400">Run the current defrag.racing server bundle (or keep your engine/mod
+                        updated to the latest supported release). Outdated servers may misbehave in the server browser
+                        and record system and may be delisted until updated.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">5. Stability and fair play</div>
+                        <p class="text-gray-400">Keep your server reasonably stable and reachable. Do not tamper with
+                        recorded demos, timers, or record submission in any way. Any manipulation leads to immediate
+                        deactivation.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">6. Naming and conduct</div>
+                        <p class="text-gray-400">Server names must not impersonate other servers/communities and must
+                        not contain offensive content. Admins are expected to act respectfully towards players.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">7. Support</div>
+                        <p class="text-gray-400">If you have trouble setting up the bundle or the SFTP connection,
+                        contact <a href="/profile/8"
+                                   class="text-emerald-300 hover:text-emerald-200 underline decoration-dotted">neyo</a>
+                        - via his defrag.racing profile or on Discord in the server-hosting section. We would rather
+                        help you get compliant than delist you.</p>
+                    </li>
+                </ol>
+                <p class="text-xs text-gray-500 pt-2 border-t border-white/5">
+                    These rules exist to keep the record system verifiable. Demos stay private and untouched unless a
+                    confirmed report requires a review. Thanks for hosting!
+                </p>
+            </div>
+        </details>
 
         <div v-if="successMsg"
              class="mb-6 rounded-xl border border-green-500/30 bg-black/40 backdrop-blur-sm px-4 py-3 text-sm text-green-300 shadow-2xl">
@@ -675,13 +741,29 @@ DEMO_SFTP_REMOTEDIR={{ cred.remote_path }}</code></pre>
                     <p v-if="form.errors.servers" class="text-xs text-red-400 mt-2">{{ form.errors.servers }}</p>
                 </div>
 
-                <!-- Submit -->
-                <div class="flex justify-end pt-2 border-t border-white/5">
-                    <button type="submit"
-                            :disabled="form.processing || form.message.length < 20"
-                            class="px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-400 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium transition">
-                        {{ form.processing ? 'Submitting…' : 'Submit application' }}
-                    </button>
+                <!-- Rules consent + submit -->
+                <div class="pt-2 border-t border-white/5 space-y-3">
+                    <label class="flex items-start gap-3 cursor-pointer select-none">
+                        <input v-model="form.rules_accepted"
+                               type="checkbox"
+                               class="mt-0.5 h-4 w-4 rounded border-white/20 bg-black/50 text-blue-500 focus:ring-blue-500/50 focus:ring-offset-0 cursor-pointer" />
+                        <span class="text-sm text-gray-300">
+                            I have read and agree to the
+                            <span class="text-blue-300 font-medium">server hosting rules</span> above -
+                            including mandatory serverdemos recording and the SFTP demo upload connection.
+                            <span class="text-red-400">*</span>
+                        </span>
+                    </label>
+                    <p v-if="form.errors.rules_accepted" class="text-xs text-red-400">{{ form.errors.rules_accepted }}</p>
+
+                    <div class="flex justify-end">
+                        <button type="submit"
+                                :disabled="form.processing || form.message.length < 20 || !form.rules_accepted"
+                                class="px-4 py-2 rounded-lg bg-blue-500 hover:bg-blue-400 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium transition"
+                                :title="!form.rules_accepted ? 'You must agree to the server hosting rules first' : null">
+                            {{ form.processing ? 'Submitting…' : 'Submit application' }}
+                        </button>
+                    </div>
                 </div>
             </form>
         </section>

--- a/resources/views/filament/applications/detail-modal.blade.php
+++ b/resources/views/filament/applications/detail-modal.blade.php
@@ -57,5 +57,13 @@
         @if ($record->reviewed_at)
             <div>Reviewed: {{ $record->reviewed_at?->format('Y-m-d H:i') }}</div>
         @endif
+        <div>
+            Rules accepted:
+            @if ($record->rules_accepted_at)
+                <span class="text-green-600 dark:text-green-400">{{ $record->rules_accepted_at->format('Y-m-d H:i') }}</span>
+            @else
+                <span class="italic">not recorded (application predates the rules)</span>
+            @endif
+        </div>
     </div>
 </div>


### PR DESCRIPTION
- storage VPS CLI gains 'stats' (per-account demo_count + newest-upload epoch, read passively from serverdemos) and 'check <user>' (group, shell, chroot perms, test write as the user, ingest dir, ingest daemon) - both whitelisted in the SSH wrapper
- StorageVpsProvisioner::stats()/check() + SftpCredentialChecker service that persists results (never throws - a broken check must not mask a successful provision)
- serverdemos:sync-stats command scheduled hourly: fills last_upload_at + demo_count on sftp_credentials
- Filament SFTP credentials: 'Last demo' badge (green <24h, yellow <7d, red older/never), 'Check' status badge, Check SFTP row action
- auto-check runs after admin Approve (danger notification when the fresh account fails) and after self-service provisioning (failure lands as red badge + log warning)
- Rules section