### PR TITLE
serverdemos: index them in the database

### DIFF
--- a/app/Console/Commands/IndexServerDemos.php
+++ b/app/Console/Commands/IndexServerDemos.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ServerDemo;
+use App\Models\SftpCredential;
+use App\Services\ServerDemoPath;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Walks the serverdemo store on the storage VPS and records every demo in
+ * `server_demos`.
+ *
+ * One recursive listing per credential directory: Flysystem's listContents()
+ * carries size and mtime in the listing itself, so a directory with tens of
+ * thousands of demos costs one traversal rather than a stat per file - the
+ * same trick ServerdemosBrowser already relies on.
+ *
+ * Demos that were indexed before but are no longer on the disk are NOT
+ * deleted from the index; they are marked `on_contabo = false`. Once the
+ * local copy stops being the only copy, that flag is how the app knows to
+ * serve the file from B2 instead. A directory whose listing threw is skipped
+ * entirely rather than swept, so a dropped SSH connection can never look like
+ * "every demo disappeared".
+ */
+class IndexServerDemos extends Command
+{
+    protected $signature = 'serverdemos:index
+        {--dir=* : Only these credential directories}
+        {--dry-run : Report what would be indexed without writing}';
+
+    protected $description = 'Index the serverdemos on the storage VPS into the server_demos table';
+
+    private const DISK = 'serverdemos';
+
+    /** Rows per upsert. Small enough to stay well inside max_allowed_packet. */
+    private const BATCH = 500;
+
+    public function handle(): int
+    {
+        $dry = (bool) $this->option('dry-run');
+        $disk = Storage::disk(self::DISK);
+        $startedAt = Carbon::now();
+
+        try {
+            $roots = $this->option('dir') ?: $disk->directories('');
+        } catch (\Throwable $e) {
+            $this->error('Could not list the serverdemos root: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        $roots = array_values(array_filter(
+            array_map(fn ($d) => trim($d, '/'), $roots),
+            fn ($d) => $d !== '' && ! in_array($d, ServerDemoPath::SKIP_DIRS, true)
+        ));
+
+        if ($roots === []) {
+            $this->warn('No credential directories found.');
+            return self::SUCCESS;
+        }
+
+        $credentials = SftpCredential::pluck('id', 'sftp_username');
+
+        $totals = ['seen' => 0, 'unparsed' => 0, 'gone' => 0, 'failed' => 0];
+
+        foreach ($roots as $root) {
+            $this->line("Indexing {$root}/ ...");
+
+            $batch = [];
+            $seen = 0;
+            $unparsed = 0;
+
+            try {
+                foreach ($disk->getDriver()->listContents($root, true) as $item) {
+                    if (! $item->isFile()) {
+                        continue;
+                    }
+
+                    $parsed = ServerDemoPath::parse($item->path());
+
+                    if ($parsed === null) {
+                        // Not a demo file. The ingest daemon deletes anything
+                        // that is not a .dm_68, so this should be rare.
+                        $unparsed++;
+                        continue;
+                    }
+
+                    $batch[] = [
+                        'owner_dir'          => $parsed['owner_dir'],
+                        'sftp_credential_id' => $credentials[$parsed['owner_dir']] ?? null,
+                        'path'               => $item->path(),
+                        'filename'           => $parsed['filename'],
+                        'size'               => (int) ($item->fileSize() ?? 0),
+                        'recorded_at'        => $item->lastModified()
+                            ? Carbon::createFromTimestamp($item->lastModified())
+                            : null,
+                        'rs_server_id'       => $parsed['rs_server_id'],
+                        'map_name'           => $parsed['map_name'],
+                        'physics'            => $parsed['physics'],
+                        'time_ms'            => $parsed['time_ms'],
+                        'mdd_id'             => $parsed['mdd_id'],
+                        'on_contabo'         => true,
+                        'indexed_at'         => $startedAt,
+                        'created_at'         => $startedAt,
+                        'updated_at'         => $startedAt,
+                    ];
+
+                    $seen++;
+
+                    if (count($batch) >= self::BATCH) {
+                        $this->flush($batch, $dry);
+                        $batch = [];
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Partial listing: keep whatever was already written, but do
+                // NOT sweep - the missing files may simply never have been
+                // listed.
+                $this->flush($batch, $dry);
+                $this->error("  listing failed after {$seen} file(s): " . $e->getMessage());
+                $totals['seen'] += $seen;
+                $totals['failed']++;
+                continue;
+            }
+
+            $this->flush($batch, $dry);
+
+            // Anything in this directory the walk did not touch is no longer
+            // on the local disk.
+            $gone = 0;
+            if (! $dry) {
+                $gone = ServerDemo::where('owner_dir', $root)
+                    ->where('on_contabo', true)
+                    ->where(fn ($q) => $q->whereNull('indexed_at')->orWhere('indexed_at', '<', $startedAt))
+                    ->update(['on_contabo' => false, 'updated_at' => Carbon::now()]);
+            }
+
+            $this->line(sprintf(
+                '  %d demo(s)%s%s',
+                $seen,
+                $unparsed ? ", {$unparsed} non-demo file(s) ignored" : '',
+                $gone ? ", {$gone} no longer on the local disk" : ''
+            ));
+
+            $totals['seen'] += $seen;
+            $totals['unparsed'] += $unparsed;
+            $totals['gone'] += $gone;
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '%s %d demo(s) across %d director%s.%s%s',
+            $dry ? 'Would index' : 'Indexed',
+            $totals['seen'],
+            count($roots),
+            count($roots) === 1 ? 'y' : 'ies',
+            $totals['gone'] ? " {$totals['gone']} marked as gone from the local disk." : '',
+            $totals['unparsed'] ? " {$totals['unparsed']} file(s) were not demos." : ''
+        ));
+
+        if ($totals['failed']) {
+            $this->error("{$totals['failed']} director(y/ies) failed to list; their entries were left untouched.");
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function flush(array $batch, bool $dry): void
+    {
+        if ($batch === [] || $dry) {
+            return;
+        }
+
+        ServerDemo::upsert(
+            $batch,
+            ['path'],
+            [
+                'owner_dir', 'sftp_credential_id', 'filename', 'size', 'recorded_at',
+                'rs_server_id', 'map_name', 'physics', 'time_ms', 'mdd_id',
+                'on_contabo', 'indexed_at', 'updated_at',
+            ]
+        );
+    }
+}

--- a/app/Models/ServerDemo.php
+++ b/app/Models/ServerDemo.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * One demo the recordsystem wrote on a community server.
+ *
+ * These are NOT public. They exist so an admin - and, once the report
+ * workflow lands, a moderator handling a specific report - can verify a
+ * reported record. There is no public route to them and there must never be
+ * one.
+ */
+class ServerDemo extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'owner_dir',
+        'sftp_credential_id',
+        'path',
+        'filename',
+        'size',
+        'recorded_at',
+        'rs_server_id',
+        'map_name',
+        'physics',
+        'time_ms',
+        'mdd_id',
+        'record_id',
+        'on_contabo',
+        'on_b2',
+        'on_nas',
+        'indexed_at',
+    ];
+
+    protected $casts = [
+        'size' => 'integer',
+        'recorded_at' => 'datetime',
+        'indexed_at' => 'datetime',
+        'rs_server_id' => 'integer',
+        'time_ms' => 'integer',
+        'mdd_id' => 'integer',
+        'on_contabo' => 'boolean',
+        'on_b2' => 'boolean',
+        'on_nas' => 'boolean',
+    ];
+
+    public function credential()
+    {
+        return $this->belongsTo(SftpCredential::class, 'sftp_credential_id');
+    }
+
+    public function record()
+    {
+        return $this->belongsTo(Record::class, 'record_id');
+    }
+
+    /**
+     * The demo of exactly this record's run, if the record was set on one of
+     * our servers. A record set elsewhere simply has none - that is an
+     * answer, not a failure.
+     */
+    public function scopeForRecord($query, Record $record)
+    {
+        return $query
+            ->where('map_name', $record->mapname)
+            ->where('mdd_id', $record->mdd_id)
+            ->where('time_ms', $record->time)
+            ->when($record->physics, fn ($q, $physics) => $q->where('physics', strtolower($physics)));
+    }
+}

--- a/app/Services/ServerDemoPath.php
+++ b/app/Services/ServerDemoPath.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Everything a serverdemo tells us about itself, read out of its own path.
+ *
+ * The MDD recordsystem writes one demo per finished run:
+ *
+ *   <credential>/serverdemos/server_<rs id>/<physics>/<map>[<time ms>][<mdd id>].dm_68
+ *
+ * - map, time in ms and the player's MDD id come from the filename
+ * - physics from the directory holding the file
+ * - the rs server id from the `server_<id>` segment
+ * - the first segment is the SFTP credential that uploaded it
+ *
+ * The player is identified by MDD id, so nothing here has to guess at
+ * nicknames the way the public demo pipeline does.
+ *
+ * Layout is not fixed depth: most credentials produce
+ * `<user>/serverdemos/server_<id>/<physics>/<file>` but older ones have no
+ * `serverdemos` level, so the `server_<id>` segment is located rather than
+ * assumed to be at a given depth.
+ */
+class ServerDemoPath
+{
+    /** Directories the recordsystem uses for physics. Anything else -> null. */
+    private const PHYSICS = ['cpm', 'vq3'];
+
+    /** Revoked accounts are parked here by the provisioner; not live data. */
+    public const SKIP_DIRS = ['_revoked'];
+
+    /**
+     * @return array{owner_dir:string,filename:string,rs_server_id:?int,physics:?string,map_name:string,time_ms:?int,mdd_id:?int}|null
+     *         null when the path is not a demo file at all
+     */
+    public static function parse(string $path): ?array
+    {
+        $path = ltrim($path, '/');
+        $segments = explode('/', $path);
+        $filename = array_pop($segments);
+
+        if ($filename === null || $segments === []) {
+            return null;
+        }
+
+        if (! preg_match('/\.dm_\d+$/i', $filename)) {
+            return null;
+        }
+
+        $ownerDir = $segments[0];
+
+        if (in_array($ownerDir, self::SKIP_DIRS, true)) {
+            return null;
+        }
+
+        $rsServerId = null;
+        foreach ($segments as $segment) {
+            if (preg_match('/^server_(\d+)$/i', $segment, $m)) {
+                $rsServerId = (int) $m[1];
+            }
+        }
+
+        // Physics is the directory the file sits in, and only when it really
+        // is one - a demo dropped straight into server_<id>/ must not turn its
+        // parent directory name into a physics value.
+        $physics = null;
+        $parent = end($segments);
+        if ($parent !== false && in_array(strtolower($parent), self::PHYSICS, true)) {
+            $physics = strtolower($parent);
+        }
+
+        $parsed = self::parseFilename($filename);
+
+        return [
+            'owner_dir'    => $ownerDir,
+            'filename'     => $filename,
+            'rs_server_id' => $rsServerId,
+            'physics'      => $physics,
+            'map_name'     => $parsed['map'],
+            'time_ms'      => $parsed['time'],
+            'mdd_id'       => $parsed['mdd_id'],
+        ];
+    }
+
+    /**
+     * `<map>[<time_ms>][<mdd_id>].dm_68`, plus the underscore variant older
+     * demos use. A name that matches neither still yields a map, because the
+     * file is real and belongs in the index either way.
+     *
+     * @return array{map:string,time:?int,mdd_id:?int}
+     */
+    public static function parseFilename(string $filename): array
+    {
+        $base = preg_replace('/\.dm_\d+$/i', '', $filename);
+
+        if (preg_match('/^(.+?)\[(\d+)\]\[(\d+)\]$/', $base, $m)) {
+            return ['map' => $m[1], 'time' => (int) $m[2], 'mdd_id' => (int) $m[3]];
+        }
+
+        if (preg_match('/^(.+?)_(\d+)_(\d+)$/', $base, $m)) {
+            return ['map' => $m[1], 'time' => (int) $m[2], 'mdd_id' => (int) $m[3]];
+        }
+
+        return ['map' => $base, 'time' => null, 'mdd_id' => null];
+    }
+}

--- a/database/migrations/2026_08_01_210000_create_server_demos_table.php
+++ b/database/migrations/2026_08_01_210000_create_server_demos_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * An index of the serverdemos the MDD recordsystem uploads from community
+ * servers. Until now nothing in the database knew a single one existed - the
+ * admin browser was a live SFTP directory listing, which means it cannot
+ * survive the files moving off the storage VPS and cannot answer the one
+ * question the feature is for: does this record have a serverdemo?
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('server_demos', function (Blueprint $table) {
+            $table->id();
+
+            // Where it came from. owner_dir is the directory on the storage
+            // VPS; the credential is resolved from it and may be missing for
+            // accounts provisioned by CLI without a web credential.
+            $table->string('owner_dir')->index();
+            $table->foreignId('sftp_credential_id')->nullable()
+                ->constrained('sftp_credentials')->nullOnDelete();
+
+            // 500 chars keeps the unique index inside InnoDB's 3072-byte key
+            // limit on utf8mb4 while being far longer than any real demo path.
+            $table->string('path', 500)->unique();
+            $table->string('filename');
+            $table->unsignedBigInteger('size')->default(0);
+            $table->timestamp('recorded_at')->nullable()->index();
+
+            // Parsed out of the path - see App\Services\ServerDemoPath.
+            $table->unsignedInteger('rs_server_id')->nullable()->index();
+            $table->string('map_name')->nullable();
+            $table->string('physics', 10)->nullable();
+            $table->unsignedInteger('time_ms')->nullable();
+            $table->unsignedInteger('mdd_id')->nullable();
+
+            // Usually NULL and that is correct: a demo is written on every
+            // finished run, while `records` holds only the current best time
+            // per player per map. A run the player later improved on has no
+            // record row at all. Nothing may assume this is populated.
+            $table->unsignedBigInteger('record_id')->nullable()->index();
+
+            // Where the bytes are. The local copy is not forever; B2 is the
+            // mirror, the NAS the third copy.
+            $table->boolean('on_contabo')->default(true);
+            $table->boolean('on_b2')->default(false);
+            $table->boolean('on_nas')->default(false);
+
+            $table->timestamp('indexed_at')->nullable();
+            $table->timestamps();
+
+            // The lookup the report workflow lives on: given a record, is
+            // there a demo of exactly that run?
+            $table->index(['map_name', 'physics', 'mdd_id', 'time_ms'], 'server_demos_record_lookup');
+
+            // "everything this player ever ran here", newest first
+            $table->index(['mdd_id', 'recorded_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('server_demos');
+    }
+};


### PR DESCRIPTION
Nothing in the database knew a single serverdemo existed - the admin browser is a live SFTP directory listing. That has two consequences: it cannot survive the files moving off the storage VPS, and it cannot answer the question the whole feature is for, which is whether a given record has a demo behind it.

The path carries everything needed, confirmed against a random sample of 30 files plus the ten oldest and five newest:

  <credential>/serverdemos/server_<rs id>/<physics>/<map>[<time ms>][<mdd id>]

So the player is identified by MDD id and none of the nickname matching the public demo pipeline needs applies here. ServerDemoPath is shared so the browser and the indexer can never disagree about a filename; it handles the older underscore format, names without brackets, and the older credentials whose demos have no `serverdemos` path level.

record_id is deliberately nullable and will usually be null: a demo is written on every finished run, while `records` holds only the current best time per player per map, so a run the player later improved on has no record row at all. The lookup that matters runs the other way - given a record, is there a demo of exactly that run - and it answers yes precisely when the record was set on one of our servers.

Demos that vanish from the local disk are marked on_contabo = false rather than deleted from the index, which is what will let the app serve them from B2 later. A directory whose listing throws is left untouched instead of swept, so a dropped connection cannot look like mass deletion.