### PR TITLE
Serverdemo validators, instant play, and a scraper cleanup

### DIFF
--- a/app/Console/Commands/ScrapeServers.php
+++ b/app/Console/Commands/ScrapeServers.php
@@ -123,10 +123,18 @@ class ScrapeServers extends Command
                 }
             }
 
-            // If both failed, fall back to basic getstatus
-            if ($result === null) {
-                $result = $connection->getData();
-            }
+            // getstatus is gone. It only ever returned player NAMES - no uid,
+            // country, model or spectating - and it was unreachable in
+            // practice: measured 2026-08-03 across every online server, four
+            // did not answer getdfstatus and rcon works on all four, so the
+            // branch below never ran.
+            // Nothing is left uncovered either: a null result drops the
+            // server into handle_failed_servers(), which still tries q3df.org
+            // before marking it offline.
+            //
+            // if ($result === null) {
+            //     $result = $connection->getData();
+            // }
 
         } catch (\Exception $e) {
             return null;

--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -116,6 +116,17 @@ class DefragServer
         return $result;
     }    
 
+    /**
+     * Plain Quake3 getstatus. NOT USED by the scraper any more - see the
+     * commented-out branch in ScrapeServers::getServerData().
+     *
+     * It returns score, ping and name per player, of which only the name is
+     * kept: no uid, no country, no model, no spectating. Every engine in the
+     * list answers getdfstatus or rcon, so this was measured to be dead code
+     * on 2026-08-03. Left here rather than deleted because it is the only
+     * implementation of the vanilla protocol we have, and an engine that
+     * speaks nothing else may still turn up one day.
+     */
     public function getData() {
         socket_sendto($this->socket, "\xff\xff\xff\xffgetstatus\x00", strlen("\xff\xff\xff\xffgetstatus\x00"), 0, $this->ip, $this->port);
         $data = socket_read($this->socket, 4096);

--- a/app/Filament/Resources/RecordFlagResource.php
+++ b/app/Filament/Resources/RecordFlagResource.php
@@ -204,6 +204,36 @@ class RecordFlagResource extends Resource
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make(),
 
+                // The gate in front of the validators. Nothing reaches them on
+                // its own: without this, one person with a grudge could push
+                // demos in front of moderators just by reporting a lot of
+                // runs. Cleared reports join the open case for that player -
+                // see App\Services\ServerdemoValidationService.
+                Tables\Actions\Action::make('clearForValidation')
+                    ->label('Clear for validation')
+                    ->icon('heroicon-o-lock-open')
+                    ->color('success')
+                    ->visible(fn ($record) => (auth()->user()?->isAdmin() ?? false) && $record->admin_cleared_at === null)
+                    ->requiresConfirmation()
+                    ->modalDescription(fn ($record) => $record->hasEnoughReports()
+                        ? 'Releases this report to the validators. Only do this if it is not a false report.'
+                        : 'Not enough independent reports yet - it will wait until there are, then join the case on its own.')
+                    ->form([
+                        \Filament\Forms\Components\Textarea::make('note')
+                            ->label('Note for the validators (optional)')
+                            ->rows(2),
+                    ])
+                    ->action(function ($record, array $data) {
+                        $case = app(\App\Services\ServerdemoValidationService::class)
+                            ->clear($record, auth()->user(), $data['note'] ?? null);
+
+                        \Filament\Notifications\Notification::make()
+                            ->success()
+                            ->title($case ? 'Cleared and added to a case' : 'Cleared - waiting for more reports')
+                            ->body($case ? 'Case against ' . $case->subjectLabel() : null)
+                            ->send();
+                    }),
+
                 // People flag a record without knowing what evidence exists
                 // behind it. This is where that gets answered: the serverdemo
                 // of the exact run if it happened on one of our servers, any

--- a/app/Filament/Resources/ServerdemoValidationResource.php
+++ b/app/Filament/Resources/ServerdemoValidationResource.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ServerdemoValidationResource\Pages;
+use App\Models\ServerdemoValidationCase;
+use App\Services\ServerdemoValidationService;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * The validator queue: one row per reported PLAYER.
+ *
+ * Reports accumulate into a case, so somebody caught on ten maps is one piece
+ * of work with ten pieces of evidence rather than ten unrelated rows. The
+ * ladder, the notes and the verdict all belong to the case.
+ */
+class ServerdemoValidationResource extends Resource
+{
+    protected static ?string $model = ServerdemoValidationCase::class;
+    protected static ?string $slug = 'serverdemo-validations';
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
+    protected static ?string $navigationGroup = 'Validators';
+    protected static ?string $navigationLabel = 'Reported players';
+    protected static ?int $navigationSort = 20;
+    protected static bool $shouldSkipAuthorization = true;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasModeratorPermission('serverdemo_validation') ?? false;
+    }
+
+    /**
+     * What this user may see at all.
+     *
+     * The admin sees every case. A validator sees only cases handed to them
+     * and cases opened to everyone - nothing else is listed, so nothing else
+     * can be opened.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        $user = auth()->user();
+        $query = parent::getEloquentQuery()->withCount('flags')->with('assignee');
+
+        if ($user?->isAdmin()) {
+            return $query;
+        }
+
+        return $query
+            ->whereNull('validation_closed_at')
+            ->where(function (Builder $q) use ($user) {
+                $q->where('assigned_to_user_id', $user?->id)
+                    ->orWhereIn('validation_stage', ['all_validators', 'admin']);
+            });
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getEloquentQuery()->whereNull('validation_closed_at')->count() ?: null;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('updated_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('subject_name')
+                    ->label('Player')
+                    ->searchable()
+                    ->formatStateUsing(fn (?string $state, $record): string => $state
+                        ? UserResource::q3tohtml($state)
+                        : e($record->subjectLabel()))
+                    ->html()
+                    ->description(fn ($record) => $record->subject_mdd_id ? 'MDD #' . $record->subject_mdd_id : null),
+                Tables\Columns\TextColumn::make('kind')
+                    ->label('Kind')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => $state === ServerdemoValidationCase::KIND_PUBLIC_DEMO ? 'Public demo' : 'Serverdemo')
+                    ->color(fn (string $state): string => $state === ServerdemoValidationCase::KIND_PUBLIC_DEMO ? 'info' : 'primary'),
+                Tables\Columns\TextColumn::make('flags_count')
+                    ->label('Runs')
+                    ->alignCenter()
+                    ->badge()
+                    ->color(fn ($state) => $state > 2 ? 'danger' : 'warning'),
+                Tables\Columns\TextColumn::make('validation_stage')
+                    ->label('Stage')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'assigned' => 'With one validator',
+                        'second_opinion' => 'Second opinion',
+                        'all_validators' => 'All validators',
+                        'admin' => 'With admin',
+                        default => $state,
+                    })
+                    ->color(fn (string $state): string => match ($state) {
+                        'admin' => 'danger',
+                        'all_validators' => 'warning',
+                        default => 'info',
+                    }),
+                Tables\Columns\TextColumn::make('assignee.name')
+                    ->label('Holder')
+                    ->placeholder('-')
+                    ->formatStateUsing(fn (?string $state): string => $state ? UserResource::q3tohtml($state) : '')
+                    ->html(),
+                Tables\Columns\TextColumn::make('validation_outcome')
+                    ->label('Outcome')
+                    ->badge()
+                    ->placeholder('-')
+                    ->color(fn (?string $state): string => match ($state) {
+                        'upheld' => 'danger',
+                        'dismissed' => 'success',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Last activity')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\Filter::make('mine')
+                    ->label('Assigned to me')
+                    ->query(fn (Builder $query) => $query->where('assigned_to_user_id', auth()->id())),
+                Tables\Filters\Filter::make('open')
+                    ->label('Still open')
+                    ->default()
+                    ->query(fn (Builder $query) => $query->whereNull('validation_closed_at')),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('open')
+                    ->label('Open')
+                    ->icon('heroicon-o-eye')
+                    ->color('gray')
+                    ->modalHeading(fn ($record) => 'Case against ' . $record->subjectLabel())
+                    ->modalContent(fn ($record) => view('filament.serverdemo-validation.case-modal', ['case' => $record]))
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Close')
+                    ->modalWidth('4xl'),
+
+                Tables\Actions\Action::make('comment')
+                    ->label('Add note')
+                    ->icon('heroicon-o-chat-bubble-left-ellipsis')
+                    ->color('gray')
+                    ->form([
+                        \Filament\Forms\Components\Textarea::make('body')
+                            ->label('Internal note')
+                            ->required()
+                            ->rows(3)
+                            ->helperText('Only validators and the admin ever see this.'),
+                    ])
+                    ->action(function ($record, array $data) {
+                        app(ServerdemoValidationService::class)->log($record, auth()->user(), null, $data['body']);
+
+                        Notification::make()->success()->title('Note added')->send();
+                    }),
+
+                Tables\Actions\Action::make('handOver')
+                    ->label('Not sure - pass on')
+                    ->icon('heroicon-o-arrow-right-circle')
+                    ->color('warning')
+                    ->visible(fn ($record) => $record->assigned_to_user_id === auth()->id() && $record->isOpen())
+                    ->form([
+                        \Filament\Forms\Components\Textarea::make('note')
+                            ->label('What did you already check?')
+                            ->required()
+                            ->rows(3)
+                            ->helperText('The next person starts from your note, so say which runs you watched and what bothers you.'),
+                    ])
+                    ->action(function ($record, array $data) {
+                        $next = app(ServerdemoValidationService::class)->handOver($record, auth()->user(), $data['note']);
+
+                        Notification::make()
+                            ->success()
+                            ->title($next ? "Passed to {$next->name}" : 'Opened to all validators')
+                            ->body($next ? null : 'Nobody left who has not seen it, so everyone can look now.')
+                            ->send();
+                    }),
+
+                Tables\Actions\Action::make('escalateAll')
+                    ->label('Open to all validators')
+                    ->icon('heroicon-o-user-group')
+                    ->color('warning')
+                    ->visible(fn ($record) => $record->isOpen()
+                        && in_array($record->validation_stage, ['assigned', 'second_opinion'], true))
+                    ->form([
+                        \Filament\Forms\Components\Textarea::make('note')
+                            ->label('Why (optional)')
+                            ->rows(2),
+                    ])
+                    ->action(function ($record, array $data) {
+                        app(ServerdemoValidationService::class)->escalateToAll($record, auth()->user(), $data['note'] ?? null);
+
+                        Notification::make()->success()->title('Open to all validators')->send();
+                    }),
+
+                Tables\Actions\Action::make('callAdmin')
+                    ->label('Call the admin')
+                    ->icon('heroicon-o-exclamation-triangle')
+                    ->color('danger')
+                    ->visible(fn ($record) => $record->isOpen() && $record->validation_stage === 'all_validators')
+                    ->form([
+                        \Filament\Forms\Components\Textarea::make('note')
+                            ->label('Where did you get stuck?')
+                            ->required()
+                            ->rows(3),
+                    ])
+                    ->action(function ($record, array $data) {
+                        app(ServerdemoValidationService::class)->callAdmin($record, auth()->user(), $data['note']);
+
+                        Notification::make()->success()->title('Sent to the admin')->send();
+                    }),
+
+                Tables\Actions\Action::make('close')
+                    ->label('Close case')
+                    ->icon('heroicon-o-check-badge')
+                    ->color('success')
+                    ->visible(fn ($record) => $record->isOpen()
+                        && ($record->assigned_to_user_id === auth()->id() || (auth()->user()?->isAdmin() ?? false)))
+                    ->form([
+                        \Filament\Forms\Components\Select::make('outcome')
+                            ->required()
+                            ->options([
+                                'upheld' => 'Upheld - the reports are right',
+                                'dismissed' => 'Dismissed - the runs are fine',
+                                'inconclusive' => 'Inconclusive',
+                            ]),
+                        \Filament\Forms\Components\Textarea::make('note')
+                            ->label('Reasoning')
+                            ->required()
+                            ->rows(3),
+                    ])
+                    ->action(function ($record, array $data) {
+                        app(ServerdemoValidationService::class)->close($record, auth()->user(), $data['outcome'], $data['note']);
+
+                        Notification::make()->success()->title('Case closed')->send();
+                    }),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListServerdemoValidations::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ServerdemoValidationResource/Pages/ListServerdemoValidations.php
+++ b/app/Filament/Resources/ServerdemoValidationResource/Pages/ListServerdemoValidations.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Resources\ServerdemoValidationResource\Pages;
+
+use App\Filament\Resources\ServerdemoValidationResource;
+use App\Models\ServerdemoValidationCase;
+use Filament\Resources\Components\Tab;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
+
+class ListServerdemoValidations extends ListRecords
+{
+    protected static string $resource = ServerdemoValidationResource::class;
+
+    /**
+     * Serverdemos and uploaded demos stay apart.
+     *
+     * A report on a RECORD is checked against the serverdemo the game server
+     * wrote - private, never browsable, handed out one file at a time. A
+     * report on an uploaded demo is about a file the player published here,
+     * which anyone can already download. Same reviewers, different evidence
+     * and different rules, so they do not belong in one list.
+     */
+    public function getTabs(): array
+    {
+        $countOpen = fn (string $kind) => ServerdemoValidationResource::getEloquentQuery()
+            ->where('kind', $kind)
+            ->whereNull('validation_closed_at')
+            ->count() ?: null;
+
+        return [
+            'serverdemos' => Tab::make('Serverdemos')
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('kind', ServerdemoValidationCase::KIND_SERVERDEMO))
+                ->badge(fn () => $countOpen(ServerdemoValidationCase::KIND_SERVERDEMO)),
+
+            'public_demos' => Tab::make('Public demos')
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('kind', ServerdemoValidationCase::KIND_PUBLIC_DEMO))
+                ->badge(fn () => $countOpen(ServerdemoValidationCase::KIND_PUBLIC_DEMO)),
+
+            'all' => Tab::make('All'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ServerdemoValidatorApplicationResource.php
+++ b/app/Filament/Resources/ServerdemoValidatorApplicationResource.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ServerdemoValidatorApplicationResource\Pages;
+use App\Models\ServerdemoValidatorApplication;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class ServerdemoValidatorApplicationResource extends Resource
+{
+    protected static ?string $model = ServerdemoValidatorApplication::class;
+    protected static ?string $navigationIcon = 'heroicon-o-identification';
+    protected static ?string $navigationGroup = 'Validators';
+    protected static ?string $navigationLabel = 'Applications';
+    protected static ?int $navigationSort = 10;
+    protected static bool $shouldSkipAuthorization = true;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasModeratorPermission('serverdemo_validator_applications') ?? false;
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) ServerdemoValidatorApplication::pending()->count() ?: null;
+    }
+
+    /**
+     * Cleared-out applications are still reachable here - the Deleted filter
+     * decides whether they show. Everywhere else on the site they are gone,
+     * which is what lets the person apply again.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->withoutGlobalScopes([SoftDeletingScope::class]);
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Applicant')
+                    ->searchable()
+                    ->formatStateUsing(fn (string $state): string => UserResource::q3tohtml($state))->html()
+                    ->url(fn ($record) => "/profile/{$record->user_id}"),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'pending' => 'warning',
+                        'shortlisted' => 'info',
+                        'approved' => 'success',
+                        'not_selected' => 'gray',
+                        'rejected' => 'danger',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => $state === 'not_selected' ? 'Not selected' : ucfirst($state)),
+                Tables\Columns\TextColumn::make('availability')
+                    ->label('Around')
+                    ->placeholder('-')
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('contact')
+                    ->placeholder('-')
+                    ->copyable()
+                    ->toggleable(),
+                // The tally, admin-side only. Voters never see a running
+                // score - see the public page.
+                Tables\Columns\TextColumn::make('votes')
+                    ->label('Votes')
+                    ->alignCenter()
+                    ->state(function ($record) {
+                        $round = \App\Models\ServerdemoValidatorVoteRound::query()
+                            ->latest('opened_at')
+                            ->first();
+
+                        return $round
+                            ? \App\Models\ServerdemoValidatorVote::where('round_id', $round->id)
+                                ->where('application_id', $record->id)
+                                ->count()
+                            : 0;
+                    })
+                    ->sortable(false)
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'success' : 'gray'),
+                Tables\Columns\IconColumn::make('is_validator')
+                    ->label('Has permission')
+                    ->boolean()
+                    ->state(fn ($record) => (bool) $record->user?->hasModeratorPermission('serverdemo_validation')),
+                // What this applicant's history looks like. Deleted rows are
+                // counted on purpose - that is the whole reason deleting does
+                // not destroy anything.
+                Tables\Columns\TextColumn::make('past_rejections')
+                    ->label('Turned down before')
+                    ->alignCenter()
+                    ->state(fn ($record) => ServerdemoValidatorApplication::withTrashed()
+                        ->where('user_id', $record->user_id)
+                        ->where('id', '!=', $record->id)
+                        ->where('status', 'rejected')
+                        ->count())
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'warning' : 'gray'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Applied')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->label('Deleted')
+                    ->dateTime()
+                    ->placeholder('-')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'pending' => 'Pending',
+                        'shortlisted' => 'Shortlisted',
+                        'approved' => 'Approved',
+                        'rejected' => 'Rejected',
+                    ]),
+                Tables\Filters\TrashedFilter::make()
+                    ->label('Deleted applications'),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('view')
+                    ->icon('heroicon-o-eye')
+                    ->color('gray')
+                    ->modalHeading(fn ($record) => 'Application from ' . ($record->user->plain_name ?? $record->user->name ?? 'user #' . $record->user_id))
+                    ->modalContent(fn ($record) => view('filament.validator-applications.detail-modal', ['record' => $record]))
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Close')
+                    ->modalWidth('3xl'),
+
+                Tables\Actions\Action::make('setStatus')
+                    ->label('Decide')
+                    ->icon('heroicon-o-check-circle')
+                    ->color('success')
+                    ->form([
+                        \Filament\Forms\Components\Select::make('status')
+                            ->required()
+                            ->options([
+                                'shortlisted' => 'Shortlist (goes to the vote)',
+                                'approved' => 'Approve',
+                                'not_selected' => 'Not selected this round',
+                                'rejected' => 'Reject',
+                                'pending' => 'Back to pending',
+                            ]),
+                        \Filament\Forms\Components\Textarea::make('review_note')
+                            ->label('Note shown to the applicant (optional)')
+                            ->rows(2),
+                    ])
+                    ->action(function ($record, array $data) {
+                        $record->update([
+                            'status' => $data['status'],
+                            'review_note' => $data['review_note'] ?? null,
+                            'reviewed_by' => auth()->id(),
+                            'reviewed_at' => now(),
+                        ]);
+
+                        Notification::make()->success()->title('Application updated')->send();
+                    }),
+
+                // Approving and granting access are separate on purpose: the
+                // vote decides the first, and nobody should get the permission
+                // as a side effect of a status change.
+                Tables\Actions\Action::make('grantPermission')
+                    ->label('Grant validator access')
+                    ->icon('heroicon-o-key')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription('Makes this user a moderator with the serverdemo validation permission and nothing else. They still cannot browse the serverdemo archive - only demos of reports handed to them.')
+                    ->visible(fn ($record) => $record->status === 'approved'
+                        && ! ($record->user?->hasModeratorPermission('serverdemo_validation') ?? false))
+                    ->action(function ($record) {
+                        $user = $record->user;
+                        if (! $user) {
+                            Notification::make()->danger()->title('User is gone')->send();
+                            return;
+                        }
+
+                        $permissions = $user->moderator_permissions ?? [];
+                        $permissions[] = 'serverdemo_validation';
+
+                        $user->update([
+                            'is_moderator' => true,
+                            'moderator_permissions' => array_values(array_unique($permissions)),
+                        ]);
+
+                        Notification::make()->success()->title('Validator access granted')->send();
+                    }),
+
+                Tables\Actions\Action::make('revokePermission')
+                    ->label('Revoke validator access')
+                    ->icon('heroicon-o-no-symbol')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn ($record) => $record->user?->hasModeratorPermission('serverdemo_validation')
+                        && ! ($record->user?->isAdmin() ?? false))
+                    ->action(function ($record) {
+                        $user = $record->user;
+                        $permissions = array_values(array_diff($user->moderator_permissions ?? [], ['serverdemo_validation']));
+
+                        // Leave is_moderator alone - they may hold other
+                        // permissions, and this action is about one of them.
+                        $user->update(['moderator_permissions' => $permissions]);
+
+                        Notification::make()->success()->title('Validator access revoked')->send();
+                    }),
+
+                // Hides the application so the person may apply again. The
+                // row and its rejection stay - there is deliberately no force
+                // delete anywhere in this resource.
+                Tables\Actions\DeleteAction::make()
+                    ->label('Clear out')
+                    ->modalHeading('Clear out this application')
+                    ->modalDescription('It disappears from the list and they can apply again. The record of it, including a rejection, is kept and stays visible under the Deleted filter.'),
+
+                Tables\Actions\RestoreAction::make()
+                    ->label('Bring back'),
+            ])
+            ->bulkActions([
+                // After a round closes, everyone who was not picked is marked
+                // in one go. "Not selected" rather than "rejected" on purpose:
+                // losing a round is not a verdict on the person, and they are
+                // expected back next time.
+                Tables\Actions\BulkAction::make('markNotSelected')
+                    ->label('Mark as not selected')
+                    ->icon('heroicon-o-minus-circle')
+                    ->color('gray')
+                    ->requiresConfirmation()
+                    ->modalDescription('For everyone who did not get in this round. They keep their record and can apply again.')
+                    ->form([
+                        \Filament\Forms\Components\Textarea::make('review_note')
+                            ->label('Note shown to them (optional)')
+                            ->rows(2)
+                            ->default('Not selected in this round - you are welcome to apply again.'),
+                    ])
+                    ->action(function ($records, array $data) {
+                        $touched = 0;
+
+                        foreach ($records as $record) {
+                            // Never overwrite someone who got in.
+                            if ($record->status === 'approved') {
+                                continue;
+                            }
+
+                            $record->update([
+                                'status' => 'not_selected',
+                                'review_note' => $data['review_note'] ?: null,
+                                'reviewed_by' => auth()->id(),
+                                'reviewed_at' => now(),
+                            ]);
+                            $touched++;
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title("{$touched} marked as not selected")
+                            ->body('Approved applications were left alone.')
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListServerdemoValidatorApplications::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ServerdemoValidatorApplicationResource/Pages/ListServerdemoValidatorApplications.php
+++ b/app/Filament/Resources/ServerdemoValidatorApplicationResource/Pages/ListServerdemoValidatorApplications.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Resources\ServerdemoValidatorApplicationResource\Pages;
+
+use App\Filament\Resources\ServerdemoValidatorApplicationResource;
+use App\Models\ServerdemoValidatorVoteRound;
+use Filament\Actions;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ListRecords;
+
+class ListServerdemoValidatorApplications extends ListRecords
+{
+    protected static string $resource = ServerdemoValidatorApplicationResource::class;
+
+    /**
+     * The vote is opened and closed by hand. No schedule: the round should
+     * end when everyone has voted, which is not something a date knows.
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('openVoting')
+                ->label('Open voting round')
+                ->icon('heroicon-o-play')
+                ->color('success')
+                ->visible(fn () => ServerdemoValidatorVoteRound::current() === null)
+                ->form([
+                    \Filament\Forms\Components\TextInput::make('title')
+                        ->label('Shown to voters (optional)')
+                        ->placeholder('First round - pick who gets the position'),
+                ])
+                ->action(function (array $data) {
+                    ServerdemoValidatorVoteRound::create([
+                        'title' => $data['title'] ?? null,
+                        'opened_at' => now(),
+                        'opened_by' => auth()->id(),
+                    ]);
+
+                    Notification::make()->success()->title('Voting is open')->send();
+                }),
+
+            Actions\Action::make('closeVoting')
+                ->label('Close voting round')
+                ->icon('heroicon-o-stop')
+                ->color('danger')
+                ->visible(fn () => ServerdemoValidatorVoteRound::current() !== null)
+                ->requiresConfirmation()
+                ->modalDescription('Nobody can vote after this. The tally stays visible to you.')
+                ->action(function () {
+                    $round = ServerdemoValidatorVoteRound::current();
+                    $round?->update(['closed_at' => now()]);
+
+                    Notification::make()->success()->title('Voting closed')->send();
+                }),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -95,6 +95,8 @@ class UserResource extends Resource
                                 'server_owner_applications' => 'Server Owner Applications',
                                 'storage_browser' => 'Storage Browser (dl.defrag.racing)',
                                 'serverdemos_browser' => 'Serverdemos Browser',
+                                'serverdemo_validation' => 'Serverdemo Validation (reported records only)',
+                                'serverdemo_validator_applications' => 'Serverdemo Validator Applications',
                             ])
                             ->visible(fn (Forms\Get $get) => $get('is_moderator'))
                             ->columns(2),

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -702,6 +702,15 @@ class MapsController extends Controller
             ->with('onlinePlayers')
             ->get();
 
+        // Every online server, for the instant-play picker. Deliberately a
+        // second list: the one above is servers ALREADY running this map,
+        // which is the opposite of what you want when looking for somewhere
+        // to load it. Same query the Play Later list uses.
+        $onlineServers = \App\Models\Server::where('online', true)
+            ->where('visible', true)
+            ->with('onlinePlayers')
+            ->get();
+
         // Get public maplists that include this map
         $publicMaplists = \App\Models\Maplist::whereHas('maps', function($query) use ($map) {
                 $query->where('map_id', $map->id);
@@ -742,6 +751,7 @@ class MapsController extends Controller
             ->with('showOldtop', ($showOldtop === 'true'))
             ->with('showOffline', ($showOffline === 'true'))
             ->with('servers', $servers)
+            ->with('onlineServers', $onlineServers)
             ->with('publicMaplists', $publicMaplists)
             ->with('clusterMetaVq3', $clusterMetaVq3)
             ->with('clusterMetaCpm', $clusterMetaCpm)

--- a/app/Http/Controllers/RecordFlagController.php
+++ b/app/Http/Controllers/RecordFlagController.php
@@ -87,6 +87,13 @@ class RecordFlagController extends Controller
                 'note' => $notes,
             ]);
 
+            // A report the admin already cleared but that was short of the
+            // reporter threshold joins its case the moment it reaches it -
+            // the two conditions can be met in either order.
+            if ($existing->isReadyForValidators() && $existing->validation_case_id === null) {
+                app(\App\Services\ServerdemoValidationService::class)->attachToCase($existing);
+            }
+
             return back()->with('success', 'Flag added. ' . count($users) . ' users have flagged this.');
         }
 

--- a/app/Http/Controllers/ServerdemoValidationDownloadController.php
+++ b/app/Http/Controllers/ServerdemoValidationDownloadController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\RecordFlag;
+use App\Models\ServerDemo;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Hands a validator the ONE serverdemo they are entitled to.
+ *
+ * Deliberately different from StorageBrowserDownloadController: there the
+ * caller names a path and the permission decides whether they may read it.
+ * Here the caller names a REPORT, and the path is looked up from it - a
+ * validator can never ask for a demo, only for the demo of a report that was
+ * handed to them. There is no path parameter to tamper with.
+ *
+ * Three things must all hold, and they are checked on every hit rather than
+ * only when the link is minted:
+ * - the report was cleared by an admin and is still open,
+ * - this user is the one holding it, or it has been opened to everyone,
+ * - the run actually has a serverdemo.
+ */
+class ServerdemoValidationDownloadController extends Controller
+{
+    /** rclone mirrors /var/lib/serverdemos into this prefix of the bucket. */
+    private const B2_PREFIX = 'serverdemos/';
+
+    public function __invoke(Request $request, RecordFlag $flag)
+    {
+        $user = $request->user();
+        abort_unless($user?->hasModeratorPermission('serverdemo_validation'), 403);
+
+        // The gate. Without an admin clearing the report there is nothing to
+        // download, no matter who is asking.
+        abort_unless($flag->admin_cleared_at !== null, 403);
+
+        // Entitlement follows the CASE, not the individual report: a
+        // validator takes on a player and gets everything reported against
+        // them, which is the point of grouping in the first place.
+        $case = $flag->validationCase;
+        abort_if($case === null, 403);
+        abort_unless($case->isOpen() || $user->isAdmin(), 403);
+
+        $entitled = $user->isAdmin()
+            || $case->assigned_to_user_id === $user->id
+            || in_array($case->validation_stage, ['all_validators', 'admin'], true);
+        abort_unless($entitled, 403);
+
+        $demo = $flag->serverDemo();
+        abort_if($demo === null, 404);
+
+        $stream = $this->open($demo);
+        abort_unless(is_resource($stream), 404);
+
+        // Chunked and flushed: Octane/Swoole caps a single buffered body and
+        // answers 502 when a Content-Length accompanies chunked writes.
+        return response()->streamDownload(function () use ($stream) {
+            while (! feof($stream)) {
+                $chunk = fread($stream, 64 * 1024);
+                if ($chunk === false) {
+                    break;
+                }
+                echo $chunk;
+                flush();
+            }
+            fclose($stream);
+        }, basename($demo->path), [
+            'Content-Type' => 'application/octet-stream',
+            'X-Accel-Buffering' => 'no',
+        ]);
+    }
+
+    /**
+     * A serverdemo has two homes - the storage VPS and the B2 mirror - and
+     * `on_contabo` is a scheduled guess, so both are tried in the order it
+     * suggests rather than switched between.
+     */
+    private function open(ServerDemo $demo)
+    {
+        $candidates = $demo->on_contabo
+            ? [['serverdemos', $demo->path], ['serverdemos_b2', self::B2_PREFIX . $demo->path]]
+            : [['serverdemos_b2', self::B2_PREFIX . $demo->path], ['serverdemos', $demo->path]];
+
+        foreach ($candidates as [$disk, $path]) {
+            try {
+                $stream = Storage::disk($disk)->readStream($path);
+            } catch (\Throwable) {
+                $stream = null;
+            }
+
+            if (is_resource($stream)) {
+                return $stream;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/ServerdemoValidatorController.php
+++ b/app/Http/Controllers/ServerdemoValidatorController.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ServerdemoValidatorApplication;
+use App\Models\ServerdemoValidatorVote;
+use App\Models\ServerdemoValidatorVoteRound;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+/**
+ * Applications for the serverdemo validator position, and the vote that
+ * decides them.
+ *
+ * The page is public on purpose - it explains how reported runs get reviewed,
+ * and that is worth reading whether or not you intend to apply. Applying and
+ * voting need an account; voting additionally needs an application of your
+ * own, because the people doing this work pick who they work with.
+ */
+class ServerdemoValidatorController extends Controller
+{
+    /**
+     * Who may vote: anyone who put their name forward and was not turned
+     * down - including the people already doing the job. They know it best
+     * and have the most to lose by picking badly.
+     */
+    private const VOTER_STATUSES = ['pending', 'shortlisted', 'approved'];
+
+    /** Who is on the ballot: only people still seeking the position. */
+    private const CANDIDATE_STATUSES = ['pending', 'shortlisted'];
+
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $round = ServerdemoValidatorVoteRound::current();
+
+        $ownApplication = $user
+            ? ServerdemoValidatorApplication::where('user_id', $user->id)->latest()->first()
+            : null;
+
+        $canVote = $round !== null
+            && $ownApplication !== null
+            && in_array($ownApplication->status, self::VOTER_STATUSES, true);
+
+        $myVotes = $canVote
+            ? ServerdemoValidatorVote::where('round_id', $round->id)
+                ->where('voter_id', $user->id)
+                ->pluck('application_id')
+                ->all()
+            : [];
+
+        return Inertia::render('ServerdemoValidators', [
+            'application' => $ownApplication,
+            'applicantCount' => ServerdemoValidatorApplication::open()->count(),
+            'validators' => User::query()
+                ->where('is_moderator', true)
+                ->get()
+                ->filter(fn (User $u) => $u->hasModeratorPermission('serverdemo_validation') && ! $u->isAdmin())
+                ->map(fn (User $u) => ['id' => $u->id, 'name' => $u->name])
+                ->values(),
+
+            'voting' => [
+                'open' => $round !== null,
+                'title' => $round?->title,
+                'canVote' => $canVote,
+                'myVotes' => $myVotes,
+                // Tallies stay hidden while people are still voting - a
+                // running score turns a vote into a bandwagon.
+                'candidates' => $round === null ? [] : $this->candidates($user),
+            ],
+        ]);
+    }
+
+    /**
+     * Who is on the ballot: every live application except the viewer's own.
+     */
+    private function candidates(?User $user)
+    {
+        return ServerdemoValidatorApplication::with('user')
+            ->whereIn('status', self::CANDIDATE_STATUSES)
+            ->when($user, fn ($q) => $q->where('user_id', '!=', $user->id))
+            ->get()
+            ->map(fn (ServerdemoValidatorApplication $a) => [
+                'id' => $a->id,
+                'name' => $a->user?->name,
+                'user_id' => $a->user_id,
+                'motivation' => $a->motivation,
+                'experience' => $a->experience,
+                'availability' => $a->availability,
+            ])
+            ->values();
+    }
+
+    public function apply(Request $request)
+    {
+        $user = $request->user();
+
+        // One open application at a time. A rejected one may be replaced -
+        // people improve - but a pending one cannot be spammed.
+        if (ServerdemoValidatorApplication::where('user_id', $user->id)->open()->exists()) {
+            return back()->withErrors([
+                'motivation' => 'You already have an application in progress.',
+            ]);
+        }
+
+        $data = $request->validate([
+            'motivation' => ['required', 'string', 'min:60', 'max:4000'],
+            'experience' => ['nullable', 'string', 'max:4000'],
+            'availability' => ['nullable', 'string', 'max:255'],
+            'contact' => ['nullable', 'string', 'max:255'],
+        ], [
+            'motivation.min' => 'Tell us a bit more - a couple of sentences at least.',
+        ]);
+
+        ServerdemoValidatorApplication::create([
+            ...$data,
+            'user_id' => $user->id,
+            'status' => 'pending',
+        ]);
+
+        return back()->with('success', 'Your application has been submitted.');
+    }
+
+    /**
+     * Cast or take back a vote. Toggling rather than a separate delete route:
+     * the button in front of the user is one button.
+     */
+    public function vote(Request $request, ServerdemoValidatorApplication $application)
+    {
+        $user = $request->user();
+        $round = ServerdemoValidatorVoteRound::current();
+
+        if ($round === null) {
+            return back()->withErrors(['vote' => 'Voting is not open.']);
+        }
+
+        $own = ServerdemoValidatorApplication::where('user_id', $user->id)
+            ->whereIn('status', self::VOTER_STATUSES)
+            ->first();
+
+        if ($own === null) {
+            return back()->withErrors(['vote' => 'Only applicants vote in this round.']);
+        }
+
+        if ($application->user_id === $user->id) {
+            return back()->withErrors(['vote' => 'You cannot vote for yourself.']);
+        }
+
+        if (! in_array($application->status, self::CANDIDATE_STATUSES, true)) {
+            return back()->withErrors(['vote' => 'That application is not on the ballot.']);
+        }
+
+        $existing = ServerdemoValidatorVote::where('round_id', $round->id)
+            ->where('voter_id', $user->id)
+            ->where('application_id', $application->id)
+            ->first();
+
+        if ($existing) {
+            $existing->delete();
+            return back()->with('success', 'Vote taken back.');
+        }
+
+        ServerdemoValidatorVote::create([
+            'round_id' => $round->id,
+            'application_id' => $application->id,
+            'voter_id' => $user->id,
+        ]);
+
+        return back()->with('success', 'Vote cast.');
+    }
+}

--- a/app/Models/RecordFlag.php
+++ b/app/Models/RecordFlag.php
@@ -18,11 +18,15 @@ class RecordFlag extends Model
         'resolved_by_admin_id',
         'resolved_at',
         'admin_notes',
+        'admin_cleared_at',
+        'admin_cleared_by',
+        'validation_case_id',
     ];
 
     protected $casts = [
         'resolved_at' => 'datetime',
         'flagged_by_users' => 'array',
+        'admin_cleared_at' => 'datetime',
     ];
 
     public function record()
@@ -43,5 +47,57 @@ class RecordFlag extends Model
     public function resolver()
     {
         return $this->belongsTo(User::class, 'resolved_by_admin_id');
+    }
+
+    public function clearedBy()
+    {
+        return $this->belongsTo(User::class, 'admin_cleared_by');
+    }
+
+    /**
+     * The case this report was folded into - everything reported against the
+     * same player lives together, see ServerdemoValidationCase.
+     */
+    public function validationCase()
+    {
+        return $this->belongsTo(ServerdemoValidationCase::class, 'validation_case_id');
+    }
+
+    /**
+     * Enough different people reported this independently.
+     *
+     * `flag_count` is the accumulated total; one person reporting five times
+     * does not move it, which is what makes this worth checking at all.
+     */
+    public function hasEnoughReports(): bool
+    {
+        return $this->flag_count >= config('serverdemos.validation.min_reports', 2);
+    }
+
+    /** Cleared by the admin AND reported by enough people. Both, always. */
+    public function isReadyForValidators(): bool
+    {
+        return $this->admin_cleared_at !== null && $this->hasEnoughReports();
+    }
+
+    /**
+     * The serverdemo of the run this flag is about, or null when none was
+     * ever recorded. A flag with no serverdemo has nothing for a validator to
+     * look at, so it stays with the admin.
+     */
+    public function serverDemo(): ?ServerDemo
+    {
+        return $this->record ? ServerDemo::forRecord($this->record)->first() : null;
+    }
+
+    public function scopeAwaitingClearance($query)
+    {
+        return $query->whereNull('admin_cleared_at')->where('status', 'pending');
+    }
+
+    /** Cleared reports that were folded into a case. */
+    public function scopeInValidation($query)
+    {
+        return $query->whereNotNull('admin_cleared_at')->whereNotNull('validation_case_id');
     }
 }

--- a/app/Models/ServerdemoValidationCase.php
+++ b/app/Models/ServerdemoValidationCase.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Everything reported against one player, in one place.
+ *
+ * The ladder lives here rather than on the individual report: a validator
+ * takes on a player, not a run, and hands on the whole picture when they are
+ * unsure. See the migration for why the grouping is by MDD id.
+ */
+class ServerdemoValidationCase extends Model
+{
+    protected $table = 'serverdemo_validation_cases';
+
+    protected $fillable = [
+        'subject_mdd_id',
+        'subject_user_id',
+        'subject_name',
+        'kind',
+        'validation_stage',
+        'assigned_to_user_id',
+        'assigned_at',
+        'validators_seen',
+        'validation_outcome',
+        'validation_closed_at',
+    ];
+
+    protected $casts = [
+        'assigned_at' => 'datetime',
+        'validators_seen' => 'array',
+        'validation_closed_at' => 'datetime',
+    ];
+
+    public const KIND_SERVERDEMO = 'serverdemo';
+    public const KIND_PUBLIC_DEMO = 'public_demo';
+
+    public function flags()
+    {
+        return $this->hasMany(RecordFlag::class, 'validation_case_id');
+    }
+
+    public function comments()
+    {
+        return $this->hasMany(ServerdemoValidationComment::class, 'validation_case_id')->orderBy('created_at');
+    }
+
+    public function assignee()
+    {
+        return $this->belongsTo(User::class, 'assigned_to_user_id');
+    }
+
+    public function subjectUser()
+    {
+        return $this->belongsTo(User::class, 'subject_user_id');
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->validation_closed_at === null;
+    }
+
+    /** What to call this player on screen, best identifier first. */
+    public function subjectLabel(): string
+    {
+        if ($this->subject_name) {
+            return $this->subject_name;
+        }
+
+        if ($this->subject_mdd_id) {
+            return 'MDD #' . $this->subject_mdd_id;
+        }
+
+        return $this->subjectUser?->name ?? 'unknown player';
+    }
+
+    public function scopeOpen($query)
+    {
+        return $query->whereNull('validation_closed_at');
+    }
+}

--- a/app/Models/ServerdemoValidationComment.php
+++ b/app/Models/ServerdemoValidationComment.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ServerdemoValidationComment extends Model
+{
+    protected $fillable = [
+        'validation_case_id',
+        'record_flag_id',
+        'user_id',
+        'body',
+        'event',
+    ];
+
+    public function validationCase()
+    {
+        return $this->belongsTo(ServerdemoValidationCase::class, 'validation_case_id');
+    }
+
+    /** Kept for the notes written before comments moved onto the case. */
+    public function flag()
+    {
+        return $this->belongsTo(RecordFlag::class, 'record_flag_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ServerdemoValidatorApplication.php
+++ b/app/Models/ServerdemoValidatorApplication.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ServerdemoValidatorApplication extends Model
+{
+    /**
+     * Deleting hides an application, it does not destroy it. Rejecting is the
+     * decision and stays on the record; deleting only clears the row out of
+     * the way so the person may apply again. Both facts survive - see the
+     * migration that added this.
+     */
+    use SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'motivation',
+        'experience',
+        'availability',
+        'contact',
+        'status',
+        'reviewed_by',
+        'reviewed_at',
+        'review_note',
+    ];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function reviewer()
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    public function scopePending($query)
+    {
+        return $query->where('status', 'pending');
+    }
+
+    /**
+     * An application still in play - the applicant should not be able to send
+     * a second one while the first is being considered or has been accepted.
+     */
+    public function scopeOpen($query)
+    {
+        return $query->whereIn('status', ['pending', 'shortlisted', 'approved']);
+    }
+}

--- a/app/Models/ServerdemoValidatorVote.php
+++ b/app/Models/ServerdemoValidatorVote.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ServerdemoValidatorVote extends Model
+{
+    protected $fillable = ['round_id', 'application_id', 'voter_id'];
+
+    public function round()
+    {
+        return $this->belongsTo(ServerdemoValidatorVoteRound::class, 'round_id');
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(ServerdemoValidatorApplication::class, 'application_id');
+    }
+
+    public function voter()
+    {
+        return $this->belongsTo(User::class, 'voter_id');
+    }
+}

--- a/app/Models/ServerdemoValidatorVoteRound.php
+++ b/app/Models/ServerdemoValidatorVoteRound.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ServerdemoValidatorVoteRound extends Model
+{
+    protected $fillable = ['title', 'opened_at', 'closed_at', 'opened_by'];
+
+    protected $casts = [
+        'opened_at' => 'datetime',
+        'closed_at' => 'datetime',
+    ];
+
+    public function votes()
+    {
+        return $this->hasMany(ServerdemoValidatorVote::class, 'round_id');
+    }
+
+    public function opener()
+    {
+        return $this->belongsTo(User::class, 'opened_by');
+    }
+
+    /** The round people can vote in right now, if there is one. */
+    public static function current(): ?self
+    {
+        return static::whereNull('closed_at')->latest('opened_at')->first();
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->closed_at === null;
+    }
+}

--- a/app/Services/ServerdemoValidationService.php
+++ b/app/Services/ServerdemoValidationService.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\RecordFlag;
+use App\Models\ServerdemoValidationCase;
+use App\Models\ServerdemoValidationComment;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Groups reports by player and walks the resulting case along the ladder.
+ *
+ * Two rules shape everything here.
+ *
+ * A report goes nowhere until an admin has cleared it as not-false. Without
+ * that, one person with a grudge could push demos in front of moderators just
+ * by reporting a lot of runs.
+ *
+ * And a cleared report joins the OPEN CASE for that player rather than
+ * starting its own. Somebody who cheats does it on many maps; reviewing that
+ * as many separate rows is more work and worse work, because the pattern
+ * across the runs is usually the evidence.
+ *
+ * The ladder only ever widens - one validator, a second, everyone, the admin.
+ * Each step means the last person said they were unsure, so handing it back
+ * to them would loop forever.
+ */
+class ServerdemoValidationService
+{
+    /**
+     * Everyone who may validate. Admins hold every permission implicitly, so
+     * they are filtered back out: the admin is the last rung of the ladder,
+     * not a candidate for the first.
+     */
+    public function validators(): Collection
+    {
+        return User::query()
+            ->where('is_moderator', true)
+            ->get()
+            ->filter(fn (User $user) => $user->hasModeratorPermission('serverdemo_validation') && ! $user->isAdmin())
+            ->values();
+    }
+
+    /**
+     * Admin says this is not a false report. Only then does it join a case -
+     * and only if enough different people reported it.
+     */
+    public function clear(RecordFlag $flag, User $admin, ?string $note = null): ?ServerdemoValidationCase
+    {
+        $flag->admin_cleared_at = now();
+        $flag->admin_cleared_by = $admin->id;
+        $flag->save();
+
+        if (! $flag->hasEnoughReports()) {
+            return null;
+        }
+
+        return $this->attachToCase($flag, $admin, $note);
+    }
+
+    /**
+     * Put a cleared report into the open case for that player, opening one if
+     * there is none. A case that has been closed is left alone - a new report
+     * after a verdict deserves a fresh look, not a reopened argument.
+     */
+    public function attachToCase(RecordFlag $flag, ?User $actor = null, ?string $note = null): ?ServerdemoValidationCase
+    {
+        $subject = $this->subjectOf($flag);
+
+        if ($subject === null) {
+            return null;
+        }
+
+        $kind = $flag->demo_id
+            ? ServerdemoValidationCase::KIND_PUBLIC_DEMO
+            : ServerdemoValidationCase::KIND_SERVERDEMO;
+
+        $case = ServerdemoValidationCase::query()
+            ->open()
+            ->where('kind', $kind)
+            ->where(function ($query) use ($subject) {
+                if ($subject['mdd_id']) {
+                    $query->where('subject_mdd_id', $subject['mdd_id']);
+                } elseif ($subject['user_id']) {
+                    $query->where('subject_user_id', $subject['user_id']);
+                } else {
+                    $query->where('subject_name', $subject['name']);
+                }
+            })
+            ->first();
+
+        $isNew = $case === null;
+
+        if ($isNew) {
+            $case = ServerdemoValidationCase::create([
+                'subject_mdd_id' => $subject['mdd_id'],
+                'subject_user_id' => $subject['user_id'],
+                'subject_name' => $subject['name'],
+                'kind' => $kind,
+            ]);
+        }
+
+        $flag->validation_case_id = $case->id;
+        $flag->save();
+
+        if ($isNew) {
+            $this->log($case, $actor, 'opened', $note ?: 'Case opened.');
+            $this->assignNext($case, $actor);
+        } else {
+            $this->log($case, $actor, 'added', 'Another cleared report was added to this case.');
+        }
+
+        return $case;
+    }
+
+    /**
+     * Who a report is about. MDD id first - it comes from the game and
+     * survives nickname changes.
+     */
+    private function subjectOf(RecordFlag $flag): ?array
+    {
+        if ($flag->demo_id && $flag->demo) {
+            return [
+                'mdd_id' => null,
+                'user_id' => $flag->demo->user_id,
+                'name' => $flag->demo->player_name ?: $flag->demo->q3df_login_name,
+            ];
+        }
+
+        if ($flag->record) {
+            return [
+                'mdd_id' => $flag->record->mdd_id ?: null,
+                'user_id' => $flag->record->user_id,
+                'name' => $flag->record->name,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Hand the case to a validator who has not held it yet.
+     *
+     * Random rather than a rotation: a predictable order tells a reported
+     * player who is about to look at their runs.
+     */
+    public function assignNext(ServerdemoValidationCase $case, ?User $actor = null): ?User
+    {
+        $seen = collect($case->validators_seen ?? []);
+        $candidate = $this->validators()
+            ->reject(fn (User $user) => $seen->contains($user->id))
+            ->shuffle()
+            ->first();
+
+        // Nobody left who has not already passed - that is what the
+        // everyone-at-once stage is for.
+        if (! $candidate) {
+            $this->escalateToAll($case, $actor);
+            return null;
+        }
+
+        $case->assigned_to_user_id = $candidate->id;
+        $case->assigned_at = now();
+        $case->validation_stage = $seen->isEmpty()
+            ? 'assigned'
+            : 'second_opinion';
+        $case->validators_seen = $seen->push($candidate->id)->unique()->values()->all();
+        $case->save();
+
+        $this->log($case, $actor, 'assigned', "Assigned to {$candidate->name}.");
+
+        return $candidate;
+    }
+
+    /**
+     * The current validator is unsure and passes it on. The note is required:
+     * the next person needs to know what has already been looked at.
+     */
+    public function handOver(ServerdemoValidationCase $case, User $from, string $note): ?User
+    {
+        $this->log($case, $from, 'handover', $note);
+
+        return $this->assignNext($case, $from);
+    }
+
+    /** Open it to every validator at once; nobody owns it any more. */
+    public function escalateToAll(ServerdemoValidationCase $case, ?User $actor = null, ?string $note = null): void
+    {
+        $case->assigned_to_user_id = null;
+        $case->validation_stage = 'all_validators';
+        $case->save();
+
+        $this->log($case, $actor, 'escalated_all', $note ?: 'Opened to all validators - agree on a verdict here.');
+    }
+
+    /** Last rung: the validators could not agree and the admin decides. */
+    public function callAdmin(ServerdemoValidationCase $case, User $actor, ?string $note = null): void
+    {
+        $case->assigned_to_user_id = null;
+        $case->validation_stage = 'admin';
+        $case->save();
+
+        $this->log($case, $actor, 'called_admin', $note ?: 'Escalated to the admin.');
+    }
+
+    /**
+     * Close the case. This does not touch the reports' own `status`, which
+     * stays the admin's decision on each report.
+     */
+    public function close(ServerdemoValidationCase $case, User $actor, string $outcome, ?string $note = null): void
+    {
+        $case->validation_outcome = $outcome;
+        $case->validation_closed_at = now();
+        $case->assigned_to_user_id = null;
+        $case->save();
+
+        $this->log($case, $actor, 'closed', $note ?: "Case closed as {$outcome}.");
+    }
+
+    public function log(ServerdemoValidationCase $case, ?User $user, ?string $event, string $body): void
+    {
+        ServerdemoValidationComment::create([
+            'validation_case_id' => $case->id,
+            'user_id' => $user?->id,
+            'body' => $body,
+            'event' => $event,
+        ]);
+    }
+}

--- a/config/serverdemos.php
+++ b/config/serverdemos.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report validation
+    |--------------------------------------------------------------------------
+    |
+    | A flagged record only reaches the validator moderators once an admin has
+    | cleared it AND enough different people have reported it independently.
+    |
+    | The threshold is deliberately NOT shown anywhere on the public site. If
+    | it were, one person with two accounts would know exactly how far to go,
+    | and the point of the number is that reporting takes more than one person.
+    |
+    */
+
+    'validation' => [
+
+        // Independent reporters required before a cleared flag is handed to a
+        // validator. Admin clearance is still required on top of this - the
+        // two conditions are AND, never OR.
+        'min_reports' => (int) env('SERVERDEMO_VALIDATION_MIN_REPORTS', 2),
+
+        // Only this account may clear reports for validation, no matter how
+        // many admins exist. Set to null to let any admin do it.
+        'clearing_admin_id' => (int) env('SERVERDEMO_VALIDATION_ADMIN_ID', 8),
+
+    ],
+
+];

--- a/database/migrations/2026_08_03_010000_create_serverdemo_validator_applications_table.php
+++ b/database/migrations/2026_08_03_010000_create_serverdemo_validator_applications_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Applications for the serverdemo validator position.
+ *
+ * Step one of becoming a validator: anyone may apply. Step two is a vote
+ * among the applicants themselves, which happens off-site for now - this
+ * table only has to record who put their name forward and what came of it.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('serverdemo_validator_applications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+            $table->text('motivation');
+            $table->text('experience')->nullable();
+            // Free text on purpose: "evenings CET", "weekends", whatever the
+            // applicant wants to promise. Nothing reads it programmatically.
+            $table->string('availability')->nullable();
+            $table->string('contact')->nullable();
+
+            // pending -> shortlisted (survived the vote) -> approved | rejected
+            $table->string('status')->default('pending');
+            $table->foreignId('reviewed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->text('review_note')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['status', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('serverdemo_validator_applications');
+    }
+};

--- a/database/migrations/2026_08_03_010100_add_validation_workflow_to_record_flags_table.php
+++ b/database/migrations/2026_08_03_010100_add_validation_workflow_to_record_flags_table.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The gate and the escalation ladder for serverdemo validation.
+ *
+ * Nothing reaches a validator on its own. A flag has to be cleared by the
+ * admin first - without that, mass-reporting by one troll would push demos in
+ * front of moderators automatically, which is the whole thing this prevents.
+ *
+ * After clearing, a flag walks up a ladder: one validator, then a second one
+ * they hand it to, then all of them, then the admin. Each step is a wider
+ * audience, never a narrower one, so `validation_stage` only moves forwards.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('record_flags', function (Blueprint $table) {
+            // The gate. Null means no validator can see this flag at all.
+            $table->timestamp('admin_cleared_at')->nullable()->after('admin_notes');
+            $table->unsignedBigInteger('admin_cleared_by')->nullable()->after('admin_cleared_at');
+
+            // none -> assigned -> second_opinion -> all_validators -> admin
+            $table->string('validation_stage')->default('none')->after('admin_cleared_by');
+            $table->unsignedBigInteger('assigned_to_user_id')->nullable()->after('validation_stage');
+            $table->timestamp('assigned_at')->nullable()->after('assigned_to_user_id');
+
+            // Who has held this flag already, so passing it on cannot hand it
+            // back to someone who has already said they are unsure.
+            $table->json('validators_seen')->nullable()->after('assigned_at');
+
+            // upheld | dismissed | inconclusive, set by whoever closes it
+            $table->string('validation_outcome')->nullable()->after('validators_seen');
+            $table->timestamp('validation_closed_at')->nullable()->after('validation_outcome');
+
+            $table->foreign('admin_cleared_by')->references('id')->on('users')->nullOnDelete();
+            $table->foreign('assigned_to_user_id')->references('id')->on('users')->nullOnDelete();
+
+            $table->index(['validation_stage', 'assigned_to_user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('record_flags', function (Blueprint $table) {
+            $table->dropForeign(['admin_cleared_by']);
+            $table->dropForeign(['assigned_to_user_id']);
+            $table->dropIndex(['validation_stage', 'assigned_to_user_id']);
+            $table->dropColumn([
+                'admin_cleared_at',
+                'admin_cleared_by',
+                'validation_stage',
+                'assigned_to_user_id',
+                'assigned_at',
+                'validators_seen',
+                'validation_outcome',
+                'validation_closed_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_08_03_010200_create_serverdemo_validation_comments_table.php
+++ b/database/migrations/2026_08_03_010200_create_serverdemo_validation_comments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Internal notes validators leave each other on a flagged record.
+ *
+ * Never public and never shown to the reporter or the player being reported -
+ * this is where "I am not sure, the strafe at 0:14 looks off" lives, and it
+ * has to be readable by whoever the flag gets handed to next.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('record_flag_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('body');
+            // Marks the automatic entries - handed over, escalated, closed -
+            // so the thread reads as a history and not just as chat.
+            $table->string('event')->nullable();
+            $table->timestamps();
+
+            $table->index(['record_flag_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('serverdemo_validation_comments');
+    }
+};

--- a/database/migrations/2026_08_03_020000_create_serverdemo_validator_voting_tables.php
+++ b/database/migrations/2026_08_03_020000_create_serverdemo_validator_voting_tables.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Step two: the applicants vote on each other.
+ *
+ * A round is explicit rather than a date range so the admin decides when
+ * people can vote, and so a second round can be run later without touching
+ * the first one's ballots.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('serverdemo_validator_vote_rounds', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->timestamp('opened_at');
+            $table->timestamp('closed_at')->nullable();
+            $table->foreignId('opened_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('serverdemo_validator_votes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('round_id')->constrained('serverdemo_validator_vote_rounds')->cascadeOnDelete();
+            $table->foreignId('application_id')->constrained('serverdemo_validator_applications')->cascadeOnDelete();
+            $table->foreignId('voter_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            // One ballot per voter per candidate per round. The database
+            // enforces it so a double-clicked button cannot count twice.
+            $table->unique(['round_id', 'application_id', 'voter_id'], 'validator_vote_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('serverdemo_validator_votes');
+        Schema::dropIfExists('serverdemo_validator_vote_rounds');
+    }
+};

--- a/database/migrations/2026_08_03_030000_add_soft_deletes_to_serverdemo_validator_applications.php
+++ b/database/migrations/2026_08_03_030000_add_soft_deletes_to_serverdemo_validator_applications.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Deleting an application hides it; it never destroys it.
+ *
+ * Rejecting and deleting are deliberately two different acts. A rejection is
+ * the decision and stays on the record forever. Deleting only clears the row
+ * out of the way so the person can put their name forward again later - the
+ * row itself, and the fact that they were once turned down, remains.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('serverdemo_validator_applications', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('serverdemo_validator_applications', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_08_03_040000_create_serverdemo_validation_cases.php
+++ b/database/migrations/2026_08_03_040000_create_serverdemo_validation_cases.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * One case per reported PLAYER, not per reported run.
+ *
+ * Somebody who cheats does it on ten maps, and reviewing that as ten
+ * unrelated rows is both ten times the work and worse work: the pattern
+ * across the runs is usually the evidence. So the flags accumulate into a
+ * case, and the case is what gets assigned, discussed and escalated.
+ *
+ * Identity is the MDD id where there is one - it comes from the game and
+ * survives nickname changes. A site account and a display name are kept
+ * alongside it for the cases where it is missing.
+ *
+ * Serverdemo cases and uploaded-demo cases are kept apart even for the same
+ * player: the evidence is private in one and public in the other, and mixing
+ * them into one thread would put both under the stricter rules for no reason.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('serverdemo_validation_cases', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('subject_mdd_id')->nullable()->index();
+            $table->unsignedBigInteger('subject_user_id')->nullable()->index();
+            $table->string('subject_name')->nullable();
+
+            // serverdemo | public_demo
+            $table->string('kind')->default('serverdemo');
+
+            // assigned -> second_opinion -> all_validators -> admin
+            $table->string('validation_stage')->default('assigned');
+            $table->unsignedBigInteger('assigned_to_user_id')->nullable();
+            $table->timestamp('assigned_at')->nullable();
+            $table->json('validators_seen')->nullable();
+
+            $table->string('validation_outcome')->nullable();
+            $table->timestamp('validation_closed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('subject_user_id')->references('id')->on('users')->nullOnDelete();
+            $table->foreign('assigned_to_user_id')->references('id')->on('users')->nullOnDelete();
+
+            $table->index(['kind', 'validation_stage']);
+            $table->index(['validation_closed_at']);
+        });
+
+        Schema::table('record_flags', function (Blueprint $table) {
+            $table->unsignedBigInteger('validation_case_id')->nullable()->after('admin_cleared_by')->index();
+            $table->foreign('validation_case_id')->references('id')->on('serverdemo_validation_cases')->nullOnDelete();
+        });
+
+        // Comments belong to the case now - the whole point is that the
+        // validators talk about the player, not about one run at a time.
+        Schema::table('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->unsignedBigInteger('validation_case_id')->nullable()->after('id')->index();
+            $table->foreign('validation_case_id')->references('id')->on('serverdemo_validation_cases')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->dropForeign(['validation_case_id']);
+            $table->dropColumn('validation_case_id');
+        });
+
+        Schema::table('record_flags', function (Blueprint $table) {
+            $table->dropForeign(['validation_case_id']);
+            $table->dropColumn('validation_case_id');
+        });
+
+        Schema::dropIfExists('serverdemo_validation_cases');
+    }
+};

--- a/database/migrations/2026_08_03_040100_make_validation_comment_flag_nullable.php
+++ b/database/migrations/2026_08_03_040100_make_validation_comment_flag_nullable.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Notes hang on the case now, not on one report.
+ *
+ * The column stays for the handful written before the move and for anything
+ * that ever wants to point at a single run, but it can no longer be required
+ * - a note about a player is not a note about any one of their runs.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->dropForeign(['record_flag_id']);
+        });
+
+        Schema::table('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->unsignedBigInteger('record_flag_id')->nullable()->change();
+            $table->foreign('record_flag_id')->references('id')->on('record_flags')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->dropForeign(['record_flag_id']);
+        });
+
+        Schema::table('serverdemo_validation_comments', function (Blueprint $table) {
+            $table->unsignedBigInteger('record_flag_id')->nullable(false)->change();
+            $table->foreign('record_flag_id')->references('id')->on('record_flags')->cascadeOnDelete();
+        });
+    }
+};

--- a/resources/js/Components/InstantPlayConfirm.vue
+++ b/resources/js/Components/InstantPlayConfirm.vue
@@ -1,0 +1,96 @@
+<script setup>
+/**
+ * Confirmation step between picking a server and being dropped onto it.
+ *
+ * Shared by the map detail page and the Play Later list so both describe the
+ * same thing the same way - the server you are about to join, whether anyone
+ * is already on it, and the exact callvote that will be waiting on the
+ * clipboard.
+ */
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+    show: Boolean,
+    server: Object,
+    mapName: String,
+});
+
+const emit = defineEmits(['close']);
+
+const copied = ref(false);
+
+const command = computed(() => `/cv map ${props.mapName}`);
+
+const playerCount = computed(() => props.server?.online_players?.length || 0);
+
+/**
+ * Copy first, connect second. The clipboard write is asynchronous and
+ * navigating away can cancel it, which would land you on the server with
+ * nothing to paste - the one thing this exists to prevent.
+ */
+const connect = async () => {
+    if (!props.server) {
+        return;
+    }
+
+    try {
+        await navigator.clipboard.writeText(command.value);
+        copied.value = true;
+    } catch (error) {
+        console.error('Failed to copy the callvote command:', error);
+    }
+
+    window.location.href = `defrag://${props.server.ip}:${props.server.port}`;
+
+    setTimeout(() => {
+        copied.value = false;
+        emit('close');
+    }, 1500);
+};
+</script>
+
+<template>
+    <!-- Teleported: the page's transformed and overflow-hidden containers
+         would otherwise clip this or trap it behind later sections. -->
+    <Teleport to="body">
+        <div v-if="show" class="fixed inset-0 z-[200] flex items-center justify-center p-4" @click.self="emit('close')">
+            <div class="fixed inset-0 bg-black/60"></div>
+
+            <div class="relative bg-gray-900 border border-white/10 rounded-2xl shadow-2xl max-w-md w-full p-6">
+                <h3 class="text-lg font-bold text-white mb-1">Connect and load the map?</h3>
+                <p class="text-sm text-gray-500 mb-4">{{ mapName }}</p>
+
+                <div class="bg-white/5 border border-white/10 rounded-lg p-3 mb-4">
+                    <span v-html="q3tohtml(server?.name)" class="font-semibold block"></span>
+                    <div class="text-xs text-gray-500 mt-1">
+                        {{ server?.ip }}:{{ server?.port }}
+                        <span v-if="server?.location"> - {{ server.location }}</span>
+                    </div>
+                    <div v-if="playerCount > 0" class="text-xs text-yellow-400 mt-2">
+                        {{ playerCount }} {{ playerCount === 1 ? 'player is' : 'players are' }} on this server - your callvote may not pass.
+                    </div>
+                </div>
+
+                <p class="text-gray-300 text-sm mb-2">
+                    The game opens and this lands on your clipboard, ready to paste into the console:
+                </p>
+                <code class="block bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-sm text-green-400 mb-4 break-all">{{ command }}</code>
+
+                <div class="flex gap-3">
+                    <button
+                        @click="connect"
+                        class="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-semibold rounded-xl transition-colors"
+                    >
+                        {{ copied ? 'Copied - connecting...' : 'Copy and connect' }}
+                    </button>
+                    <button
+                        @click="emit('close')"
+                        class="flex-1 px-4 py-2.5 bg-white/5 hover:bg-white/10 text-gray-300 font-semibold rounded-xl border border-white/10 transition-colors"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    </Teleport>
+</template>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -10,6 +10,7 @@
     import Dropdown from '@/Components/Laravel/Dropdown.vue';
     import AddToMaplistModal from '@/Components/Maplists/AddToMaplistModal.vue';
     import CopyButton from '@/Components/Basic/CopyButton.vue';
+    import InstantPlayConfirm from '@/Components/InstantPlayConfirm.vue';
     import { watchEffect, watch, ref, onMounted, onUnmounted, computed } from 'vue';
     import { useClipboard } from '@/Composables/useClipboard';
     import axios from 'axios';
@@ -221,6 +222,12 @@
         my_vq3_record: Object,
         gametypeStats: Object,
         servers: Array,
+        // Every online server, not just the ones already running this map -
+        // that is what the instant-play picker needs.
+        onlineServers: {
+            type: Array,
+            default: () => []
+        },
         publicMaplists: {
             type: Array,
             default: () => []
@@ -253,6 +260,81 @@
 
     const page = usePage();
     localIsNsfw.value = props.map.is_nsfw;
+
+    // --- Instant play -----------------------------------------------------
+    // Pick a server, confirm, and the callvote for this map is on the
+    // clipboard by the time the game window is up. Same idea as the Play
+    // Later list, with a confirmation step because here it is a single map
+    // and one wrong click drops you onto someone else's server.
+    const instantPlayOpen = ref(false);
+    const instantPlayShowAll = ref(false);
+    const instantPlayServer = ref(null);
+    const instantPlayConfirm = ref(false);
+
+    // The dropdown is teleported to body and positioned by hand. Left in the
+    // page it rendered UNDER the records panel below it: z-index only orders
+    // siblings within a stacking context, and the button sits in one that the
+    // records section outranks, so no value of z would have lifted it out.
+    const instantPlayAnchor = ref(null);
+    const instantPlayStyle = ref({});
+
+    const positionInstantPlay = () => {
+        const el = instantPlayAnchor.value;
+        if (!el) return;
+
+        const rect = el.getBoundingClientRect();
+        const width = Math.min(320, window.innerWidth - 16);
+        // Keep it on screen when the button sits near the right edge.
+        const left = Math.max(8, Math.min(rect.left, window.innerWidth - width - 8));
+
+        instantPlayStyle.value = {
+            position: 'fixed',
+            top: `${rect.bottom + 8}px`,
+            left: `${left}px`,
+            width: `${width}px`,
+        };
+    };
+
+    const toggleInstantPlay = () => {
+        instantPlayOpen.value = !instantPlayOpen.value;
+        if (instantPlayOpen.value) {
+            positionInstantPlay();
+        }
+    };
+
+    // Fixed coordinates are a snapshot, so they have to be retaken while the
+    // list is open or it would hang in mid-air once the page moves.
+    const repositionInstantPlay = () => {
+        if (instantPlayOpen.value) {
+            positionInstantPlay();
+        }
+    };
+
+    onMounted(() => {
+        window.addEventListener('scroll', repositionInstantPlay, true);
+        window.addEventListener('resize', repositionInstantPlay);
+    });
+
+    onUnmounted(() => {
+        window.removeEventListener('scroll', repositionInstantPlay, true);
+        window.removeEventListener('resize', repositionInstantPlay);
+    });
+
+    const instantPlayEmptyServers = computed(() =>
+        (props.onlineServers || [])
+            .filter(s => !s.online_players || s.online_players.length === 0)
+            .sort((a, b) => (a.plain_name || '').localeCompare(b.plain_name || ''))
+    );
+
+    const instantPlayList = computed(() =>
+        instantPlayShowAll.value ? (props.onlineServers || []) : instantPlayEmptyServers.value
+    );
+
+    const pickInstantPlayServer = (server) => {
+        instantPlayServer.value = server;
+        instantPlayOpen.value = false;
+        instantPlayConfirm.value = true;
+    };
 
     const dateColWidth = computed(() => {
         const fmt = page.props.dateFormat;
@@ -1296,6 +1378,62 @@
                                 <span class="bg-white/20 px-1.5 py-0.5 rounded text-[10px] whitespace-nowrap">{{ server.online_players.length }} playing</span>
                             </a>
                         </div>
+
+                        <!-- Instant Play: pick a server, load this map there -->
+                        <div v-if="onlineServers && onlineServers.length > 0" ref="instantPlayAnchor">
+                            <button
+                                @click="toggleInstantPlay"
+                                class="flex items-center gap-1.5 bg-blue-600/80 hover:bg-blue-600 text-white font-medium px-3 py-1.5 rounded-md transition-all text-xs hover:shadow-md"
+                                title="Pick a server and load this map there"
+                            >
+                                <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                                    <path d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z"/>
+                                </svg>
+                                <span class="whitespace-nowrap">Instant Play</span>
+                                <svg class="w-3 h-3 transition-transform" :class="{ 'rotate-180': instantPlayOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                                </svg>
+                            </button>
+
+                            <Teleport to="body">
+                                <!-- Catches the click that closes the list -->
+                                <div v-if="instantPlayOpen" class="fixed inset-0 z-[190]" @click="instantPlayOpen = false"></div>
+
+                                <div v-if="instantPlayOpen" :style="instantPlayStyle" class="z-[200] bg-gray-900 border border-white/15 rounded-lg overflow-hidden shadow-2xl shadow-black/60">
+                                    <div class="px-4 py-2.5 border-b border-white/10 flex items-center justify-between bg-gray-800/80">
+                                        <span class="text-xs font-bold text-gray-300 uppercase tracking-wider">
+                                            {{ instantPlayShowAll ? 'All servers' : 'Empty servers' }}
+                                        </span>
+                                        <button @click.stop="instantPlayShowAll = !instantPlayShowAll" class="text-xs text-blue-400 hover:text-blue-300 font-medium">
+                                            {{ instantPlayShowAll ? 'Empty only' : 'Show all servers' }}
+                                        </button>
+                                    </div>
+                                    <div class="max-h-64 overflow-y-auto">
+                                        <div
+                                            v-for="server in instantPlayList"
+                                            :key="server.id"
+                                            @click="pickInstantPlayServer(server)"
+                                            class="px-4 py-3 hover:bg-blue-500/15 cursor-pointer transition border-b border-white/5 last:border-0"
+                                        >
+                                            <div class="flex items-center justify-between gap-3">
+                                                <div class="min-w-0">
+                                                    <span v-html="q3tohtml(server.name)" class="font-semibold truncate block text-sm"></span>
+                                                    <div class="text-xs text-gray-500 mt-0.5">
+                                                        {{ server.ip }}:{{ server.port }}
+                                                        <span v-if="server.location"> - {{ server.location }}</span>
+                                                    </div>
+                                                </div>
+                                                <span v-if="server.online_players && server.online_players.length > 0" class="text-yellow-400 text-xs font-bold flex-shrink-0 px-2 py-0.5 bg-yellow-500/15 rounded">{{ server.online_players.length }} playing</span>
+                                                <span v-else class="text-gray-500 text-xs font-bold flex-shrink-0 px-2 py-0.5 bg-white/5 rounded">EMPTY</span>
+                                            </div>
+                                        </div>
+                                        <div v-if="instantPlayList.length === 0" class="px-4 py-6 text-center text-gray-500 text-sm">
+                                            No empty servers available right now
+                                        </div>
+                                    </div>
+                                </div>
+                            </Teleport>
+                        </div>
                     </div>
 
                     <!-- Tags Section -->
@@ -2120,6 +2258,13 @@
                 <div class="border-t border-white/10 mt-1 pt-1">Score: <span class="text-yellow-400 font-bold">{{ scoreTooltip.score }}</span></div>
             </div>
         </Teleport>
+
+        <InstantPlayConfirm
+            :show="instantPlayConfirm"
+            :server="instantPlayServer"
+            :map-name="map.name"
+            @close="instantPlayConfirm = false"
+        />
     </div>
 </template>
 

--- a/resources/js/Pages/Maplists/Show.vue
+++ b/resources/js/Pages/Maplists/Show.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { Head, Link, router } from '@inertiajs/vue3';
 import MapCard from '@/Components/MapCard.vue';
 import DialogModal from '@/Components/Laravel/DialogModal.vue';
@@ -45,8 +45,49 @@ const editForm = ref({
 });
 const saving = ref(false);
 const showPublicConfirmation = ref(false);
-const copiedMapId = ref(null);
 const showServerDropdown = ref(false);
+const copiedMapId = ref(null);
+
+/**
+ * Copy the callvote, then open the game. No confirmation step: the server was
+ * already chosen deliberately in step one, so there is nothing here to click
+ * by mistake - unlike the map page, where the server is picked by the same
+ * click that connects you.
+ *
+ * Copy first, connect second. The clipboard write is asynchronous and
+ * navigating away can cancel it, which would drop you onto the server with
+ * nothing to paste.
+ */
+const copyAndConnect = async (map) => {
+    const server = selectedServer.value;
+    if (!server) {
+        return;
+    }
+
+    try {
+        await navigator.clipboard.writeText(`/cv map ${map.name}`);
+        copiedMapId.value = map.id;
+    } catch (error) {
+        console.error('Failed to copy the callvote command:', error);
+    }
+
+    window.location.href = `defrag://${server.ip}:${server.port}`;
+
+    setTimeout(() => {
+        copiedMapId.value = null;
+    }, 2000);
+};
+
+// The grid renders `maps`, a local copy that drag-and-drop reordering needs to
+// mutate freely. Without this, a `router.reload()` after removing a map brings
+// fresh props in and the copy keeps showing the map that is already gone -
+// removal looked like it had done nothing until the page was loaded again.
+// Skipped mid-reorder, where the local order is the one being edited.
+watch(() => props.maplist.maps, (fresh) => {
+    if (!isReordering.value) {
+        maps.value = [...(fresh || [])];
+    }
+});
 
 const isPlayLater = computed(() => props.maplist.is_play_later);
 
@@ -152,22 +193,6 @@ const removeMap = async (mapId) => {
         console.error('Error removing map:', error);
         alert('Failed to remove map');
     }
-};
-
-const connectToServer = (map) => {
-    if (!selectedServer.value) {
-        alert('Please select a server first');
-        return;
-    }
-
-    const server = selectedServer.value;
-    const callvoteCommand = `callvote map ${map.name}`;
-
-    // Copy callvote command to clipboard
-    navigator.clipboard.writeText(callvoteCommand).then(() => {
-        // Trigger defrag:// protocol to connect
-        window.location.href = `defrag://${server.address}:${server.port}`;
-    });
 };
 
 const toggleReordering = () => {
@@ -352,18 +377,6 @@ const saveEdits = async () => {
         }
     } finally {
         saving.value = false;
-    }
-};
-
-const copyMapCommand = async (mapId, mapName) => {
-    try {
-        await navigator.clipboard.writeText(`/cv map ${mapName}`);
-        copiedMapId.value = mapId;
-        setTimeout(() => {
-            copiedMapId.value = null;
-        }, 2000);
-    } catch (error) {
-        console.error('Failed to copy to clipboard:', error);
     }
 };
 
@@ -712,6 +725,23 @@ const closeServerDropdown = () => {
                         </div>
                         <!-- Play Wizard (for Play Later only) -->
                         <div v-if="isPlayLater && servers && servers.length > 0" class="mt-5 pt-5 border-t border-white/10 relative z-30" @click.stop>
+                            <!-- Summary: what is queued and where it can go -->
+                            <div class="flex flex-wrap items-center gap-2 mb-4">
+                                <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-blue-500/15 border border-blue-400/30 text-blue-300 text-xs font-bold">
+                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                                    </svg>
+                                    {{ maps.length }} {{ maps.length === 1 ? 'map queued' : 'maps queued' }}
+                                </span>
+                                <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-bold"
+                                    :class="emptyServers.length > 0
+                                        ? 'bg-green-500/15 border border-green-400/30 text-green-300'
+                                        : 'bg-white/5 border border-white/15 text-gray-400'">
+                                    <span class="w-1.5 h-1.5 rounded-full" :class="emptyServers.length > 0 ? 'bg-green-400' : 'bg-gray-500'"></span>
+                                    {{ emptyServers.length }} empty {{ emptyServers.length === 1 ? 'server' : 'servers' }}
+                                </span>
+                            </div>
+
                             <!-- Step indicators -->
                             <div class="flex items-center gap-3 mb-4">
                                 <div class="flex items-center gap-2">
@@ -728,14 +758,14 @@ const closeServerDropdown = () => {
                                         :class="selectedServer ? 'bg-blue-500 text-white ring-2 ring-blue-500/30' : 'bg-white/10 text-gray-500'">
                                         2
                                     </div>
-                                    <span class="text-sm" :class="selectedServer ? 'text-white font-semibold' : 'text-gray-500'">Click Connect on a map</span>
+                                    <span class="text-sm" :class="selectedServer ? 'text-white font-semibold' : 'text-gray-500'">Click Copy and connect on a map</span>
                                 </div>
                                 <div class="h-px flex-1 bg-white/10"></div>
                                 <div class="flex items-center gap-2">
                                     <div class="flex items-center justify-center w-7 h-7 rounded-full text-xs font-black flex-shrink-0 bg-green-500/20 text-green-400 border border-green-500/40">
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" /></svg>
                                     </div>
-                                    <span class="text-sm text-green-400/80 font-medium">Callvote auto-copied upon clicking Connect</span>
+                                    <span class="text-sm text-green-400/80 font-medium">Callvote lands on your clipboard, paste it in the console</span>
                                 </div>
                             </div>
 
@@ -823,24 +853,33 @@ const closeServerDropdown = () => {
                     <MapCard :map="map" />
 
                     <!-- Play Button (for Play Later with server selected) -->
-                    <a
+                    <button
                         v-if="isPlayLater && selectedServer"
-                        :href="`defrag://${selectedServer.ip}:${selectedServer.port}`"
-                        @click="copyMapCommand(map.id, map.name)"
+                        @click="copyAndConnect(map)"
                         :class="selectedServer.defrag?.toLowerCase().includes('cpm') ? 'connect-button-cpm' : 'connect-button-vq3'"
-                        class="connect-button absolute bottom-0 left-0 right-0 z-10 flex items-center justify-between px-3 py-2 rounded-b-lg text-white font-bold text-xs transition-all"
-                        :title="`Connect to ${selectedServer.ip}:${selectedServer.port} (/cv map ${map.name} copied to clipboard)`">
+                        class="connect-button w-full mt-2 flex items-center justify-between px-3 py-2 rounded-lg text-white font-bold text-xs transition-all"
+                        :title="`Connect to ${selectedServer.ip}:${selectedServer.port} and load ${map.name}`">
                         <div class="flex items-center gap-1.5">
                             <svg v-if="copiedMapId !== map.id" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
                             </svg>
-                            <svg v-else class="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
-                            {{ copiedMapId === map.id ? 'Copied!' : 'Connect' }}
+                            <svg v-else class="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                            </svg>
+                            {{ copiedMapId === map.id ? 'Copied - connecting...' : 'Copy and connect' }}
                         </div>
                         <span :class="selectedServer.defrag?.toLowerCase().includes('cpm') ? 'bg-purple-500/30 border-purple-400/50 text-purple-300' : 'bg-blue-500/30 border-blue-400/50 text-blue-300'" class="px-2 py-0.5 text-[10px] font-black uppercase tracking-wider rounded border">
                             {{ selectedServer.defrag?.toLowerCase().includes('cpm') ? 'CPM' : 'VQ3' }}
                         </span>
-                    </a>
+                    </button>
+
+                    <!-- Queue position. Play Later is an ordered list you can
+                         drag around, so the order is worth showing. -->
+                    <div
+                        v-if="isPlayLater"
+                        class="absolute top-2 right-2 z-10 min-w-[1.5rem] h-6 px-1.5 flex items-center justify-center rounded-md bg-black/70 border border-white/15 text-white text-xs font-black backdrop-blur-sm">
+                        {{ index + 1 }}
+                    </div>
 
                     <!-- Remove Button (for owner) -->
                     <button
@@ -859,9 +898,15 @@ const closeServerDropdown = () => {
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16 mb-4 opacity-40">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />
                 </svg>
-                <p class="font-semibold text-lg mb-2">No maps in this maplist yet</p>
-                <p class="text-sm mb-4" v-if="is_owner">Start adding maps to build your collection!</p>
-                <Link v-if="is_owner" :href="'/maps'" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold transition">
+                <template v-if="isPlayLater">
+                    <p class="font-semibold text-lg mb-2">Nothing queued yet</p>
+                    <p class="text-sm mb-4">Add maps from any map page and they land here, ready to load onto a server.</p>
+                </template>
+                <template v-else>
+                    <p class="font-semibold text-lg mb-2">No maps in this maplist yet</p>
+                    <p class="text-sm mb-4" v-if="is_owner">Start adding maps to build your collection!</p>
+                </template>
+                <Link v-if="is_owner || isPlayLater" :href="'/maps'" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold transition">
                     Browse Maps
                 </Link>
             </div>
@@ -956,6 +1001,7 @@ const closeServerDropdown = () => {
                 </button>
             </template>
         </DialogModal>
+
     </div>
 </template>
 

--- a/resources/js/Pages/ServerdemoValidators.vue
+++ b/resources/js/Pages/ServerdemoValidators.vue
@@ -1,0 +1,350 @@
+<script>
+import MainLayout from '@/Layouts/MainLayout.vue';
+
+export default {
+    layout: MainLayout,
+};
+</script>
+
+<script setup>
+import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const props = defineProps({
+    application: { type: Object, default: null },
+    applicantCount: { type: Number, default: 0 },
+    validators: { type: Array, default: () => [] },
+    voting: {
+        type: Object,
+        default: () => ({ open: false, canVote: false, myVotes: [], candidates: [] }),
+    },
+});
+
+const votedFor = (applicationId) => (props.voting.myVotes || []).includes(applicationId);
+
+const toggleVote = (candidate) => {
+    router.post(route('serverdemo-validators.vote', candidate.id), {}, {
+        preserveScroll: true,
+    });
+};
+
+const page = usePage();
+
+const user = computed(() => page.props.auth?.user);
+
+const form = useForm({
+    motivation: '',
+    experience: '',
+    availability: '',
+    contact: '',
+});
+
+const statusLabel = {
+    pending: 'Waiting to be reviewed',
+    shortlisted: 'Shortlisted - goes to the vote',
+    approved: 'Approved - you are a validator',
+    not_selected: 'Not selected this round - apply again next time',
+    rejected: 'Not accepted this time',
+};
+
+const statusClass = {
+    pending: 'bg-yellow-500/15 border-yellow-400/30 text-yellow-300',
+    shortlisted: 'bg-blue-500/15 border-blue-400/30 text-blue-300',
+    approved: 'bg-green-500/15 border-green-400/30 text-green-300',
+    not_selected: 'bg-white/5 border-white/15 text-gray-300',
+    rejected: 'bg-red-500/15 border-red-400/30 text-red-300',
+};
+
+// Anything already decided against may be replaced with a fresh application;
+// anything still in play may not.
+const canApply = computed(() => !props.application
+    || ['rejected', 'not_selected'].includes(props.application.status));
+
+const submit = () => {
+    form.post(route('serverdemo-validators.apply'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
+    });
+};
+</script>
+
+<template>
+    <Head title="Serverdemo Validators" />
+
+    <div class="min-h-screen py-10 px-4 md:px-6 lg:px-8">
+        <div class="max-w-4xl mx-auto">
+
+            <!-- Header -->
+            <div class="mb-8">
+                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/15 border border-blue-400/30 text-blue-300 text-xs font-bold uppercase tracking-wider mb-4">
+                    Step one of two
+                </div>
+                <h1 class="text-3xl md:text-4xl font-black text-white mb-3">Serverdemo validators</h1>
+                <p class="text-gray-300 text-lg leading-relaxed">
+                    When a player reports a record, someone has to watch the serverdemo of that run and
+                    decide what actually happened. This form is the first step to being one of those people.
+                </p>
+            </div>
+
+            <!-- How you get the position -->
+            <div class="bg-white/5 border border-white/10 rounded-2xl p-6 mb-6">
+                <h2 class="text-xl font-bold text-white mb-4">How the selection works</h2>
+
+                <div class="space-y-4">
+                    <div class="flex gap-4">
+                        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-500 text-white font-black text-sm flex items-center justify-center">1</div>
+                        <div>
+                            <div class="font-semibold text-white">You apply here</div>
+                            <p class="text-gray-400 text-sm mt-1">
+                                Tell us who you are and why you want to do this. Applying costs nothing and
+                                commits you to nothing.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="flex gap-4">
+                        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-500/20 border border-blue-400/40 text-blue-300 font-black text-sm flex items-center justify-center">2</div>
+                        <div>
+                            <div class="font-semibold text-white">The applicants vote</div>
+                            <p class="text-gray-400 text-sm mt-1">
+                                Everyone who applied then votes on who gets the position. The people doing this
+                                work pick the people they will be working with, rather than one person deciding
+                                it alone.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="flex gap-4">
+                        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-green-500/20 border border-green-400/40 text-green-300 font-black text-sm flex items-center justify-center">3</div>
+                        <div>
+                            <div class="font-semibold text-white">Access is granted by hand</div>
+                            <p class="text-gray-400 text-sm mt-1">
+                                Whoever comes through the vote is added in the admin panel with permission for
+                                serverdemo validation and nothing else.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- What the job actually is -->
+            <div class="bg-white/5 border border-white/10 rounded-2xl p-6 mb-6">
+                <h2 class="text-xl font-bold text-white mb-4">What a validator does</h2>
+
+                <ul class="space-y-3 text-gray-300 text-sm">
+                    <li class="flex gap-3">
+                        <span class="text-blue-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            A cleared report is assigned to <span class="text-white font-semibold">one</span> validator, picked at random.
+                            You watch the serverdemo of that run and say what you see.
+                        </span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-blue-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            Not sure? <span class="text-white font-semibold">Hand it to someone else.</span> That is a normal outcome,
+                            not a failure - leaving a note about what you already checked is part of the job.
+                        </span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-blue-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            If the second person is not sure either, the report opens to
+                            <span class="text-white font-semibold">every validator at once</span> and you work it out together in
+                            the internal notes on that report.
+                        </span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-blue-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            If the group cannot agree, it goes to the <span class="text-white font-semibold">admin</span> for a final call.
+                        </span>
+                    </li>
+                </ul>
+            </div>
+
+            <!-- The guard rails -->
+            <div class="bg-yellow-500/5 border border-yellow-500/25 rounded-2xl p-6 mb-6">
+                <h2 class="text-xl font-bold text-yellow-300 mb-4">What you will not get</h2>
+
+                <ul class="space-y-3 text-gray-300 text-sm">
+                    <li class="flex gap-3">
+                        <span class="text-yellow-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            <span class="text-white font-semibold">No access to the serverdemo archive.</span>
+                            Not a browser, not a search, not a download link. Only the single demo belonging to a
+                            report that has been handed to you.
+                        </span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-yellow-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            <span class="text-white font-semibold">Nothing reaches you automatically.</span>
+                            Every report is checked by the admin first and only released if it is not a false
+                            report. Nobody can flood validators with work by reporting a lot of runs.
+                        </span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-yellow-400 font-bold flex-shrink-0">-</span>
+                        <span>
+                            <span class="text-white font-semibold">A single report never moves.</span>
+                            A run has to be reported independently by several different people before it is
+                            looked at, on top of the admin clearing it. How many is deliberately not published.
+                        </span>
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Who is doing it today -->
+            <div v-if="validators.length > 0 || applicantCount > 0" class="flex flex-wrap gap-2 mb-8">
+                <span v-if="applicantCount > 0" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/5 border border-white/15 text-gray-300 text-xs font-bold">
+                    {{ applicantCount }} {{ applicantCount === 1 ? 'application' : 'applications' }} so far
+                </span>
+                <span v-if="validators.length > 0" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-green-500/10 border border-green-400/25 text-green-300 text-xs font-bold">
+                    {{ validators.length }} active {{ validators.length === 1 ? 'validator' : 'validators' }}
+                </span>
+            </div>
+
+            <!-- The vote -->
+            <div v-if="voting.open" class="bg-blue-500/5 border border-blue-400/25 rounded-2xl p-6 mb-6">
+                <div class="flex items-center gap-2 mb-1">
+                    <span class="w-2 h-2 rounded-full bg-blue-400 animate-pulse"></span>
+                    <h2 class="text-xl font-bold text-white">Voting is open</h2>
+                </div>
+                <p class="text-gray-400 text-sm mb-5">
+                    {{ voting.title || 'Applicants pick who gets the position.' }}
+                    Counts stay hidden until the round closes.
+                </p>
+
+                <div v-if="!user" class="text-gray-400 text-sm">
+                    Log in to see the ballot.
+                </div>
+
+                <div v-else-if="!voting.canVote" class="rounded-lg bg-white/5 border border-white/10 px-4 py-3 text-gray-400 text-sm">
+                    Only people who applied vote in this round.
+                </div>
+
+                <div v-else-if="voting.candidates.length === 0" class="text-gray-400 text-sm">
+                    Nobody else is on the ballot yet.
+                </div>
+
+                <div v-else class="space-y-3">
+                    <div
+                        v-for="candidate in voting.candidates"
+                        :key="candidate.id"
+                        class="rounded-xl border p-4 transition-colors"
+                        :class="votedFor(candidate.id)
+                            ? 'bg-green-500/10 border-green-400/40'
+                            : 'bg-black/20 border-white/10'"
+                    >
+                        <div class="flex items-start justify-between gap-4">
+                            <div class="min-w-0">
+                                <div class="font-bold text-white mb-1" v-html="q3tohtml(candidate.name)"></div>
+                                <p class="text-gray-400 text-sm whitespace-pre-line">{{ candidate.motivation }}</p>
+                                <p v-if="candidate.experience" class="text-gray-500 text-sm mt-2 whitespace-pre-line">{{ candidate.experience }}</p>
+                                <p v-if="candidate.availability" class="text-gray-600 text-xs mt-2">Around: {{ candidate.availability }}</p>
+                            </div>
+
+                            <button
+                                @click="toggleVote(candidate)"
+                                class="flex-shrink-0 px-4 py-2 rounded-xl font-semibold text-sm transition-colors"
+                                :class="votedFor(candidate.id)
+                                    ? 'bg-green-600 hover:bg-green-500 text-white'
+                                    : 'bg-white/5 hover:bg-white/10 text-gray-300 border border-white/15'"
+                            >
+                                {{ votedFor(candidate.id) ? 'Voted' : 'Vote' }}
+                            </button>
+                        </div>
+                    </div>
+
+                    <p class="text-gray-500 text-xs">
+                        Vote for as many people as you think should get it. Click again to take a vote back.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Existing application -->
+            <div v-if="application" class="rounded-2xl border p-5 mb-6" :class="statusClass[application.status] || statusClass.pending">
+                <div class="font-bold mb-1">{{ statusLabel[application.status] || application.status }}</div>
+                <p class="text-sm opacity-90">
+                    You applied on {{ new Date(application.created_at).toLocaleDateString() }}.
+                    <span v-if="application.review_note"> {{ application.review_note }}</span>
+                </p>
+            </div>
+
+            <!-- Form -->
+            <div v-if="user && canApply" class="bg-white/5 border border-white/10 rounded-2xl p-6">
+                <h2 class="text-xl font-bold text-white mb-1">Apply</h2>
+                <p class="text-gray-500 text-sm mb-5">Applying as <span class="font-semibold" v-html="q3tohtml(user.name)"></span>.</p>
+
+                <form @submit.prevent="submit" class="space-y-5">
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-300 mb-2">
+                            Why do you want to do this?
+                            <span class="text-red-400">*</span>
+                        </label>
+                        <textarea
+                            v-model="form.motivation"
+                            rows="5"
+                            placeholder="A few sentences is plenty."
+                            class="w-full px-4 py-3 bg-black/40 border border-white/10 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        ></textarea>
+                        <p v-if="form.errors.motivation" class="text-red-400 text-sm mt-1">{{ form.errors.motivation }}</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-300 mb-2">
+                            Anything that makes you good at spotting a bad run?
+                        </label>
+                        <textarea
+                            v-model="form.experience"
+                            rows="4"
+                            placeholder="Years played, physics you know well, moderating you have done elsewhere. Optional."
+                            class="w-full px-4 py-3 bg-black/40 border border-white/10 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        ></textarea>
+                        <p v-if="form.errors.experience" class="text-red-400 text-sm mt-1">{{ form.errors.experience }}</p>
+                    </div>
+
+                    <div class="grid md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-semibold text-gray-300 mb-2">Roughly when are you around?</label>
+                            <input
+                                v-model="form.availability"
+                                type="text"
+                                placeholder="Evenings CET, weekends, ..."
+                                class="w-full px-4 py-3 bg-black/40 border border-white/10 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.availability" class="text-red-400 text-sm mt-1">{{ form.errors.availability }}</p>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-semibold text-gray-300 mb-2">Where can we reach you?</label>
+                            <input
+                                v-model="form.contact"
+                                type="text"
+                                placeholder="Discord handle"
+                                class="w-full px-4 py-3 bg-black/40 border border-white/10 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            />
+                            <p v-if="form.errors.contact" class="text-red-400 text-sm mt-1">{{ form.errors.contact }}</p>
+                        </div>
+                    </div>
+
+                    <button
+                        type="submit"
+                        :disabled="form.processing || !form.motivation.trim()"
+                        class="px-5 py-3 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors"
+                    >
+                        {{ form.processing ? 'Sending...' : 'Send application' }}
+                    </button>
+                </form>
+            </div>
+
+            <!-- Logged out -->
+            <div v-else-if="!user" class="bg-white/5 border border-white/10 rounded-2xl p-6 text-center">
+                <p class="text-gray-300 mb-4">You need an account to apply.</p>
+                <Link :href="route('login')" class="inline-block px-5 py-3 bg-blue-600 hover:bg-blue-500 text-white font-semibold rounded-xl transition-colors">
+                    Log in
+                </Link>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/views/filament/serverdemo-validation/case-modal.blade.php
+++ b/resources/views/filament/serverdemo-validation/case-modal.blade.php
@@ -1,0 +1,123 @@
+@php
+    /**
+     * One player, every report against them, and the thread the validators
+     * keep. Demo links are minted here rather than stored: they are signed,
+     * short-lived, and the endpoint re-checks entitlement on every hit.
+     */
+    $stages = [
+        'assigned' => 'With one validator',
+        'second_opinion' => 'Second opinion',
+        'all_validators' => 'Open to all validators',
+        'admin' => 'With the admin',
+    ];
+
+    $flags = $case->flags()->with(['record', 'demo'])->orderBy('created_at')->get();
+@endphp
+
+<div class="space-y-5 text-sm">
+    <div class="grid grid-cols-3 gap-4">
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Stage</div>
+            <div class="text-gray-800 dark:text-gray-200">{{ $stages[$case->validation_stage] ?? $case->validation_stage }}</div>
+        </div>
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Reported runs</div>
+            <div class="text-gray-800 dark:text-gray-200">{{ $flags->count() }}</div>
+        </div>
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Identity</div>
+            <div class="text-gray-800 dark:text-gray-200">
+                {{ $case->subject_mdd_id ? 'MDD #' . $case->subject_mdd_id : ($case->subject_user_id ? 'site account' : 'name only') }}
+            </div>
+        </div>
+    </div>
+
+    {{-- The evidence, run by run --}}
+    <div>
+        <div class="text-xs uppercase tracking-wide text-gray-500 mb-2">Runs in this case</div>
+
+        <div class="space-y-2">
+            @foreach ($flags as $flag)
+                @php
+                    $serverDemo = $flag->demo_id ? null : $flag->serverDemo();
+                    $signedUrl = $serverDemo
+                        ? \Illuminate\Support\Facades\URL::temporarySignedRoute(
+                            'defraghq.validation-demo',
+                            now()->addMinutes(5),
+                            ['flag' => $flag->id],
+                        )
+                        : null;
+                @endphp
+
+                <div class="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <div class="font-semibold text-gray-800 dark:text-gray-200">
+                                @if ($flag->demo_id)
+                                    {{ $flag->demo?->map_name ?? 'demo #' . $flag->demo_id }}
+                                @else
+                                    {{ $flag->record?->mapname ?? 'record is gone' }}
+                                    <span class="text-gray-500 font-normal">{{ $flag->record?->physics }} {{ $flag->record?->mode }}</span>
+                                @endif
+                            </div>
+                            <div class="text-xs text-gray-500 mt-0.5">
+                                {{ $flag->flag_type }} - {{ $flag->flag_count }} {{ $flag->flag_count === 1 ? 'report' : 'reports' }}
+                            </div>
+                            @if ($flag->note)
+                                <div class="text-xs text-gray-600 dark:text-gray-400 mt-1 whitespace-pre-line">{{ $flag->note }}</div>
+                            @endif
+                        </div>
+
+                        <div class="flex-shrink-0">
+                            @if ($flag->demo_id && $flag->demo)
+                                <a href="{{ url('/demos/' . $flag->demo->id . '/download') }}"
+                                   class="px-3 py-1.5 rounded-lg bg-primary-600 hover:bg-primary-500 text-white text-xs font-semibold">
+                                    Download
+                                </a>
+                            @elseif ($signedUrl)
+                                <a href="{{ $signedUrl }}"
+                                   class="px-3 py-1.5 rounded-lg bg-primary-600 hover:bg-primary-500 text-white text-xs font-semibold">
+                                    Serverdemo
+                                </a>
+                            @else
+                                <span class="text-xs text-yellow-600 dark:text-yellow-400">no demo</span>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+        <p class="text-xs text-gray-500 mt-2">
+            Links expire in 5 minutes and only work while this case is yours.
+        </p>
+    </div>
+
+    {{-- The thread --}}
+    <div>
+        <div class="text-xs uppercase tracking-wide text-gray-500 mb-2">Internal notes</div>
+
+        @if ($case->comments->isEmpty())
+            <div class="text-gray-400 italic">Nothing yet.</div>
+        @else
+            <div class="space-y-3">
+                @foreach ($case->comments as $comment)
+                    <div class="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2">
+                        <div class="flex items-center justify-between gap-3 mb-1">
+                            <span class="font-semibold text-gray-800 dark:text-gray-200">
+                                {{ $comment->user?->plain_name ?? $comment->user?->name ?? 'system' }}
+                            </span>
+                            <span class="text-xs text-gray-500">
+                                @if ($comment->event)
+                                    <span class="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 uppercase tracking-wide mr-2">{{ str_replace('_', ' ', $comment->event) }}</span>
+                                @endif
+                                {{ $comment->created_at->diffForHumans() }}
+                            </span>
+                        </div>
+                        <div class="whitespace-pre-line text-gray-700 dark:text-gray-300">{{ $comment->body }}</div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/filament/validator-applications/detail-modal.blade.php
+++ b/resources/views/filament/validator-applications/detail-modal.blade.php
@@ -1,0 +1,31 @@
+<div class="space-y-5 text-sm">
+    <div>
+        <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Why they want it</div>
+        <blockquote class="border-l-2 border-blue-500/40 pl-3 whitespace-pre-line text-gray-800 dark:text-gray-200">{{ $record->motivation }}</blockquote>
+    </div>
+
+    @if ($record->experience)
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Experience</div>
+            <blockquote class="border-l-2 border-gray-400/40 pl-3 whitespace-pre-line text-gray-800 dark:text-gray-200">{{ $record->experience }}</blockquote>
+        </div>
+    @endif
+
+    <div class="grid grid-cols-2 gap-4">
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Around</div>
+            <div class="text-gray-800 dark:text-gray-200">{{ $record->availability ?: '-' }}</div>
+        </div>
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Contact</div>
+            <div class="text-gray-800 dark:text-gray-200">{{ $record->contact ?: '-' }}</div>
+        </div>
+    </div>
+
+    @if ($record->review_note)
+        <div>
+            <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Review note</div>
+            <div class="text-gray-800 dark:text-gray-200 whitespace-pre-line">{{ $record->review_note }}</div>
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,6 +75,16 @@ Route::post('/maps/{id}/unflag-nsfw', [MapsController::class, 'unflagNsfw'])->wh
 Route::post('/maps/{id}/rate-difficulty', [MapsController::class, 'rateDifficulty'])->where('id', '[0-9]+')->middleware('auth')->name('maps.rate-difficulty');
 Route::get('/maps/{mapname}', [MapsController::class, 'map'])->name('maps.map');
 
+// Serverdemo validators. The page is public - it explains how reported runs
+// are reviewed - while applying needs a verified account.
+Route::get('/serverdemo-validators', [\App\Http\Controllers\ServerdemoValidatorController::class, 'index'])->name('serverdemo-validators.index');
+Route::post('/serverdemo-validators/apply', [\App\Http\Controllers\ServerdemoValidatorController::class, 'apply'])
+    ->middleware(['auth', 'verified', 'throttle:5,60'])
+    ->name('serverdemo-validators.apply');
+Route::post('/serverdemo-validators/vote/{application}', [\App\Http\Controllers\ServerdemoValidatorController::class, 'vote'])
+    ->middleware(['auth', 'verified', 'throttle:60,60'])
+    ->name('serverdemo-validators.vote');
+
 Route::get('/ranking', [RankingController::class, 'index'])->name('ranking');
 Route::get('/ranking/how-it-works', [RankingController::class, 'howItWorks'])->name('ranking.how-it-works');
 
@@ -85,6 +95,12 @@ Route::get('/community', [CommunityLeaderboardController::class, 'index'])->name
 Route::get('/defraghq/storage-download', \App\Http\Controllers\StorageBrowserDownloadController::class)
     ->middleware(['auth', 'signed'])
     ->name('defraghq.storage-download');
+
+// The demo of ONE reported run, for the validator holding that report. No
+// path parameter: the file is looked up from the report itself.
+Route::get('/defraghq/validation-demo/{flag}', \App\Http\Controllers\ServerdemoValidationDownloadController::class)
+    ->middleware(['auth', 'signed'])
+    ->name('defraghq.validation-demo');
 
 // DefragLive most-watched-player contest (public leaderboard + raffle odds).
 Route::get('/defraglive/contest', [DefragliveContestController::class, 'index'])->name('defraglive.contest');


### PR DESCRIPTION
Three independent pieces of work.

## Serverdemo validators

Reported runs are reviewed by one person today. This adds the people, the way
they get chosen, and the place they work.

**Applying** - `/serverdemo-validators` is public and explains how a report is
handled; the form needs an account. Step two is a vote among the applicants,
joined by the validators already doing the job.

**The vote** is approval-style: vote for as many people as you think should get
it, take a vote back while the round is open. The site needs several
validators, not one winner, so one vote each would only split and tell us
nothing. Tallies stay hidden until the round closes and rounds are opened and
closed by hand.

**The gate** - nothing reaches a validator on its own. A report moves only once
an admin has cleared it as not-false **and** enough different people reported
it independently. The threshold is config and is deliberately not published:
otherwise one person with two accounts knows exactly how far to go.

**Cases, not reports** - a cleared report joins the open case for that *player*
rather than starting its own row. Somebody who cheats does it on ten maps, and
the pattern across the runs is usually the evidence. Identity is the MDD id
where there is one, since it survives nickname changes.

**The ladder** - one validator, the second they hand it to, all of them, then
the admin. It only ever widens. Assignment is random rather than a rotation, so
a reported player cannot predict who is about to watch their runs. Internal
notes hang on the case, so whoever gets it next starts from what was checked.

**Access** - a validator names a *report*, never a path; the file is looked up
from it, so there is no way to ask for a demo you were not given. Links are
signed, last five minutes and are re-checked on every hit. Serverdemo cases and
uploaded-demo cases stay separate even for the same player - one kind of
evidence is private, the other is already public.

Approving somebody and granting them access are separate actions, and the
permission covers validation only: no archive browsing, no search. Deleting an
application hides it and never destroys it, so the record of a past rejection
survives while the person can apply again.

## Instant play

A map page gets an Instant Play button - pick a server, confirm, and the
callvote is on the clipboard by the time the game window is up. The
confirmation is there because the server is chosen by the same click that
connects you. Play Later needs no confirmation, since the server was chosen in
step one, so its button copies and connects directly.

Fixes along the way: removing a map from Play Later now updates the grid
immediately, and the Connect button is finally the width of the card - a scoped
`position: relative` had been overriding Tailwind's `absolute` since the button
was written. Both dropdowns are teleported out of their stacking context, which
is the only way to get them above the records panel.

## Scraper

The `getstatus` fallback is commented out. It returned player names and nothing
else, and it was unreachable in practice: of every online server, four do not
answer `getdfstatus`, and rcon works on all four. `handle_failed_servers()` still
reads q3df.org before anything is marked offline.

## Deploying

Needs `php artisan migrate` - seven migrations - and `octane:reload`. Worth
checking `scrape:servers finished` in the log afterwards to confirm the offline
count has not moved.
