### PR TITLE
serverdemos: 15-minute B2 mirror, B2 fallback, and evidence on flagged records

### DIFF
--- a/app/Console/Commands/IndexServerDemos.php
+++ b/app/Console/Commands/IndexServerDemos.php
@@ -29,6 +29,7 @@ class IndexServerDemos extends Command
 {
     protected $signature = 'serverdemos:index
         {--dir=* : Only these credential directories}
+        {--sweep : Also flag demos that are no longer on the local disk}
         {--dry-run : Report what would be indexed without writing}';
 
     protected $description = 'Index the serverdemos on the storage VPS into the server_demos table';
@@ -62,14 +63,22 @@ class IndexServerDemos extends Command
         }
 
         $credentials = SftpCredential::pluck('id', 'sftp_username');
+        $sweep = (bool) $this->option('sweep');
 
-        $totals = ['seen' => 0, 'unparsed' => 0, 'gone' => 0, 'failed' => 0];
+        $totals = ['seen' => 0, 'written' => 0, 'unparsed' => 0, 'gone' => 0, 'failed' => 0];
 
         foreach ($roots as $root) {
             $this->line("Indexing {$root}/ ...");
 
+            // What the index already holds for this directory, so an
+            // unchanged demo costs nothing. The traversal itself is ~14 s for
+            // the whole store, cheap enough to run every few minutes - but
+            // rewriting all 116k rows each time would not be.
+            $known = $sweep ? [] : $this->knownRows($root);
+
             $batch = [];
             $seen = 0;
+            $written = 0;
             $unparsed = 0;
 
             try {
@@ -87,15 +96,25 @@ class IndexServerDemos extends Command
                         continue;
                     }
 
+                    $seen++;
+
+                    $size = (int) ($item->fileSize() ?? 0);
+                    $mtime = $item->lastModified() ? (int) $item->lastModified() : null;
+
+                    // Already indexed and untouched since. Skipping keeps a
+                    // frequent run to only the demos that actually arrived.
+                    $before = $known[$item->path()] ?? null;
+                    if ($before !== null && $before['size'] === $size && $before['mtime'] === $mtime) {
+                        continue;
+                    }
+
                     $batch[] = [
                         'owner_dir'          => $parsed['owner_dir'],
                         'sftp_credential_id' => $credentials[$parsed['owner_dir']] ?? null,
                         'path'               => $item->path(),
                         'filename'           => $parsed['filename'],
-                        'size'               => (int) ($item->fileSize() ?? 0),
-                        'recorded_at'        => $item->lastModified()
-                            ? Carbon::createFromTimestamp($item->lastModified())
-                            : null,
+                        'size'               => $size,
+                        'recorded_at'        => $mtime ? Carbon::createFromTimestamp($mtime) : null,
                         'rs_server_id'       => $parsed['rs_server_id'],
                         'map_name'           => $parsed['map_name'],
                         'physics'            => $parsed['physics'],
@@ -108,7 +127,7 @@ class IndexServerDemos extends Command
                         'updated_at'         => $startedAt,
                     ];
 
-                    $seen++;
+                    $written++;
 
                     if (count($batch) >= self::BATCH) {
                         $this->flush($batch, $dry);
@@ -128,10 +147,11 @@ class IndexServerDemos extends Command
 
             $this->flush($batch, $dry);
 
-            // Anything in this directory the walk did not touch is no longer
-            // on the local disk.
+            // Only a sweeping run may conclude that a demo is gone. A normal
+            // run skips unchanged rows, so their indexed_at stays old and
+            // every one of them would look missing.
             $gone = 0;
-            if (! $dry) {
+            if ($sweep && ! $dry) {
                 $gone = ServerDemo::where('owner_dir', $root)
                     ->where('on_contabo', true)
                     ->where(fn ($q) => $q->whereNull('indexed_at')->orWhere('indexed_at', '<', $startedAt))
@@ -139,24 +159,27 @@ class IndexServerDemos extends Command
             }
 
             $this->line(sprintf(
-                '  %d demo(s)%s%s',
+                '  %d demo(s), %d written%s%s',
                 $seen,
+                $written,
                 $unparsed ? ", {$unparsed} non-demo file(s) ignored" : '',
                 $gone ? ", {$gone} no longer on the local disk" : ''
             ));
 
             $totals['seen'] += $seen;
+            $totals['written'] += $written;
             $totals['unparsed'] += $unparsed;
             $totals['gone'] += $gone;
         }
 
         $this->newLine();
         $this->info(sprintf(
-            '%s %d demo(s) across %d director%s.%s%s',
+            '%s %d demo(s) across %d director%s, %d new or changed.%s%s',
             $dry ? 'Would index' : 'Indexed',
             $totals['seen'],
             count($roots),
             count($roots) === 1 ? 'y' : 'ies',
+            $totals['written'],
             $totals['gone'] ? " {$totals['gone']} marked as gone from the local disk." : '',
             $totals['unparsed'] ? " {$totals['unparsed']} file(s) were not demos." : ''
         ));
@@ -167,6 +190,31 @@ class IndexServerDemos extends Command
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * path => size + mtime for one directory, so the walk can tell an
+     * unchanged demo from a new one without writing anything. One select of
+     * three narrow columns; even the largest credential is a few MB.
+     */
+    private function knownRows(string $root): array
+    {
+        $known = [];
+
+        ServerDemo::where('owner_dir', $root)
+            ->select('path', 'size', 'recorded_at')
+            ->toBase()
+            ->orderBy('id')
+            ->chunk(20000, function ($rows) use (&$known) {
+                foreach ($rows as $row) {
+                    $known[$row->path] = [
+                        'size' => (int) $row->size,
+                        'mtime' => $row->recorded_at ? Carbon::parse($row->recorded_at)->getTimestamp() : null,
+                    ];
+                }
+            });
+
+        return $known;
     }
 
     private function flush(array $batch, bool $dry): void

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -103,10 +103,16 @@ class Kernel extends ConsoleKernel
         $schedule->command('serverdemos:sync-stats')->withoutOverlapping()->hourly();
 
         // Keeps the server_demos index in step with the store on the storage
-        // VPS. The admin browser reads the table rather than listing SFTP, so
-        // a demo uploaded since the last run is not visible until this runs.
-        // Nightly at 05:00, after the 04:00 backup has finished with the disk.
-        $schedule->command('serverdemos:index')->withoutOverlapping()->dailyAt('05:00');
+        // VPS - the admin browser reads the table, not SFTP, so a demo is
+        // invisible until this has run. Walking all 116k files takes ~14 s
+        // and unchanged rows are skipped, so every 15 minutes is affordable.
+        $schedule->command('serverdemos:index')->withoutOverlapping()->everyFifteenMinutes();
+
+        // Once a night the same walk runs with --sweep, which is what flags
+        // demos that are no longer on the local disk. The frequent runs skip
+        // unchanged rows, so they cannot tell "unchanged" from "missing" and
+        // must not draw that conclusion.
+        $schedule->command('serverdemos:index --sweep')->withoutOverlapping()->dailyAt('05:00');
 
         // Auto-populate demome render queue when idle (tiered rotation, tops up to 5)
         $schedule->command('demome:populate-queue')->withoutOverlapping()->everyTenMinutes();

--- a/app/Filament/Resources/RecordFlagResource.php
+++ b/app/Filament/Resources/RecordFlagResource.php
@@ -204,6 +204,32 @@ class RecordFlagResource extends Resource
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make(),
 
+                // People flag a record without knowing what evidence exists
+                // behind it. This is where that gets answered: the serverdemo
+                // of the exact run if it happened on one of our servers, any
+                // uploaded demos, and the player's other runs on that map.
+                Tables\Actions\Action::make('evidence')
+                    ->label('Demos')
+                    ->icon('heroicon-o-film')
+                    ->color('info')
+                    ->visible(fn (RecordFlag $record) => $record->record_id !== null)
+                    ->modalHeading('Evidence for this record')
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Close')
+                    ->modalWidth('3xl')
+                    ->modalContent(function (RecordFlag $record) {
+                        $target = $record->record;
+
+                        if (! $target) {
+                            return view('filament.record-flag-evidence-missing');
+                        }
+
+                        return view('filament.record-flag-evidence', [
+                            'record' => $target,
+                            ...\App\Services\RecordEvidence::for($target, $record->demo),
+                        ]);
+                    }),
+
                 Tables\Actions\Action::make('approve')
                     ->label('Approve')
                     ->icon('heroicon-o-check-circle')

--- a/app/Http/Controllers/RecordFlagController.php
+++ b/app/Http/Controllers/RecordFlagController.php
@@ -29,7 +29,12 @@ class RecordFlagController extends Controller
     {
         $user = Auth::user();
 
-        if (!$user->canReportDemos()) {
+        // Flagging a DEMO keeps the 30-record bar: it is a claim about
+        // somebody's upload and carries weight. Flagging a RECORD does not -
+        // it only says a time looks wrong, and what evidence exists behind it
+        // is something only staff can see anyway. Anyone with an account may
+        // raise one.
+        if ($request->demo_id && !$user->canReportDemos()) {
             return back()->with('danger', 'You need at least 30 records to flag demos.');
         }
 

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ServerDemo;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
@@ -17,11 +18,15 @@ use Illuminate\Support\Facades\Storage;
  * - 'signed' middleware: the url expires (5 min) and can't be forged.
  * - auth + the SAME granular moderator permission the originating panel
  *   requires, re-checked here on every hit.
- * - The file is streamed SFTP -> HTTP response directly; NOTHING is ever
- *   written to local disk, so no watcher/worker (e.g. the public demo
- *   pipeline) can accidentally pick a private serverdemo up.
+ * - The file is streamed from its storage straight into the HTTP response;
+ *   NOTHING is ever written to local disk, so no watcher/worker (e.g. the
+ *   public demo pipeline) can accidentally pick a private serverdemo up.
+ *   That holds for the B2 mirror too - the bucket is private and its url is
+ *   never handed out, the bytes come through here.
  * - Flysystem path normalisation rejects '..' traversal outside the disk
- *   root, and only the two whitelisted disks are reachable.
+ *   root, and the `disk` parameter only accepts the two whitelisted names;
+ *   the B2 mirror is reachable as a fallback for a serverdemo, never by
+ *   asking for it.
  */
 class StorageBrowserDownloadController extends Controller
 {
@@ -30,6 +35,37 @@ class StorageBrowserDownloadController extends Controller
         'serverdemos' => 'serverdemos_browser',
         'dl_storage' => 'storage_browser',
     ];
+
+    /** rclone mirrors /var/lib/serverdemos into this prefix of the bucket. */
+    private const B2_PREFIX = 'serverdemos/';
+
+    /**
+     * Where a serverdemo may be read from, best guess first.
+     *
+     * The demos live on the storage VPS and are mirrored to B2, and the point
+     * of the index is that the local copy will not be permanent. `on_contabo`
+     * says which one to reach for, but it is only a hint: it is refreshed by
+     * a scheduled walk, so it can be minutes stale in either direction.
+     *
+     * So both are tried rather than switched between. Whichever the index
+     * expects goes first, and a wrong guess costs one failed open instead of
+     * a 404 on a file that plainly exists.
+     */
+    private function candidates(string $diskName, string $path): array
+    {
+        if ($diskName !== 'serverdemos') {
+            return [[$diskName, $path]];
+        }
+
+        $local = ['serverdemos', $path];
+        $mirror = ['serverdemos_b2', self::B2_PREFIX . $path];
+
+        $demo = ServerDemo::where('path', $path)->first(['on_contabo']);
+
+        return $demo && ! $demo->on_contabo
+            ? [$mirror, $local]
+            : [$local, $mirror];
+    }
 
     public function __invoke(Request $request)
     {
@@ -55,8 +91,6 @@ class StorageBrowserDownloadController extends Controller
             }
         }
 
-        $disk = Storage::disk($diskName);
-
         // Open the stream as the single source of truth for existence +
         // readability. We deliberately DON'T gate on a separate exists()
         // stat first: on the serverdemos disk the per-user directory is a
@@ -67,10 +101,20 @@ class StorageBrowserDownloadController extends Controller
         // still fails closed (throws -> not a resource -> 404) for a file
         // that genuinely isn't there. Opening before the response starts
         // also means a failure is a clean 404, not a half-sent body.
+        //
+        // A serverdemo has two homes, so each candidate is tried in turn -
+        // see candidates() for the order and why it is not a hard switch.
         $stream = null;
-        try {
-            $stream = $disk->readStream($path);
-        } catch (\Throwable) {
+        foreach ($this->candidates($diskName, $path) as [$candidateDisk, $candidatePath]) {
+            try {
+                $stream = Storage::disk($candidateDisk)->readStream($candidatePath);
+            } catch (\Throwable) {
+                $stream = null;
+            }
+
+            if (is_resource($stream)) {
+                break;
+            }
         }
         abort_unless(is_resource($stream), 404);
 

--- a/app/Http/Controllers/StorageBrowserDownloadController.php
+++ b/app/Http/Controllers/StorageBrowserDownloadController.php
@@ -30,10 +30,21 @@ use Illuminate\Support\Facades\Storage;
  */
 class StorageBrowserDownloadController extends Controller
 {
-    /** disk name => moderator permission required to pull from it */
+    /**
+     * disk name => moderator permissions that may pull from it, any one of
+     * which is enough.
+     *
+     * record_flags is on the serverdemo list because the evidence panel on a
+     * flagged record hands out links to individual demos, and someone
+     * resolving reports needs to open them without being given the run of the
+     * whole archive. That is not a hole: these urls are signed server-side,
+     * so holding the permission lets you follow a link you were given, not
+     * mint one for a path of your choosing. Browsing still needs
+     * serverdemos_browser, which gates the page itself.
+     */
     private const DISKS = [
-        'serverdemos' => 'serverdemos_browser',
-        'dl_storage' => 'storage_browser',
+        'serverdemos' => ['serverdemos_browser', 'record_flags'],
+        'dl_storage' => ['storage_browser'],
     ];
 
     /** rclone mirrors /var/lib/serverdemos into this prefix of the bucket. */
@@ -70,9 +81,13 @@ class StorageBrowserDownloadController extends Controller
     public function __invoke(Request $request)
     {
         $diskName = (string) $request->query('disk');
-        $permission = self::DISKS[$diskName] ?? null;
-        abort_if($permission === null, 404);
-        abort_unless($request->user()?->hasModeratorPermission($permission) ?? false, 403);
+        $permissions = self::DISKS[$diskName] ?? null;
+        abort_if($permissions === null, 404);
+
+        $user = $request->user();
+        $allowed = $user !== null && collect($permissions)
+            ->contains(fn (string $permission) => $user->hasModeratorPermission($permission));
+        abort_unless($allowed, 403);
 
         $path = trim((string) $request->query('path'), '/');
         abort_if($path === '', 404);

--- a/app/Services/RecordEvidence.php
+++ b/app/Services/RecordEvidence.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Record;
+use App\Models\ServerDemo;
+use App\Models\UploadedDemo;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Everything a moderator can look at when a record is flagged.
+ *
+ * People flag a record, not a demo - they have no way of knowing what
+ * evidence exists behind it. Finding that out is this class's job, and it
+ * pulls from two unrelated places:
+ *
+ * - **public uploads**: someone uploaded a demo and it was matched to this
+ *   record (`uploaded_demos.record_id`)
+ * - **serverdemos**: the run happened on one of our servers, so the
+ *   recordsystem wrote a demo of it. That exists whether or not anybody
+ *   uploaded anything, and the player never had a chance to pick which run
+ *   to show - which is exactly what makes it worth having
+ *
+ * On top of that it returns the player's other serverdemos on the same map.
+ * A single run rarely proves anything by itself; a jump from a plausible
+ * time to an implausible one, or a first-ever attempt that lands on a world
+ * record, is what a human actually spots. Until record time history arrives
+ * from the MDD database, this is the closest thing we have to it, and it is
+ * real evidence rather than a derived number.
+ */
+class RecordEvidence
+{
+    /** Enough to see how a player got to a time without loading a career. */
+    private const HISTORY_LIMIT = 50;
+
+    /** Same five minutes the storage browsers hand out. */
+    private const LINK_MINUTES = 5;
+
+    /**
+     * @return array{
+     *   serverdemo: ?ServerDemo,
+     *   history: Collection<int, ServerDemo>,
+     *   uploads: Collection<int, UploadedDemo>
+     * }
+     */
+    public static function for(Record $record, ?UploadedDemo $flaggedDemo = null): array
+    {
+        $serverdemo = ServerDemo::forRecord($record)
+            ->orderByDesc('recorded_at')
+            ->first();
+
+        $uploads = UploadedDemo::where('record_id', $record->id)
+            ->orderByDesc('created_at')
+            ->get();
+
+        // A flag can name a demo that was never matched to this record.
+        // It was still what the reporter was looking at, so it belongs here.
+        if ($flaggedDemo && ! $uploads->contains('id', $flaggedDemo->id)) {
+            $uploads->prepend($flaggedDemo);
+        }
+
+        return [
+            'serverdemo' => $serverdemo,
+            'history' => self::history($record, $serverdemo),
+            'uploads' => $uploads,
+        ];
+    }
+
+    /**
+     * The player's other runs on this map, newest first. The flagged run
+     * itself is left out - it is shown on its own above.
+     */
+    private static function history(Record $record, ?ServerDemo $exclude): Collection
+    {
+        if (! $record->mdd_id || ! $record->mapname) {
+            return collect();
+        }
+
+        return ServerDemo::query()
+            ->where('map_name', $record->mapname)
+            ->where('mdd_id', $record->mdd_id)
+            ->when($record->physics, fn ($q, $physics) => $q->where('physics', strtolower($physics)))
+            ->when($record->mode, fn ($q, $mode) => $q->where('mode', strtolower($mode)))
+            ->when($exclude, fn ($q, $demo) => $q->where('id', '!=', $demo->id))
+            ->orderByDesc('recorded_at')
+            ->limit(self::HISTORY_LIMIT)
+            ->get();
+    }
+
+    /**
+     * A short-lived signed link to one serverdemo. Nothing else may produce
+     * these: the bucket and the storage VPS are both private, and this is the
+     * only door.
+     */
+    public static function downloadUrl(ServerDemo $demo): string
+    {
+        return URL::temporarySignedRoute(
+            'defraghq.storage-download',
+            now()->addMinutes(self::LINK_MINUTES),
+            ['disk' => 'serverdemos', 'path' => $demo->path],
+        );
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -121,6 +121,26 @@ return [
                 'throw'      => true,
             ],
 
+        // The B2 mirror of the same demos, written by scripts/backup.sh and
+        // serverdemos-mirror.sh through rclone. Read-only as far as the app
+        // is concerned: it is the copy that outlives the storage VPS, and it
+        // is what the admin browser falls back to for a demo that is no
+        // longer on that disk.
+        //
+        // Same bucket-scoped key the mirror already uses, so no new
+        // credential. Private bucket - links come from temporaryUrl(), never
+        // a public URL, hence no 'url' key.
+        'serverdemos_b2' => [
+            'driver'   => 's3',
+            'key'      => env('B2_SERVERDEMOS_KEY_ID'),
+            'secret'   => env('B2_SERVERDEMOS_APP_KEY'),
+            'region'   => env('B2_SERVERDEMOS_REGION', 'eu-central-003'),
+            'bucket'   => env('B2_SERVERDEMOS_BUCKET', 'defrag-serverdemos'),
+            'endpoint' => env('B2_SERVERDEMOS_ENDPOINT', 'https://s3.eu-central-003.backblazeb2.com'),
+            'use_path_style_endpoint' => false,
+            'throw'    => true,
+        ],
+
     ],
 
     /*

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -147,6 +147,12 @@
         return isLoggedIn.value && page.props.canReportDemos;
     });
 
+    // Reporting a demo says "this upload is wrong", which needs someone with
+    // enough of a history here to be worth listening to. Flagging a record is
+    // a different thing - it only says "this time looks off", staff decide
+    // the rest - so it asks for nothing but an account.
+    const canFlagRecord = computed(() => isLoggedIn.value);
+
     const isAdmin = computed(() => {
         return page.props.auth?.user?.is_admin || page.props.auth?.user?.admin;
     });
@@ -833,8 +839,11 @@
                     </svg>
                 </div>
                 <div v-if="actionsExpanded" class="flex items-center gap-0.5">
+                    <!-- Flagging a record needs no demo and no record count:
+                         anybody can see a time that looks wrong, and whether
+                         there is evidence behind it is for staff to find out. -->
                     <button
-                        v-if="canReportDemo && !record.oldtop"
+                        v-if="canFlagRecord && !record.oldtop"
                         @click.stop="showFlagModal = true"
                         class="p-0.5 rounded transition-all hover:scale-110 bg-gray-700/50 text-gray-400 hover:text-red-400 hover:bg-red-500/10"
                         title="Flag validity issue"

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -1026,9 +1026,17 @@
         }
     };
 
+    // Flagging a record asks for nothing but an account; flagging a demo
+    // still needs the record count, so the demo is only attached for users
+    // who may actually flag one - otherwise the button would offer something
+    // the server refuses.
+    const canFlagRecord = computed(() => !!page.props.auth?.user);
+
     const openFlagModal = (record) => {
         flagRecordId.value = record.id;
-        flagDemoId.value = record.uploaded_demos?.[0]?.id || null;
+        flagDemoId.value = page.props.canReportDemos
+            ? (record.uploaded_demos?.[0]?.id || null)
+            : null;
         showFlagModal.value = true;
     };
 
@@ -2556,7 +2564,7 @@
                                         </div>
 
                                         <!-- Flag button -->
-                                        <div v-if="page.props.canReportDemos" class="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" @click.stop.prevent>
+                                        <div v-if="canFlagRecord" class="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" @click.stop.prevent>
                                             <button @click="openFlagModal(record)" class="p-0.5 rounded transition-all hover:scale-110 bg-gray-700/50 text-gray-400 hover:text-red-400 hover:bg-red-500/10" title="Flag record">
                                                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" /></svg>
                                             </button>
@@ -2685,7 +2693,7 @@
                                         </div>
 
                                         <!-- Flag button -->
-                                        <div v-if="page.props.canReportDemos" class="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" @click.stop.prevent>
+                                        <div v-if="canFlagRecord" class="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" @click.stop.prevent>
                                             <button @click="openFlagModal(record)" class="p-0.5 rounded transition-all hover:scale-110 bg-gray-700/50 text-gray-400 hover:text-red-400 hover:bg-red-500/10" title="Flag record">
                                                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" /></svg>
                                             </button>

--- a/resources/views/filament/record-flag-evidence-missing.blade.php
+++ b/resources/views/filament/record-flag-evidence-missing.blade.php
@@ -1,0 +1,4 @@
+<div class="rounded-lg border border-gray-700 p-4 text-sm text-gray-400">
+    The flagged record no longer exists - it was deleted or replaced after this
+    flag was filed. Any demos of that run are still in the Serverdemos Browser.
+</div>

--- a/resources/views/filament/record-flag-evidence.blade.php
+++ b/resources/views/filament/record-flag-evidence.blade.php
@@ -1,0 +1,118 @@
+@php
+    // $record, $serverdemo, $history, $uploads come from the action's
+    // modalContent(). Times are milliseconds everywhere in this project.
+    $fmtTime = function ($ms) {
+        if ($ms === null) return '—';
+        $sec = $ms / 1000;
+        $min = floor($sec / 60);
+        return sprintf('%d:%06.3f', $min, $sec - $min * 60);
+    };
+    $fmtSize = function ($b) {
+        if (! $b) return '—';
+        return $b >= 1048576 ? round($b / 1048576, 1) . ' MB' : round($b / 1024) . ' kB';
+    };
+@endphp
+
+<div class="space-y-6 text-sm">
+
+    <div class="rounded-lg border border-gray-700 p-4">
+        <div class="font-semibold text-base mb-2">{{ $record->mapname }}</div>
+        <div class="grid grid-cols-2 gap-x-6 gap-y-1 text-gray-400">
+            <div>Time <span class="text-gray-200 font-mono">{{ $fmtTime($record->time) }}</span></div>
+            <div>Physics <span class="text-gray-200">{{ $record->physics }} / {{ $record->mode }}</span></div>
+            <div>Player <span class="text-gray-200">{{ $record->name }}</span></div>
+            <div>mdd id <span class="text-gray-200 font-mono">{{ $record->mdd_id }}</span></div>
+            <div>Set <span class="text-gray-200">{{ $record->date_set }}</span></div>
+        </div>
+    </div>
+
+    {{-- The unfakeable one: written by the server, not chosen by the player. --}}
+    <div>
+        <div class="font-semibold mb-2">Serverdemo of this exact run</div>
+        @if ($serverdemo)
+            <div class="flex items-center justify-between rounded-lg border border-green-800 bg-green-950/30 p-3">
+                <div>
+                    <div class="font-mono text-xs text-gray-300">{{ $serverdemo->filename }}</div>
+                    <div class="text-xs text-gray-500 mt-1">
+                        {{ $fmtSize($serverdemo->size) }} ·
+                        recorded {{ $serverdemo->recorded_at?->format('Y-m-d H:i') ?? '—' }} ·
+                        server {{ $serverdemo->rs_server_id ?? '—' }}
+                        @unless ($serverdemo->on_contabo) · from the B2 mirror @endunless
+                    </div>
+                </div>
+                <a href="{{ \App\Services\RecordEvidence::downloadUrl($serverdemo) }}"
+                   class="shrink-0 rounded-md bg-primary-600 px-3 py-1.5 text-white text-xs font-medium hover:bg-primary-500">
+                    Download
+                </a>
+            </div>
+        @else
+            <div class="rounded-lg border border-gray-700 p-3 text-gray-500">
+                None. This record was not set on a server that uploads to us,
+                so there is no server-side recording of it.
+            </div>
+        @endif
+    </div>
+
+    {{-- Uploaded by a person, so it is evidence of a different weight. --}}
+    <div>
+        <div class="font-semibold mb-2">Uploaded demos ({{ $uploads->count() }})</div>
+        @forelse ($uploads as $upload)
+            <div class="flex items-center justify-between rounded-lg border border-gray-700 p-3 mb-2">
+                <div>
+                    <div class="font-mono text-xs text-gray-300">{{ $upload->original_filename }}</div>
+                    <div class="text-xs text-gray-500 mt-1">
+                        {{ $fmtSize($upload->file_size) }} ·
+                        uploaded {{ $upload->created_at?->format('Y-m-d H:i') }}
+                        @if ($upload->player_name) · as {{ $upload->player_name }} @endif
+                    </div>
+                </div>
+                <a href="{{ route('demos.download', $upload->id) }}" target="_blank"
+                   class="shrink-0 rounded-md bg-gray-700 px-3 py-1.5 text-white text-xs font-medium hover:bg-gray-600">
+                    Download
+                </a>
+            </div>
+        @empty
+            <div class="rounded-lg border border-gray-700 p-3 text-gray-500">
+                Nobody uploaded a demo for this record.
+            </div>
+        @endforelse
+    </div>
+
+    {{-- What usually settles it: how the player got to this time. --}}
+    <div>
+        <div class="font-semibold mb-2">
+            Same player, same map ({{ $history->count() }}{{ $history->count() === 50 ? '+' : '' }})
+        </div>
+        @if ($history->isEmpty())
+            <div class="rounded-lg border border-gray-700 p-3 text-gray-500">
+                No other runs of this player on this map were recorded on our servers.
+            </div>
+        @else
+            <p class="text-xs text-gray-500 mb-2">
+                Every finished run leaves a demo, so this is the player's history on
+                this map as far as our servers saw it. Record time history from the
+                MDD database does not exist yet - when it does, this becomes the
+                evidence behind it rather than a substitute for it.
+            </p>
+            <div class="max-h-80 overflow-y-auto rounded-lg border border-gray-700 divide-y divide-gray-800">
+                @foreach ($history as $demo)
+                    <div class="flex items-center justify-between p-2">
+                        <div class="flex items-center gap-3">
+                            <span class="font-mono text-gray-200 w-24">{{ $fmtTime($demo->time_ms) }}</span>
+                            <span class="text-xs text-gray-500">
+                                {{ $demo->recorded_at?->format('Y-m-d H:i') ?? '—' }}
+                            </span>
+                        </div>
+                        <a href="{{ \App\Services\RecordEvidence::downloadUrl($demo) }}"
+                           class="text-xs text-primary-400 hover:text-primary-300">Download</a>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    <p class="text-xs text-gray-600">
+        Download links expire in 5 minutes. Serverdemos are never public - they
+        are only ever handed out here, to staff resolving a report.
+    </p>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -192,8 +192,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Demo reporting routes
     Route::post('/demos/{demo}/report', [DemoReportController::class, 'store'])->name('demos.report');
 
-    // Record/demo flag routes
-    Route::post('/flags', [\App\Http\Controllers\RecordFlagController::class, 'store'])->name('flags.store');
+    // Record/demo flag routes. Throttled because flagging a record no longer
+    // requires a record count of your own - the controller still refuses a
+    // duplicate flag of the same type on the same target, but nothing else
+    // caps how many different records one account could work through.
+    Route::post('/flags', [\App\Http\Controllers\RecordFlagController::class, 'store'])
+        ->middleware('throttle:20,60')
+        ->name('flags.store');
 });
 
 // Frontend error logging (works for both authenticated and anonymous users)

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Průběžné zrcadlení serverdem na Backblaze B2.
+#
+# Dema se zrcadlila jen jednou denně, protože visela jako třetí sekce
+# nočního backup.sh. Demo nahrané ráno tak leželo skoro celý den v jediné
+# kopii - kdyby ten disk odešel, přišli bychom o všechno z toho dne.
+# Tenhle skript běží každých 15 minut a to okno tím zkracuje na minuty.
+#
+# Proč to jde levně:
+#   --max-age    projde jen dema mladší než pár hodin, takže se neřeší
+#                celý archiv. Traverza stromu přes SFTP stojí ~14 s.
+#   --no-traverse  nevypisuje celý cílový bucket (120k objektů) jen kvůli
+#                pár novým souborům - u každého kandidáta se zeptá zvlášť.
+#
+# Noční backup.sh dělá pořád plnou kopii bez --max-age, takže je to
+# zároveň pojistka na cokoliv, co tenhle běh minul.
+#
+# copy, ne sync: smazání na storage nikdy nesmaže nic v B2.
+# Čte se přes SFTP účet dlbrowser, na storage VPS se nic neinstaluje.
+#
+# Cron:
+#   */15 * * * * /var/www/defrag-racing-project/production/current/scripts/serverdemos-mirror.sh >> /root/serverdemos-mirror.log 2>&1
+
+set -euo pipefail
+
+ENV_FILE="/var/www/defrag-racing-project/production/current/.env"
+LOCK_FILE="/run/serverdemos-mirror.lock"
+
+# Kolik zpátky se díváme. Výrazně víc než perioda cronu, aby vynechaný
+# nebo pomalý běh nenechal díru.
+MAX_AGE="${MAX_AGE:-6h}"
+
+# Druhý běh nemá co dělat, když ten první ještě jede - jen by si sedly
+# na stejné soubory. -n = raději hned skončit než čekat.
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "[$(date)] Předchozí běh ještě běží, přeskakuji"
+  exit 0
+fi
+
+read_env() { grep -E "^$1=" "$ENV_FILE" | head -n1 | cut -d '=' -f2- | tr -d "\"'"; }
+
+B2_SERVERDEMOS_KEY_ID="$(read_env B2_SERVERDEMOS_KEY_ID)"
+B2_SERVERDEMOS_APP_KEY="$(read_env B2_SERVERDEMOS_APP_KEY)"
+B2_SERVERDEMOS_BUCKET="$(read_env B2_SERVERDEMOS_BUCKET)"; B2_SERVERDEMOS_BUCKET="${B2_SERVERDEMOS_BUCKET:-defrag-serverdemos}"
+SD_HOST="$(read_env STORAGE_VPS_DL_HOST)"
+SD_PORT="$(read_env STORAGE_VPS_DL_PORT)"; SD_PORT="${SD_PORT:-2258}"
+SD_USER="$(read_env STORAGE_VPS_DL_USER)"; SD_USER="${SD_USER:-dlbrowser}"
+SD_KEY_PATH="$(read_env STORAGE_VPS_DL_KEY_PATH)"
+
+for v in B2_SERVERDEMOS_KEY_ID B2_SERVERDEMOS_APP_KEY SD_HOST SD_KEY_PATH; do
+  if [ -z "${!v}" ]; then
+    echo "[$(date)] CHYBA: $v nenalezeno v $ENV_FILE" >&2
+    exit 1
+  fi
+done
+
+export RCLONE_CONFIG_SDSFTP_TYPE=sftp
+export RCLONE_CONFIG_SDSFTP_HOST="$SD_HOST"
+export RCLONE_CONFIG_SDSFTP_PORT="$SD_PORT"
+export RCLONE_CONFIG_SDSFTP_USER="$SD_USER"
+export RCLONE_CONFIG_SDSFTP_KEY_FILE="$SD_KEY_PATH"
+export RCLONE_CONFIG_SDB2_TYPE=b2
+export RCLONE_CONFIG_SDB2_ACCOUNT="$B2_SERVERDEMOS_KEY_ID"
+export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"
+
+# --stats-one-line drží log čitelný: jeden řádek za běh místo průběžného
+# překreslování, které v souboru vypadá jako smetí.
+rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
+  --max-age "$MAX_AGE" \
+  --no-traverse \
+  --transfers 4 \
+  --sftp-concurrency 8 \
+  --stats-one-line \
+  --stats 0
+
+echo "[$(date)] Serverdemos mirror (max-age $MAX_AGE) OK"


### PR DESCRIPTION
Three things that belong together: the demos get off a single disk faster,
the app stops depending on that disk, and the whole index finally does the
job it was built for.

Mirror every 15 minutes instead of once a day. A demo uploaded at 5am used
to exist nowhere but the storage VPS until 4am the next day. Measured
first: walking all 116k files over SFTP takes 13.7 s, so no ingest-daemon
hook and no B2 credentials on the storage box are needed. The new script
uses --max-age and --no-traverse, takes its own flock, and is a separate
cron entry rather than a fourth section of backup.sh, where a failing DB
dump currently means the demos are never attempted at all. The indexer
skips unchanged rows so a frequent run writes only what arrived; flagging
demos as gone moves behind --sweep, nightly.

Downloads fall back to the B2 mirror. The browser lists from the index now,
so it keeps showing a demo whose local copy is gone - and downloading it
would 404. Both locations are tried rather than switched between, because
on_contabo is refreshed on a schedule and can be stale either way.

Evidence on a flagged record. record_flags has carried a record_id with no
demo since March, so people could always flag a time without knowing what
was behind it; the moderation screen just had no way to look. It now shows
the serverdemo of that exact run, any uploaded demos, and the player's
other runs on that map - a single run rarely proves anything, the jump from
a plausible time to an implausible one is what a human spots.

Access: record_flags may pull a serverdemo through the signed download
endpoint, so someone resolving a report can open it without being given
the archive; browsing still needs serverdemos_browser. Flagging a record no
longer needs 30 records of your own - anyone can see a time that looks
wrong - while flagging a demo keeps the bar. The route is throttled to
20/hour to replace what the record count was quietly doing.

Serverdemos remain non-public: signed 5-minute url, auth, moderator
permission, and links only ever minted inside the admin panel.

After deploy: add the */15 cron entry, and confirm the serverdemos bucket
answers on the default eu-central-003 endpoint.