### PR TITLE
bundle:build-server: survive backslash paths in the windows static zip

### DIFF
--- a/app/Console/Commands/BuildServerBundle.php
+++ b/app/Console/Commands/BuildServerBundle.php
@@ -306,17 +306,55 @@ class BuildServerBundle extends Command
         }
     }
 
+    /**
+     * Extract a zip entry by entry instead of extractTo(), because
+     * PowerShell 5.1's Compress-Archive stores nested entries with
+     * BACKSLASH separators ("defrag\modules\admin.dll"). extractTo() would
+     * take that as one literal filename and flatten the tree.
+     */
     private function extractZip(string $zipPath, string $dest): void
     {
         $zip = new \ZipArchive();
         if ($zip->open($zipPath) !== true) {
             throw new \RuntimeException("could not open zip {$zipPath}");
         }
-        if (! $zip->extractTo($dest)) {
+
+        try {
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $name = (string) $zip->getNameIndex($i);
+                if ($name === '') {
+                    continue;
+                }
+
+                $relative = ltrim(str_replace('\\', '/', $name), '/');
+                if ($relative === '' || str_ends_with($relative, '/')) {
+                    continue; // directory entry - created with the files below
+                }
+                if (preg_match('#(^|/)\.\.(/|$)#', $relative)) {
+                    throw new \RuntimeException("refusing traversal entry '{$name}' in {$zipPath}");
+                }
+
+                $target = $dest . '/' . $relative;
+                if (! is_dir(dirname($target)) && ! mkdir(dirname($target), 0775, true) && ! is_dir(dirname($target))) {
+                    throw new \RuntimeException('could not create ' . dirname($target));
+                }
+
+                $in = $zip->getStream($name);
+                if ($in === false) {
+                    throw new \RuntimeException("could not read '{$name}' from {$zipPath}");
+                }
+                $out = fopen($target, 'wb');
+                if ($out === false) {
+                    fclose($in);
+                    throw new \RuntimeException("could not write {$target}");
+                }
+                stream_copy_to_stream($in, $out);
+                fclose($in);
+                fclose($out);
+            }
+        } finally {
             $zip->close();
-            throw new \RuntimeException("could not extract {$zipPath} into {$dest}");
         }
-        $zip->close();
     }
 
     /** Zip the whole staging tree with paths relative to its root. */

--- a/deploy.py
+++ b/deploy.py
@@ -110,13 +110,14 @@ def pipeline_cmds(name):
         'echo "  - https://defrag.racing$url"; '
         'curl -s -o /dev/null --max-time 30 -w "    HTTP %{http_code}  in %{time_total}s\\n" "https://defrag.racing$url" || echo "    (failed, continuing)"; '
         'done',
-        # Republish dfsv-core.tar from the freshly deployed builder code.
-        # --force skips the engine/mod-unchanged no-op, so a deploy that only
-        # changed the builder itself still refreshes the tar (the nightly
-        # schedule keeps picking up engine/mod updates between deploys). A
-        # failure (GitHub or q3defrag.org down) only flags the deploy log -
-        # rerun `php artisan bundle:build-server --force` by hand then.
-        'echo "==> Rebuilding dfsv-core.tar..."',
+        # Republish the core bundles (dfsv-core.tar for linux, dfsv-core-win.zip
+        # for windows) from the freshly deployed builder code. --force skips the
+        # engine/mod-unchanged no-op, so a deploy that only changed the builder
+        # itself still refreshes them (the nightly schedule keeps picking up
+        # engine/mod updates between deploys). A failure (GitHub or q3defrag.org
+        # down) only flags the deploy log - rerun
+        # `php artisan bundle:build-server --force` by hand then.
+        'echo "==> Rebuilding core server bundles..."',
         "php artisan bundle:build-server --force",
     ]
 


### PR DESCRIPTION
PowerShell 5.1's Compress-Archive stores nested entries with backslash separators ("defrag\modules\admin.dll"), and ZipArchive::extractTo takes that as one literal filename - the published dfsv-core-win.zip ended up with 28 flattened entries whose names contained backslashes instead of a defrag/modules/ tree.

Extract entry by entry and normalise the separators, rejecting traversal entries while we are in there. The mod pk3s already used forward slashes, so only the static base was affected.