### PR TITLE
serverdemos: read physics and mode from fastcaps directories

### DIFF
--- a/app/Console/Commands/IndexServerDemos.php
+++ b/app/Console/Commands/IndexServerDemos.php
@@ -99,6 +99,7 @@ class IndexServerDemos extends Command
                         'rs_server_id'       => $parsed['rs_server_id'],
                         'map_name'           => $parsed['map_name'],
                         'physics'            => $parsed['physics'],
+                        'mode'               => $parsed['mode'],
                         'time_ms'            => $parsed['time_ms'],
                         'mdd_id'             => $parsed['mdd_id'],
                         'on_contabo'         => true,
@@ -179,7 +180,7 @@ class IndexServerDemos extends Command
             ['path'],
             [
                 'owner_dir', 'sftp_credential_id', 'filename', 'size', 'recorded_at',
-                'rs_server_id', 'map_name', 'physics', 'time_ms', 'mdd_id',
+                'rs_server_id', 'map_name', 'physics', 'mode', 'time_ms', 'mdd_id',
                 'on_contabo', 'indexed_at', 'updated_at',
             ]
         );

--- a/app/Models/ServerDemo.php
+++ b/app/Models/ServerDemo.php
@@ -27,6 +27,7 @@ class ServerDemo extends Model
         'rs_server_id',
         'map_name',
         'physics',
+        'mode',
         'time_ms',
         'mdd_id',
         'record_id',
@@ -62,6 +63,10 @@ class ServerDemo extends Model
      * The demo of exactly this record's run, if the record was set on one of
      * our servers. A record set elsewhere simply has none - that is an
      * answer, not a failure.
+     *
+     * Mode has to be part of the key, not just physics: the same player can
+     * hold a time on the same map in several ctf modes, and those are
+     * different records.
      */
     public function scopeForRecord($query, Record $record)
     {
@@ -69,6 +74,7 @@ class ServerDemo extends Model
             ->where('map_name', $record->mapname)
             ->where('mdd_id', $record->mdd_id)
             ->where('time_ms', $record->time)
-            ->when($record->physics, fn ($q, $physics) => $q->where('physics', strtolower($physics)));
+            ->when($record->physics, fn ($q, $physics) => $q->where('physics', strtolower($physics)))
+            ->when($record->mode, fn ($q, $mode) => $q->where('mode', strtolower($mode)));
     }
 }

--- a/app/Services/ServerDemoPath.php
+++ b/app/Services/ServerDemoPath.php
@@ -9,6 +9,10 @@ namespace App\Services;
  *
  *   <credential>/serverdemos/server_<rs id>/<physics>/<map>[<time ms>][<mdd id>].dm_68
  *
+ * The physics directory is `cpm` or `vq3` for ordinary runs, and
+ * `ctf_<physics>_<n>` on fastcaps servers, where n is the ctf mode - so it
+ * carries the mode too, which `records` keeps as `run` or `ctf1`..`ctf7`.
+ *
  * - map, time in ms and the player's MDD id come from the filename
  * - physics from the directory holding the file
  * - the rs server id from the `server_<id>` segment
@@ -24,14 +28,20 @@ namespace App\Services;
  */
 class ServerDemoPath
 {
-    /** Directories the recordsystem uses for physics. Anything else -> null. */
+    /** Plain run directories: the name is the physics and the mode is `run`. */
     private const PHYSICS = ['cpm', 'vq3'];
+
+    /**
+     * Fastcaps directories carry the mode as well: `ctf_cpm_4` is cpm physics
+     * in ctf mode 4, matching the `ctf1`..`ctf7` values in `records.mode`.
+     */
+    private const FASTCAPS = '/^ctf_(cpm|vq3)_([1-7])$/i';
 
     /** Revoked accounts are parked here by the provisioner; not live data. */
     public const SKIP_DIRS = ['_revoked'];
 
     /**
-     * @return array{owner_dir:string,filename:string,rs_server_id:?int,physics:?string,map_name:string,time_ms:?int,mdd_id:?int}|null
+     * @return array{owner_dir:string,filename:string,rs_server_id:?int,physics:?string,mode:?string,map_name:string,time_ms:?int,mdd_id:?int}|null
      *         null when the path is not a demo file at all
      */
     public static function parse(string $path): ?array
@@ -61,13 +71,22 @@ class ServerDemoPath
             }
         }
 
-        // Physics is the directory the file sits in, and only when it really
-        // is one - a demo dropped straight into server_<id>/ must not turn its
-        // parent directory name into a physics value.
+        // Physics and mode both come from the directory the file sits in, and
+        // only when it really is one of the recordsystem's - a demo dropped
+        // straight into server_<id>/ must not turn its parent directory name
+        // into a physics value.
         $physics = null;
+        $mode = null;
         $parent = end($segments);
-        if ($parent !== false && in_array(strtolower($parent), self::PHYSICS, true)) {
-            $physics = strtolower($parent);
+
+        if ($parent !== false) {
+            if (in_array(strtolower($parent), self::PHYSICS, true)) {
+                $physics = strtolower($parent);
+                $mode = 'run';
+            } elseif (preg_match(self::FASTCAPS, $parent, $m)) {
+                $physics = strtolower($m[1]);
+                $mode = 'ctf' . $m[2];
+            }
         }
 
         $parsed = self::parseFilename($filename);
@@ -77,6 +96,7 @@ class ServerDemoPath
             'filename'     => $filename,
             'rs_server_id' => $rsServerId,
             'physics'      => $physics,
+            'mode'         => $mode,
             'map_name'     => $parsed['map'],
             'time_ms'      => $parsed['time'],
             'mdd_id'       => $parsed['mdd_id'],

--- a/database/migrations/2026_08_02_090000_add_mode_to_server_demos_table.php
+++ b/database/migrations/2026_08_02_090000_add_mode_to_server_demos_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fastcaps servers write their demos into `ctf_<physics>_<n>` rather than
+ * `cpm` / `vq3`, so the directory carries the mode as well as the physics -
+ * `run` or `ctf1`..`ctf7`, the same values `records.mode` uses.
+ *
+ * The first index run left 1837 fastcaps demos with no physics at all, since
+ * the parser only recognised the two plain directories. Without the mode a
+ * fastcaps record could never be matched to its demo: the same player can
+ * hold a time on the same map in several ctf modes.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('server_demos', function (Blueprint $table) {
+            $table->string('mode', 10)->nullable()->after('physics');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('server_demos', function (Blueprint $table) {
+            $table->dropColumn('mode');
+        });
+    }
+};


### PR DESCRIPTION
The first index run left 1837 demos with no physics. They are all from fastcaps servers, which do not use the plain `cpm` / `vq3` directories - they write into `ctf_<physics>_<n>`, where n is the ctf mode.

So the directory carries the mode as well, and the values line up exactly with what `records.mode` holds: `run` for an ordinary run directory, `ctf1`..`ctf7` for a fastcaps one. Mode has to be part of the record lookup, not just physics: the same player can hold a time on the same map in several ctf modes, and those are different records that would otherwise collide.

Only modes 1 to 7 are accepted, matching the range the site uses everywhere else; an unrecognised directory still yields no physics rather than a made-up one.

Needs a reindex to fill the column - the indexer upserts, so rerunning it updates the existing rows in place.