### PR TITLE
Pack serverdemos on arrival + toast above the header

### DIFF
--- a/app/Services/ServerDemoPath.php
+++ b/app/Services/ServerDemoPath.php
@@ -41,6 +41,16 @@ class ServerDemoPath
     public const SKIP_DIRS = ['_revoked'];
 
     /**
+     * `.dm_68`, optionally packed as `.dm_68.7z`.
+     *
+     * Demos land raw and the ingest daemon packs them, which is worth doing:
+     * a raw serverdemo averages 1.14 MB against 310 kB for the public ones,
+     * which are packed at upload. Both forms sit in the tree side by side -
+     * the ones already here stay raw - so nothing may assume either.
+     */
+    private const DEMO_SUFFIX = '/\.dm_\d+(\.7z)?$/i';
+
+    /**
      * @return array{owner_dir:string,filename:string,rs_server_id:?int,physics:?string,mode:?string,map_name:string,time_ms:?int,mdd_id:?int}|null
      *         null when the path is not a demo file at all
      */
@@ -54,7 +64,7 @@ class ServerDemoPath
             return null;
         }
 
-        if (! preg_match('/\.dm_\d+$/i', $filename)) {
+        if (! preg_match(self::DEMO_SUFFIX, $filename)) {
             return null;
         }
 
@@ -108,11 +118,15 @@ class ServerDemoPath
      * demos use. A name that matches neither still yields a map, because the
      * file is real and belongs in the index either way.
      *
+     * Packing keeps the whole name and only appends `.7z`, so map, time and
+     * MDD id read the same out of a packed demo as out of a raw one and the
+     * index does not care which it got.
+     *
      * @return array{map:string,time:?int,mdd_id:?int}
      */
     public static function parseFilename(string $filename): array
     {
-        $base = preg_replace('/\.dm_\d+$/i', '', $filename);
+        $base = preg_replace(self::DEMO_SUFFIX, '', $filename);
 
         if (preg_match('/^(.+?)\[(\d+)\]\[(\d+)\]$/', $base, $m)) {
             return ['map' => $m[1], 'time' => (int) $m[2], 'mdd_id' => (int) $m[3]];

--- a/resources/js/Pages/Admin/ModelsAudit.vue
+++ b/resources/js/Pages/Admin/ModelsAudit.vue
@@ -1031,7 +1031,9 @@ const executeDryRun = async () => {
         <Head title="Models Audit" />
 
         <!-- Toast notifications -->
-        <div class="fixed top-4 right-4 z-50 space-y-2">
+        <!-- Nad hlavičkou, viz stejná oprava v Models/Show.vue: nav je sticky
+             se z-[200] a toast se za ni schovával. -->
+        <div class="fixed top-4 right-4 z-[300] space-y-2">
             <transition-group name="toast">
                 <div
                     v-for="toast in toasts"

--- a/resources/js/Pages/Models/Show.vue
+++ b/resources/js/Pages/Models/Show.vue
@@ -2322,7 +2322,10 @@ const confirmNsfw = () => {
                 leave-active-class="transform transition ease-in duration-200"
                 leave-from-class="translate-y-0 opacity-100"
                 leave-to-class="translate-y-2 opacity-0">
-                <div v-if="showNotification" class="fixed top-8 right-8 z-50 max-w-md">
+                <!-- Nad hlavičkou: ta je sticky se z-[200], takže hláška se
+                     zespodu schovávala za ni a z "GIF vygenerován" byl vidět
+                     jen pruh. Toast musí přebít všechno, je jen na chvíli. -->
+                <div v-if="showNotification" class="fixed top-8 right-8 z-[300] max-w-md">
                     <div :class="[
                         'rounded-2xl border shadow-2xl p-6',
                         notificationType === 'success'

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -123,7 +123,10 @@ if [ -n "$B2_SERVERDEMOS_KEY_ID" ] && [ -n "$B2_SERVERDEMOS_APP_KEY" ] && [ -n "
   export RCLONE_CONFIG_SDB2_ACCOUNT="$B2_SERVERDEMOS_KEY_ID"
   export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"
 
+  # --exclude *.part viz serverdemos-mirror.sh: rozdělaný archiv z ingestu
+  # se do B2 nesmí dostat, protože odtud už se nikdy nesmaže.
   rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
+    --exclude "*.part" \
     --transfers 4 --sftp-concurrency 8
   echo "[$(date)] Serverdemos mirror na B2 OK"
 else

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -72,7 +72,11 @@ export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"
 
 # --stats-one-line drží log čitelný: jeden řádek za běh místo průběžného
 # překreslování, které v souboru vypadá jako smetí.
+# --exclude *.part: ingest balí demo do dočasného .7z.part a teprve hotový
+# archiv přejmenuje. Nahrát rozdělaný kus by znamenalo mít ho v B2 navždy,
+# protože copy nikdy nic nemaže.
 rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
+  --exclude "*.part" \
   --max-age "$MAX_AGE" \
   --no-traverse \
   --transfers 4 \


### PR DESCRIPTION
Serverdemos average 1.14 MB, demos uploaded through the site 310 kB - the
site packs those on upload, the recordsystem writes serverdemos raw. 7z
leaves 26% of the bytes, about 90 GB on a disk that hit 100% on
2026-07-31 and grows 29 GB a month. The storage box will pack new
arrivals; this is the site's half.

The path parser takes .dm_<n> with an optional .7z. The suffix is
appended and the rest of the name kept, so map, time and MDD id read the
same - checked against both forms, fastcaps, the old underscore naming
and the _revoked skip. Nothing else needed changing: the indexer uses the
same parser, downloads are octet-stream under the file's own name, and
records match on map/physics/mode/mdd/time, never the extension. Existing
demos stay raw; converting them is a separate decision.

Both rclone jobs skip *.part now - packing builds the archive under that
suffix, and a mirror catching one mid-write would leave a truncated file
in a bucket that never deletes.

Unrelated: the sticky header is z-[200] and the model-page toasts were
z-50, so "GIF generated" showed up behind it.

Deploy before the storage box.
