### PR TITLE
server-hosting: raise the add-server rate limit to 40/hour

### DIFF
--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -194,8 +194,11 @@ class ServerHostingController extends Controller
         $user = $request->user();
         $credential = $this->ownedActiveCredential($request);
 
+        // 10/hour turned out to be too tight: a single box can legitimately
+        // host ~20 servers (the EU 10gbit box runs 17), and declaring them all
+        // right after provisioning is the normal first-time flow.
         $rateKey = 'sftp-add-server:' . $user->id;
-        if (RateLimiter::tooManyAttempts($rateKey, 10)) {
+        if (RateLimiter::tooManyAttempts($rateKey, 40)) {
             $retry = RateLimiter::availableIn($rateKey);
             return back()->with('danger', "Too many additions. Try again in {$retry} seconds.");
         }


### PR DESCRIPTION
A box with ~20 servers hits 10/hour while simply declaring what it runs - the EU 10gbit box has 17, and the limit fired halfway through.