### PR TITLE
serverdemos browser layout, resilient backups, verified SFTP host key

### DIFF
--- a/app/Filament/Pages/ServerdemosBrowser.php
+++ b/app/Filament/Pages/ServerdemosBrowser.php
@@ -105,7 +105,7 @@ class ServerdemosBrowser extends Page
 
         $stats = $this->sidebarStats();
 
-        return $creds->map(function ($c) use ($stats) {
+        $rows = $creds->map(function ($c) use ($stats) {
             $user = $c->sftp_username;
             $stat = $stats[$user] ?? null;
 
@@ -120,8 +120,34 @@ class ServerdemosBrowser extends Page
                 'count'         => $count,
                 'last'          => $last,
                 'bytes'         => $bytes,
+                'orphan'        => false,
             ];
-        })->sortByDesc('last')->values()->all();
+        });
+
+        // Directories that hold demos but have no credential on the web -
+        // accounts provisioned straight from the CLI on the storage box.
+        // Without this they are invisible here while their demos keep piling
+        // up, which is how 78 of them went unnoticed for the better part of a
+        // year.
+        $accounted = $rows->pluck('sftp_username')->all();
+
+        foreach ($stats as $dir => $stat) {
+            if (in_array($dir, $accounted, true)) {
+                continue;
+            }
+
+            $rows->push([
+                'sftp_username' => $dir,
+                'owner_name'    => 'no web credential',
+                'owner_id'      => null,
+                'count'         => (int) $stat['n'],
+                'last'          => isset($stat['last']) ? Carbon::parse($stat['last'])->getTimestamp() : null,
+                'bytes'         => (int) $stat['bytes'],
+                'orphan'        => true,
+            ]);
+        }
+
+        return $rows->sortByDesc('last')->values()->all();
     }
 
     /**
@@ -221,8 +247,13 @@ class ServerdemosBrowser extends Page
 
     public function selectUser(string $user): void
     {
-        // Normalize + guard: refuse anything that isn't a known SFTP credential.
-        $known = SftpCredential::where('sftp_username', $user)->exists();
+        // Guard: refuse anything that is neither a known credential nor a
+        // directory the index has actually seen. Both are needed - a
+        // CLI-provisioned account has demos here with no credential to match,
+        // and it is listed above, so it has to be selectable.
+        $known = SftpCredential::where('sftp_username', $user)->exists()
+            || ServerDemo::where('owner_dir', $user)->exists();
+
         if (!$known) {
             Notification::make()->title('Unknown user')->danger()->send();
             return;

--- a/resources/views/filament/pages/serverdemos-browser.blade.php
+++ b/resources/views/filament/pages/serverdemos-browser.blade.php
@@ -60,7 +60,7 @@
                             <span style="font-weight:600;color:#fafafa;font-size:13px;">{{ $c['sftp_username'] }}</span>
                             <span style="font-size:11px;color:#fb923c;font-weight:700;">{{ $c['count'] ?? '…' }}</span>
                         </div>
-                        <div style="font-size:11px;color:#71717a;margin-top:2px;">
+                        <div style="font-size:11px;color:{{ ($c['orphan'] ?? false) ? '#a16207' : '#71717a' }};margin-top:2px;">
                             {{ $c['owner_name'] }}
                         </div>
                         <div style="display:flex;justify-content:space-between;font-size:11px;color:#52525b;margin-top:4px;">

--- a/resources/views/filament/pages/serverdemos-browser.blade.php
+++ b/resources/views/filament/pages/serverdemos-browser.blade.php
@@ -30,7 +30,10 @@
         };
     @endphp
 
-    <div wire:init="initSidebar" style="display:grid;grid-template-columns:320px 1fr;gap:14px;align-items:start;">
+    {{-- Credentials across the top, the listing below at full width. Side by
+     side, the table lost 320px to a list of ten short names and the demo
+     filenames - which are the whole point of the page - had to wrap. --}}
+<div wire:init="initSidebar" style="display:flex;flex-direction:column;gap:14px;">
 
         {{-- Sidebar: SFTP credentials --}}
         <div style="background:#0f0f17;border:1px solid #27272a;border-radius:12px;overflow:hidden;">
@@ -46,11 +49,11 @@
                 </button>
             </div>
 
-            <div>
+            <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:8px;padding:10px;">
                 @foreach ($creds as $c)
                     @php $active = $c['sftp_username'] === $selected; @endphp
                     <button type="button" wire:click="selectUser(@js($c['sftp_username']))"
-                        style="display:block;width:100%;text-align:left;background:{{ $active ? 'rgba(234,88,12,0.10)' : 'transparent' }};border:none;border-bottom:1px solid #1f1f23;cursor:pointer;padding:10px 12px;transition:background 120ms;"
+                        style="text-align:left;background:{{ $active ? 'rgba(234,88,12,0.10)' : 'transparent' }};border:1px solid {{ $active ? '#ea580c' : '#27272a' }};border-radius:8px;cursor:pointer;padding:10px 12px;transition:background 120ms;"
                         onmouseover="this.style.background='rgba(234,88,12,0.06)'"
                         onmouseout="this.style.background='{{ $active ? 'rgba(234,88,12,0.10)' : 'transparent' }}'">
                         <div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">
@@ -72,7 +75,7 @@
                 @endforeach
 
                 @if (empty($creds))
-                    <div style="padding:14px;color:#71717a;font-size:12px;text-align:center;">
+                    <div style="grid-column:1/-1;padding:14px;color:#71717a;font-size:12px;text-align:center;">
                         No active SFTP credentials.
                     </div>
                 @endif
@@ -86,7 +89,7 @@
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width:48px;height:48px;margin:0 auto 12px;color:#3f3f46;">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5m7.5 0c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5m7.5 0c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125" />
                     </svg>
-                    Select a credential from the sidebar to browse demos.
+                    Pick a credential above to browse its demos.
                 </div>
             @else
                 {{-- Header --}}

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -3,9 +3,16 @@
 # Záloha defrag.racing
 #   1) DB dump + .env  -> B2 "defrag-backups"  (datované, rotované, write-only klíč)
 #   2) Média (mirror)  -> B2 "defrag-media"    (inkrementálně, read+write klíč)
+#   3) Serverdemos     -> B2 "defrag-serverdemos" (plná kontrola; průběžně to
+#                         dělá serverdemos-mirror.sh každých 15 minut)
 #
 # Spouštěno cronem z current/scripts/backup.sh.
 # Žádná tajemství zde nejsou - creds se čtou z .env za běhu.
+#
+# Každá sekce běží samostatně: pod `set -e` stačilo, aby selhal dump databáze,
+# a na média ani na dema už vůbec nedošlo - tichý výpadek přesně té zálohy,
+# kterou nikdo nekontroluje. Teď se selhání zaznamená, ostatní sekce doběhnou
+# a skript skončí nenulově, takže je to poznat i z cronu.
 
 set -euo pipefail
 
@@ -41,6 +48,7 @@ FILES_FILE="$BACKUP_DIR/files-$STAMP.tar.gz"
 echo "[$(date)] === Start zálohy $STAMP ==="
 
 # ===== 1) DB + .env -> defrag-backups (datované) =====
+sekce_db() {
 mysqldump --single-transaction --quick --routines --triggers --no-tablespaces \
   -u "$DB_USERNAME" -p"$DB_PASSWORD" "$DB_DATABASE" | gzip > "$DB_FILE"
 tar czhf "$FILES_FILE" -C "$APP_DIR" .env      # -h dereferencuje symlink .env
@@ -56,8 +64,10 @@ echo "[$(date)] DB+env upload na B2 OK"
 
 # Po úspěšném uploadu lokální dump nedržíme - vše je na B2.
 rm -f "$DB_FILE" "$FILES_FILE"
+}
 
 # ===== 2) Média mirror -> defrag-media (inkrementálně, jen přidává/přepisuje) =====
+sekce_media() {
 if [ -n "$B2_MEDIA_KEY_ID" ] && [ -n "$B2_MEDIA_APP_KEY" ]; then
   export RCLONE_CONFIG_B2MEDIA_TYPE=b2
   export RCLONE_CONFIG_B2MEDIA_ACCOUNT="$B2_MEDIA_KEY_ID"
@@ -76,8 +86,10 @@ if [ -n "$B2_MEDIA_KEY_ID" ] && [ -n "$B2_MEDIA_APP_KEY" ]; then
 else
   echo "[$(date)] Média přeskočena (B2_MEDIA_* není v .env)"
 fi
+}
 
 # ===== 3) Serverdemos mirror (storage VPS -> defrag-serverdemos) =====
+sekce_serverdemos() {
 # Archiv, ne sync: rclone copy jen přidává - smazání na storage nikdy
 # nesmaže nic v B2. Čte se přes dlbrowser SFTP účet (read ACL na
 # /var/lib/serverdemos), takže na storage VPS nic neinstalujeme.
@@ -104,6 +116,37 @@ if [ -n "$B2_SERVERDEMOS_KEY_ID" ] && [ -n "$B2_SERVERDEMOS_APP_KEY" ] && [ -n "
   echo "[$(date)] Serverdemos mirror na B2 OK"
 else
   echo "[$(date)] Serverdemos přeskočeny (B2_SERVERDEMOS_* / STORAGE_VPS_DL_* není v .env)"
+fi
+}
+
+# ---- Spuštění ----
+SELHALO=()
+
+# Sekce běží v podprocesu, který si errexit zapíná sám, a volá se MIMO `if` a
+# mimo AND-OR seznam. Kdyby se volala uvnitř podmínky, bash by errexit v celé
+# funkci potlačil a sekce by po selhaném dumpu vesele pokračovala balením a
+# uploadem prázdna. Takhle první chyba ukončí jen tu jednu sekci.
+spust() {
+  local nazev="$1" funkce="$2" navrat=0
+
+  set +e
+  ( set -e; "$funkce" )
+  navrat=$?
+  set -e
+
+  if [ "$navrat" -ne 0 ]; then
+    echo "[$(date)] !!! sekce '$nazev' SELHALA (kód $navrat), pokračuji dál" >&2
+    SELHALO+=("$nazev")
+  fi
+}
+
+spust "DB + .env" sekce_db
+spust "média" sekce_media
+spust "serverdemos" sekce_serverdemos
+
+if [ ${#SELHALO[@]} -gt 0 ]; then
+  echo "[$(date)] === Záloha $STAMP DOKONČENA S CHYBAMI: ${SELHALO[*]} ==="
+  exit 1
 fi
 
 echo "[$(date)] === Záloha $STAMP DOKONČENA ==="

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -107,6 +107,11 @@ if [ -n "$B2_SERVERDEMOS_KEY_ID" ] && [ -n "$B2_SERVERDEMOS_APP_KEY" ] && [ -n "
   export RCLONE_CONFIG_SDSFTP_PORT="$SD_PORT"
   export RCLONE_CONFIG_SDSFTP_USER="$SD_USER"
   export RCLONE_CONFIG_SDSFTP_KEY_FILE="$SD_KEY_PATH"
+# Bez tohohle si rclone klíč hostitele vůbec neověřuje a jen na to upozorní v
+# logu - spojení by tak šlo podvrhnout a dema poslat jinam. Soubor se plní
+# ručně z ověřeného otisku, takže neexistující nebo prázdný known_hosts je
+# důvod k selhání, ne k tichému pokračování.
+export RCLONE_CONFIG_SDSFTP_KNOWN_HOSTS_FILE="${HOME:-/root}/.ssh/known_hosts"
   export RCLONE_CONFIG_SDB2_TYPE=b2
   export RCLONE_CONFIG_SDB2_ACCOUNT="$B2_SERVERDEMOS_KEY_ID"
   export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -61,6 +61,11 @@ export RCLONE_CONFIG_SDSFTP_HOST="$SD_HOST"
 export RCLONE_CONFIG_SDSFTP_PORT="$SD_PORT"
 export RCLONE_CONFIG_SDSFTP_USER="$SD_USER"
 export RCLONE_CONFIG_SDSFTP_KEY_FILE="$SD_KEY_PATH"
+# Bez tohohle si rclone klíč hostitele vůbec neověřuje a jen na to upozorní v
+# logu - spojení by tak šlo podvrhnout a dema poslat jinam. Soubor se plní
+# ručně z ověřeného otisku, takže neexistující nebo prázdný known_hosts je
+# důvod k selhání, ne k tichému pokračování.
+export RCLONE_CONFIG_SDSFTP_KNOWN_HOSTS_FILE="${HOME:-/root}/.ssh/known_hosts"
 export RCLONE_CONFIG_SDB2_TYPE=b2
 export RCLONE_CONFIG_SDB2_ACCOUNT="$B2_SERVERDEMOS_KEY_ID"
 export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"


### PR DESCRIPTION
Four independent fixes that came out of running yesterday's work in anger.

Browser layout: the credential list was a fixed 320px column beside the
table, taking width from the demo filenames, which are the only thing on
that page anyone reads. Credentials move above the listing as a row of
auto-fitting cards.

Directories with no web credential are listed. The sidebar only showed
active SFTP credentials, so demos belonging to accounts provisioned from
the CLI on the storage box were invisible - 78 of them, in two
directories, for most of a year. They are shown marked "no web
credential" rather than given an invented one.

Backups no longer skip sections. Under `set -euo pipefail` a failing
database dump meant the media and serverdemo mirrors were never attempted.
Each section is now a function run in a subshell that enables errexit
itself and is called outside any `if` - that detail matters, because a
function called inside a condition has errexit suppressed for its whole
body and would carry on past a failed dump. First error ends that section,
the others still run, exit code reports what failed.

SFTP host key is verified. Both rclone scripts connected to the storage
VPS with no host key validation, announcing it in every log line. The key
is checked against known_hosts now, seeded after comparing all three
fingerprints with the ones read on the storage box itself.
