### PR TITLE
bundle:build-server: also build the windows core bundle

### DIFF
--- a/app/Console/Commands/BuildServerBundle.php
+++ b/app/Console/Commands/BuildServerBundle.php
@@ -9,47 +9,88 @@ use Illuminate\Support\Facades\Storage;
 use Symfony\Component\Process\Process;
 
 /**
- * Assembles the "core" server bundle that defrag server owners download.
+ * Assembles the "core" server bundles that defrag server owners download.
  *
- * The bundle is split in two:
- *  - dfsv-baseq3.tar  : the ~485 MB id-Quake3 paks, static forever, built once
- *                       by hand and uploaded. This command never touches it.
- *  - dfsv-core.tar    : everything that actually changes - the oDFe engine and
+ * Per platform there are two pieces:
+ *  - baseq3 data      : the ~485 MB id-Quake3 paks, static forever, built once
+ *                       by hand and uploaded (dfsv-baseq3.tar). Never touched here.
+ *  - the core bundle  : everything that actually changes - the oDFe engine and
  *                       the DeFRaG mod - plus the small static bits (recordsystem
- *                       modules, qagame, ip4db.dat, uglifix2.so). THIS command
- *                       rebuilds and publishes it.
+ *                       modules, qagame, ip4db.dat, uglifix2.so / support DLLs).
+ *                       THIS command rebuilds and publishes it.
  *
- * Only two inputs are dynamic:
- *  - oDFe.ded  : pulled from the latest Defrag-racing/oDFe GitHub release.
+ * Only two inputs are dynamic and they are shared by both platforms:
+ *  - oDFe      : pulled from the latest Defrag-racing/oDFe GitHub release.
  *  - the mod   : latest non-beta defrag_*.zip from q3defrag.org.
- * Everything else lives in dfsv-core-static.tar (uploaded once, next to the
- * output on the dl_storage disk).
+ * Everything else lives in the per-platform static archive (uploaded once, next
+ * to the output on the dl_storage disk).
  *
- * A marker file records which engine build + mod filename produced the current
- * dfsv-core.tar, so a scheduled run is a cheap no-op until something changes.
+ * A marker file per platform records which engine build + mod filename produced
+ * the current output, so a scheduled run is a cheap no-op until something changes.
+ *
+ * The windows platform is skipped with a warning while its static archive has
+ * not been uploaded yet - a linux-only box stays green.
  */
 class BuildServerBundle extends Command
 {
-    protected $signature = 'bundle:build-server {--force : Rebuild even if the engine and mod are unchanged}';
-    protected $description = 'Assemble dfsv-core.tar (oDFe engine + DeFRaG mod + static base) and publish it to the downloads disk';
+    protected $signature = 'bundle:build-server
+        {--force : Rebuild even if the engine and mod are unchanged}
+        {--platform=all : Which bundle to build: linux, windows or all}';
+
+    protected $description = 'Assemble the core server bundles (oDFe engine + DeFRaG mod + static base) and publish them to the downloads disk';
 
     /** dl_storage disk root is /www/downloads on the storage VPS (local dir in dev). */
     private const DISK = 'dl_storage';
 
-    private const STATIC_TAR = 'dfsv-core-static.tar';   // input, uploaded once (modules + qagame + ip4db + uglifix)
-    private const OUTPUT_TAR = 'dfsv-core.tar';          // published output
-    private const MARKER     = 'dfsv-core.version.json'; // records what produced the current output
-
     private const ENGINE_RELEASE = 'https://api.github.com/repos/Defrag-racing/oDFe/releases/latest';
-    // The i386 Linux server binary lives in the multi-platform zip under
-    // linux-x86/. It MUST be the 32-bit build: the MDD recordsystem is a
-    // 32-bit qagamei386.so, and a 64-bit oDFe.ded silently falls back to
-    // the qvm, which disables the recordsystem entirely.
+    // Both server binaries live in the multi-platform zip. They MUST be the
+    // 32-bit builds: the MDD recordsystem is a 32-bit qagamei386.so /
+    // qagamex86.dll, and a 64-bit oDFe.ded silently falls back to the qvm,
+    // which disables the recordsystem entirely.
     private const ENGINE_ASSET   = 'oDFe-other.zip';
     private const MOD_INDEX      = 'https://q3defrag.org/files/defrag/';
 
+    /**
+     * Per-platform recipe.
+     *
+     * static / output / marker : file names on the dl_storage disk
+     * engine_dir + engine_file : where the ded binary sits inside ENGINE_ASSET
+     * engine_target            : its name inside the published bundle
+     * format                   : tar (linux, preserves the exec bit) or zip (windows)
+     * required                  : false = warn and skip when the static archive is missing
+     */
+    private const PLATFORMS = [
+        'linux' => [
+            'static'        => 'dfsv-core-static.tar',
+            'output'        => 'dfsv-core.tar',
+            'marker'        => 'dfsv-core.version.json',
+            'engine_dir'    => 'linux-x86',
+            'engine_file'   => 'oDFe.ded',
+            'engine_target' => 'oDFe.ded',
+            'format'        => 'tar',
+            'required'      => true,
+        ],
+        'windows' => [
+            'static'        => 'dfsv-core-win-static.zip',
+            'output'        => 'dfsv-core-win.zip',
+            'marker'        => 'dfsv-core-win.version.json',
+            'engine_dir'    => 'windows-msvc-x86',
+            'engine_file'   => 'oDFe.ded.exe',
+            'engine_target' => 'oDFe.ded.exe',
+            'format'        => 'zip',
+            'required'      => false,
+        ],
+    ];
+
     public function handle(): int
     {
+        $platform = strtolower((string) $this->option('platform'));
+        if (! in_array($platform, ['all', 'linux', 'windows'], true)) {
+            $this->error("Unknown --platform '{$platform}' (use linux, windows or all).");
+            return self::FAILURE;
+        }
+        $targets = $platform === 'all' ? array_keys(self::PLATFORMS) : [$platform];
+
         $disk = Storage::disk(self::DISK);
 
         $engine = $this->latestEngine();
@@ -67,74 +108,58 @@ class BuildServerBundle extends Command
         $this->info("Latest engine build: {$engine['version']}");
         $this->info("Latest mod:          {$mod['file']}");
 
-        // Cheap no-op when nothing changed since the last successful build.
-        if (! $this->option('force') && $disk->exists(self::OUTPUT_TAR) && $disk->exists(self::MARKER)) {
-            $marker = json_decode((string) $disk->get(self::MARKER), true) ?: [];
-            if (($marker['engine'] ?? null) === $engine['version'] && ($marker['mod'] ?? null) === $mod['file']) {
-                $this->info('Engine and mod unchanged since last build - nothing to do (use --force to rebuild).');
-                return self::SUCCESS;
+        // Which targets actually need work? Resolving this first means the
+        // engine and mod are downloaded only when at least one build runs.
+        $todo = [];
+        foreach ($targets as $name) {
+            $recipe = self::PLATFORMS[$name];
+
+            if (! $this->option('force') && $disk->exists($recipe['output']) && $disk->exists($recipe['marker'])) {
+                $marker = json_decode((string) $disk->get($recipe['marker']), true) ?: [];
+                if (($marker['engine'] ?? null) === $engine['version'] && ($marker['mod'] ?? null) === $mod['file']) {
+                    $this->info("[{$name}] engine and mod unchanged since last build - nothing to do (use --force to rebuild).");
+                    continue;
+                }
             }
+
+            if (! $disk->exists($recipe['static'])) {
+                $message = $recipe['static'] . ' is missing on the ' . self::DISK . ' disk. Upload it once before building.';
+                if ($recipe['required']) {
+                    $this->error("[{$name}] {$message}");
+                    return self::FAILURE;
+                }
+                $this->warn("[{$name}] skipped: {$message}");
+                continue;
+            }
+
+            $todo[] = $name;
         }
 
-        if (! $disk->exists(self::STATIC_TAR)) {
-            $this->error(self::STATIC_TAR . ' is missing on the ' . self::DISK . ' disk. Upload it once before building.');
-            return self::FAILURE;
+        if (empty($todo)) {
+            return self::SUCCESS;
         }
 
-        $work  = storage_path('app/bundle-build-' . uniqid());
-        $stage = $work . '/stage';
-        @mkdir($stage, 0775, true);
+        $work = storage_path('app/bundle-build-' . uniqid());
+        @mkdir($work, 0775, true);
 
         try {
-            // Static base -> stage/
-            file_put_contents($work . '/static.tar', $disk->get(self::STATIC_TAR));
-            $this->runProcess(['tar', '-xf', $work . '/static.tar', '-C', $stage]);
-
-            // Fresh engine -> stage/oDFe.ded
+            // Shared inputs - fetched once, reused by every platform.
             $this->info('Downloading engine...');
             $this->download($engine['url'], $work . '/engine.zip');
             $this->runProcess(['unzip', '-o', '-q', $work . '/engine.zip', '-d', $work . '/engine']);
-            $ded = is_dir($work . '/engine/linux-x86')
-                ? $this->findFile($work . '/engine/linux-x86', 'oDFe.ded')
-                : null;
-            if ($ded === null) {
-                throw new \RuntimeException('linux-x86/oDFe.ded (the required i386 build) not found inside ' . self::ENGINE_ASSET);
-            }
-            copy($ded, $stage . '/oDFe.ded');
-            chmod($stage . '/oDFe.ded', 0755);
 
-            // Fresh mod -> stage/defrag/zz-*.pk3
             $this->info('Downloading mod...');
             $this->download($mod['url'], $work . '/mod.zip');
             $this->runProcess(['unzip', '-o', '-q', $work . '/mod.zip', '-d', $work . '/mod']);
-            @mkdir($stage . '/defrag', 0775, true);
+
             $pk3s = $this->findAll($work . '/mod', 'zz-*.pk3');
             if (empty($pk3s)) {
                 throw new \RuntimeException('no zz-*.pk3 found inside ' . $mod['file']);
             }
-            foreach ($pk3s as $pk3) {
-                copy($pk3, $stage . '/defrag/' . basename($pk3));
+
+            foreach ($todo as $name) {
+                $this->buildPlatform($name, $work, $pk3s, $engine, $mod, $disk);
             }
-
-            // Repack -> dfsv-core.tar
-            $this->runProcess(['tar', '-cf', $work . '/' . self::OUTPUT_TAR, '-C', $stage, '.']);
-
-            // Publish (stream so a ~10 MB body never sits in one buffer)
-            $out = fopen($work . '/' . self::OUTPUT_TAR, 'rb');
-            $disk->writeStream(self::OUTPUT_TAR, $out);
-            if (is_resource($out)) {
-                fclose($out);
-            }
-
-            $disk->put(self::MARKER, json_encode([
-                'engine'   => $engine['version'],
-                'mod'      => $mod['file'],
-                'built_at' => now()->toIso8601String(),
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-
-            $mb = round(filesize($work . '/' . self::OUTPUT_TAR) / 1048576, 2);
-            $this->info("Published " . self::OUTPUT_TAR . " ({$mb} MB) with " . count($pk3s) . ' mod pk3(s).');
-            Log::info('bundle:build-server published', ['engine' => $engine['version'], 'mod' => $mod['file'], 'mb' => $mb]);
 
             return self::SUCCESS;
         } catch (\Throwable $e) {
@@ -147,7 +172,86 @@ class BuildServerBundle extends Command
     }
 
     /**
-     * Latest oDFe Linux build. The release tag is the rolling "latest", so the
+     * Stage one platform's bundle (static base + fresh engine + fresh mod pk3s)
+     * and publish it with its marker.
+     *
+     * @param  string[]                     $pk3s
+     * @param  array{version:string,url:string} $engine
+     * @param  array{file:string,url:string}    $mod
+     */
+    private function buildPlatform(
+        string $name,
+        string $work,
+        array $pk3s,
+        array $engine,
+        array $mod,
+        \Illuminate\Contracts\Filesystem\Filesystem $disk
+    ): void {
+        $recipe = self::PLATFORMS[$name];
+        $stage  = $work . '/stage-' . $name;
+        @mkdir($stage, 0775, true);
+
+        // Static base -> stage/
+        $staticLocal = $work . '/static-' . $name;
+        file_put_contents($staticLocal, $disk->get($recipe['static']));
+        if (str_ends_with(strtolower($recipe['static']), '.zip')) {
+            $this->extractZip($staticLocal, $stage);
+        } else {
+            $this->runProcess(['tar', '-xf', $staticLocal, '-C', $stage]);
+        }
+
+        // Fresh engine -> stage/<engine_target>
+        $engineDir = $work . '/engine/' . $recipe['engine_dir'];
+        $ded       = is_dir($engineDir) ? $this->findFile($engineDir, $recipe['engine_file']) : null;
+        if ($ded === null) {
+            throw new \RuntimeException(
+                $recipe['engine_dir'] . '/' . $recipe['engine_file']
+                . ' (the required 32-bit build) not found inside ' . self::ENGINE_ASSET
+            );
+        }
+        copy($ded, $stage . '/' . $recipe['engine_target']);
+        chmod($stage . '/' . $recipe['engine_target'], 0755);
+
+        // Fresh mod -> stage/defrag/zz-*.pk3
+        @mkdir($stage . '/defrag', 0775, true);
+        foreach ($pk3s as $pk3) {
+            copy($pk3, $stage . '/defrag/' . basename($pk3));
+        }
+
+        // Repack
+        $outLocal = $work . '/' . $recipe['output'];
+        if ($recipe['format'] === 'zip') {
+            $this->packZip($stage, $outLocal);
+        } else {
+            $this->runProcess(['tar', '-cf', $outLocal, '-C', $stage, '.']);
+        }
+
+        // Publish (stream so a ~10 MB body never sits in one buffer)
+        $out = fopen($outLocal, 'rb');
+        $disk->writeStream($recipe['output'], $out);
+        if (is_resource($out)) {
+            fclose($out);
+        }
+
+        $disk->put($recipe['marker'], json_encode([
+            'engine'   => $engine['version'],
+            'mod'      => $mod['file'],
+            'built_at' => now()->toIso8601String(),
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        $mb = round(filesize($outLocal) / 1048576, 2);
+        $this->info("[{$name}] published " . $recipe['output'] . " ({$mb} MB) with " . count($pk3s) . ' mod pk3(s).');
+        Log::info('bundle:build-server published', [
+            'platform' => $name,
+            'output'   => $recipe['output'],
+            'engine'   => $engine['version'],
+            'mod'      => $mod['file'],
+            'mb'       => $mb,
+        ]);
+    }
+
+    /**
+     * Latest oDFe build. The release tag is the rolling "latest", so the
      * asset's updated_at is what actually identifies a given build.
      *
      * @return array{version:string,url:string}|null
@@ -199,6 +303,36 @@ class BuildServerBundle extends Command
             ->timeout(180)->get($url);
         if (! $res->successful()) {
             throw new \RuntimeException("download failed ({$url}): HTTP " . $res->status());
+        }
+    }
+
+    private function extractZip(string $zipPath, string $dest): void
+    {
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new \RuntimeException("could not open zip {$zipPath}");
+        }
+        if (! $zip->extractTo($dest)) {
+            $zip->close();
+            throw new \RuntimeException("could not extract {$zipPath} into {$dest}");
+        }
+        $zip->close();
+    }
+
+    /** Zip the whole staging tree with paths relative to its root. */
+    private function packZip(string $stage, string $dest): void
+    {
+        $zip = new \ZipArchive();
+        if ($zip->open($dest, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException("could not create zip {$dest}");
+        }
+        // walk() yields files only; zip creates the parent entries implicitly.
+        $prefix = rtrim($stage, '/') . '/';
+        foreach ($this->walk($stage) as $file) {
+            $zip->addFile($file->getPathname(), substr($file->getPathname(), strlen($prefix)));
+        }
+        if (! $zip->close()) {
+            throw new \RuntimeException("could not finalize zip {$dest}");
         }
     }
 


### PR DESCRIPTION
The command now builds one core bundle per platform from the same two dynamic inputs (latest oDFe release + latest DeFRaG mod), each with its own static base, output name and version marker:

  linux   dfsv-core-static.tar    -> dfsv-core.tar    (linux-x86/oDFe.ded)
  windows dfsv-core-win-static.zip -> dfsv-core-win.zip (windows-msvc-x86/oDFe.ded.exe)

Both engines must be the 32-bit builds, same reason as before: the MDD recordsystem is a 32-bit qagame and a 64-bit ded silently falls back to the qvm.

The engine and mod archives are downloaded once per run and shared by both builds, and each platform keeps its own marker so the daily scheduled run stays a cheap no-op. --platform=linux|windows|all selects what to build.

While dfsv-core-win-static.zip has not been uploaded yet the windows build is skipped with a warning instead of failing the run, so nothing changes for the linux pipeline until the static input exists.

This is what lets the windows servers (defrag-server-windows repo) get their engine, mod, modules and support DLLs from dl.defrag.racing instead of hand-copied files.