### PR TITLE
Euro prizes, a link to the validators page, and a readable layout

### DIFF
--- a/app/Filament/Resources/DefragliveContestResource.php
+++ b/app/Filament/Resources/DefragliveContestResource.php
@@ -51,9 +51,16 @@ class DefragliveContestResource extends Resource
                     ->numeric()
                     ->default(5)
                     ->required(),
-                Forms\Components\TextInput::make('prize_currency')
-                    ->default('USD')
-                    ->maxLength(8)
+                Forms\Components\Select::make('prize_currency')
+                    ->options(array_combine(
+                        array_keys(DefragliveContest::CURRENCIES),
+                        array_map(
+                            fn ($symbol, $code) => "{$code}  {$symbol}",
+                            DefragliveContest::CURRENCIES,
+                            array_keys(DefragliveContest::CURRENCIES)
+                        )
+                    ))
+                    ->default(DefragliveContest::DEFAULT_CURRENCY)
                     ->required(),
                 Forms\Components\Select::make('status')
                     ->options([
@@ -95,7 +102,7 @@ class DefragliveContestResource extends Resource
                 Tables\Columns\TextColumn::make('starts_at')->dateTime('M j, H:i')->sortable(),
                 Tables\Columns\TextColumn::make('ends_at')->dateTime('M j, H:i')->sortable(),
                 Tables\Columns\TextColumn::make('prize_amount')
-                    ->formatStateUsing(fn ($state, DefragliveContest $r) => ($r->prize_currency === 'USD' ? '$' : '') . $state . ($r->prize_currency !== 'USD' ? ' ' . $r->prize_currency : '')),
+                    ->formatStateUsing(fn ($state, DefragliveContest $r) => DefragliveContest::formatPrize($state, $r->prize_currency)),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->color(fn (string $state) => match ($state) {

--- a/app/Http/Controllers/DefragliveContestController.php
+++ b/app/Http/Controllers/DefragliveContestController.php
@@ -160,6 +160,10 @@ class DefragliveContestController extends Controller
                     'ends_at' => $contest->ends_at?->toIso8601String(),
                     'prize_amount' => (float) $contest->prize_amount,
                     'prize_currency' => $contest->prize_currency,
+                    // Formatted here rather than in the overlay: that page is
+                    // standalone for OBS and loads no bundle, so it cannot
+                    // reach the shared formatter the rest of the site uses.
+                    'prize_label' => DefragliveContest::formatPrize($contest->prize_amount, $contest->prize_currency),
                 ],
                 'top' => array_map(fn ($e) => [
                     'name' => $e['name'],

--- a/app/Models/DefragliveContest.php
+++ b/app/Models/DefragliveContest.php
@@ -8,11 +8,24 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * A DefragLive watch-time contest window. Winner is drawn by a watch-time-
  * weighted raffle over the watch sessions in [starts_at, ends_at]
- * (DefragliveWatchService::draw). Default $5 / 2 weeks, but per-row.
+ * (DefragliveWatchService::draw). Default 5 EUR / 2 weeks, but per-row.
  */
 class DefragliveContest extends Model
 {
     protected $table = 'defraglive_contests';
+
+    /**
+     * Currencies a prize may be set in, and how they are written. The prize is
+     * paid out of one person's pocket, so this is a short list on purpose - a
+     * free-text field invites "eur", "Euro" and "EU" into the same column, and
+     * every one of those would then print without a symbol.
+     */
+    public const CURRENCIES = [
+        'EUR' => '€',
+        'USD' => '$',
+    ];
+
+    public const DEFAULT_CURRENCY = 'EUR';
 
     public const STATUS_DRAFT = 'draft';
     public const STATUS_ACTIVE = 'active';
@@ -49,6 +62,10 @@ class DefragliveContest extends Model
         'notes',
     ];
 
+    protected $attributes = [
+        'prize_currency' => self::DEFAULT_CURRENCY,
+    ];
+
     protected $casts = [
         'starts_at' => 'datetime',
         'ends_at' => 'datetime',
@@ -64,6 +81,21 @@ class DefragliveContest extends Model
     public function winner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'winner_user_id');
+    }
+
+    /**
+     * A prize written for humans. An unknown currency keeps its code rather
+     * than losing the unit, so a bad row reads oddly instead of claiming the
+     * prize is in whatever the reader assumes.
+     */
+    public static function formatPrize($amount, ?string $currency): string
+    {
+        $value = number_format((float) $amount, 2);
+        $symbol = self::CURRENCIES[$currency] ?? null;
+
+        return $symbol === null
+            ? trim($value . ' ' . $currency)
+            : $symbol . $value;
     }
 
     public function isOpenForWatching(): bool

--- a/database/migrations/2026_08_03_050000_default_defraglive_contest_prize_to_eur.php
+++ b/database/migrations/2026_08_03_050000_default_defraglive_contest_prize_to_eur.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The prize is paid from one person's pocket and that pocket is in euros, so
+ * EUR is the sensible default rather than the USD this shipped with.
+ *
+ * Existing rows are deliberately left alone: they record what was actually
+ * paid out, and relabelling a settled USD prize as euros would make the hall
+ * of fame lie about what people received.
+ *
+ * Raw SQL because the project has no doctrine/dbal, so ->change() is not
+ * available. Only MySQL is touched - it is what runs here and in production,
+ * and the model carries the same default anyway, so any other driver still
+ * gets EUR through Eloquent.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql' || ! Schema::hasTable('defraglive_contests')) {
+            return;
+        }
+
+        DB::statement("ALTER TABLE defraglive_contests ALTER COLUMN prize_currency SET DEFAULT 'EUR'");
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql' || ! Schema::hasTable('defraglive_contests')) {
+            return;
+        }
+
+        DB::statement("ALTER TABLE defraglive_contests ALTER COLUMN prize_currency SET DEFAULT 'USD'");
+    }
+};

--- a/resources/js/Components/DefragliveContestBanner.vue
+++ b/resources/js/Components/DefragliveContestBanner.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Link, usePage } from '@inertiajs/vue3';
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { formatPrize } from '@/utils/currency';
 
 // Sitewide nudge toward the contest while one is live, fed by the
 // `defragliveContest` shared Inertia prop (cached). Three layouts:
@@ -51,7 +52,7 @@ const timeLeft = computed(() => {
 const prize = computed(() => {
     if (!contest.value) return '';
     const c = contest.value;
-    return (c.prize_currency === 'USD' ? '$' : '') + c.prize_amount + (c.prize_currency !== 'USD' ? ' ' + c.prize_currency : '');
+    return formatPrize(c.prize_amount, c.prize_currency);
 });
 
 // Segmented countdown for the hero variant's ticker boxes.

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -718,6 +718,7 @@
                                             </template>
                                             <Link :href="route('settings.show') + '?tab=security'" class="block text-sm text-gray-400 hover:text-red-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Security</Link>
                                             <Link :href="route('server-hosting.index')" class="block text-sm text-gray-400 hover:text-emerald-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Server hosting</Link>
+                                            <Link :href="route('serverdemo-validators.index')" class="block text-sm text-gray-400 hover:text-blue-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Serverdemo validators</Link>
                                         </div>
                                         <a v-if="$page.props.auth.user.admin || $page.props.auth.user.is_moderator" href="/defraghq" target="_blank" class="block w-full px-4 py-2 text-sm leading-5 text-emerald-400 hover:bg-white/5 transition-all font-semibold">
                                             Admin Panel

--- a/resources/js/Pages/DefragliveContest.vue
+++ b/resources/js/Pages/DefragliveContest.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Head, Link, router } from '@inertiajs/vue3';
 import { ref, computed, onMounted, onUnmounted, getCurrentInstance, watch } from 'vue';
+import { formatPrize } from '@/utils/currency';
 
 const props = defineProps({
     contest: Object,
@@ -286,13 +287,13 @@ const statusColor = (s) => ({
                 <div class="flex items-center gap-6 shrink-0">
                     <div class="text-right">
                         <div class="text-3xl md:text-4xl font-black text-emerald-400">
-                            {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ contest.prize_amount }}{{ contest.prize_currency !== 'USD' ? ' ' + contest.prize_currency : '' }}
+                            {{ formatPrize(contest.prize_amount, contest.prize_currency) }}
                         </div>
                         <div class="text-sm font-bold uppercase tracking-widest text-gray-300">prize</div>
                         <!-- Pool transparency: base prize vs what previous winners forwarded in -->
                         <div v-if="contest.carried_over_amount > 0" class="text-[11px] text-purple-200/90 mt-1 leading-snug">
-                            {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ (contest.prize_amount - contest.carried_over_amount).toFixed(2) }} base
-                            + {{ contest.prize_currency === 'USD' ? '$' : '' }}{{ contest.carried_over_amount.toFixed(2) }}
+                            {{ formatPrize(contest.prize_amount - contest.carried_over_amount, contest.prize_currency) }} base
+                            + {{ formatPrize(contest.carried_over_amount, contest.prize_currency) }}
                             carried over from previous winners
                         </div>
                     </div>
@@ -427,9 +428,9 @@ const statusColor = (s) => ({
                             </div>
                         </div>
                         <div class="text-right shrink-0">
-                            <div class="font-bold text-emerald-400">{{ w.prize_currency === 'USD' ? '$' : '' }}{{ w.prize_amount }}</div>
+                            <div class="font-bold text-emerald-400">{{ formatPrize(w.prize_amount, w.prize_currency) }}</div>
                             <div v-if="w.carried_over_amount > 0" class="text-[10px] text-purple-300/80 leading-tight">
-                                incl. {{ w.prize_currency === 'USD' ? '$' : '' }}{{ w.carried_over_amount.toFixed(2) }} carried over
+                                incl. {{ formatPrize(w.carried_over_amount, w.prize_currency) }} carried over
                             </div>
                             <div class="text-[11px] uppercase" :class="statusColor(w.status)">{{ statusLabel(w.status) }}</div>
                         </div>
@@ -454,7 +455,7 @@ const statusColor = (s) => ({
                     </component>
                     <div class="text-right shrink-0">
                         <div class="font-bold text-white">{{ h.wins }} {{ h.wins === 1 ? 'win' : 'wins' }}</div>
-                        <div class="text-xs text-emerald-400">{{ h.currency === 'USD' ? '$' : '' }}{{ h.total.toFixed(2) }}{{ h.currency !== 'USD' ? ' ' + h.currency : '' }} won</div>
+                        <div class="text-xs text-emerald-400">{{ formatPrize(h.total, h.currency) }} won</div>
                         <div v-if="h.seconds" class="text-[11px] text-purple-300/80">{{ fmtWatch(h.seconds) }} watched</div>
                     </div>
                 </div>

--- a/resources/js/Pages/ServerdemoValidators.vue
+++ b/resources/js/Pages/ServerdemoValidators.vue
@@ -71,23 +71,28 @@ const submit = () => {
 <template>
     <Head title="Serverdemo Validators" />
 
-    <div class="min-h-screen py-10 px-4 md:px-6 lg:px-8">
-        <div class="max-w-4xl mx-auto">
+    <div class="min-h-screen py-10">
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
 
-            <!-- Header -->
+            <!-- Header. Prose is capped even though the page is not: a line of
+                 body text running the full width of a monitor is unreadable. -->
             <div class="mb-8">
                 <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/15 border border-blue-400/30 text-blue-300 text-xs font-bold uppercase tracking-wider mb-4">
                     Step one of two
                 </div>
                 <h1 class="text-3xl md:text-4xl font-black text-white mb-3">Serverdemo validators</h1>
-                <p class="text-gray-300 text-lg leading-relaxed">
+                <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
                     When a player reports a record, someone has to watch the serverdemo of that run and
                     decide what actually happened. This form is the first step to being one of those people.
                 </p>
             </div>
 
+            <!-- The three explainers sit side by side rather than stacking, so
+                 the width buys shorter lines instead of longer ones. -->
+            <div class="grid gap-6 mb-6 lg:grid-cols-3">
+
             <!-- How you get the position -->
-            <div class="bg-white/5 border border-white/10 rounded-2xl p-6 mb-6">
+            <div class="h-full bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-6 shadow-2xl">
                 <h2 class="text-xl font-bold text-white mb-4">How the selection works</h2>
 
                 <div class="space-y-4">
@@ -128,7 +133,7 @@ const submit = () => {
             </div>
 
             <!-- What the job actually is -->
-            <div class="bg-white/5 border border-white/10 rounded-2xl p-6 mb-6">
+            <div class="h-full bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-6 shadow-2xl">
                 <h2 class="text-xl font-bold text-white mb-4">What a validator does</h2>
 
                 <ul class="space-y-3 text-gray-300 text-sm">
@@ -163,8 +168,10 @@ const submit = () => {
                 </ul>
             </div>
 
-            <!-- The guard rails -->
-            <div class="bg-yellow-500/5 border border-yellow-500/25 rounded-2xl p-6 mb-6">
+            <!-- The guard rails. Dark like its neighbours - the yellow wash it
+                 had was the worst of the three to read - with the colour kept
+                 in the border and heading so it still reads as a warning. -->
+            <div class="h-full bg-black/40 backdrop-blur-sm border border-yellow-500/30 rounded-2xl p-6 shadow-2xl">
                 <h2 class="text-xl font-bold text-yellow-300 mb-4">What you will not get</h2>
 
                 <ul class="space-y-3 text-gray-300 text-sm">
@@ -195,6 +202,8 @@ const submit = () => {
                 </ul>
             </div>
 
+            </div><!-- /explainers -->
+
             <!-- Who is doing it today -->
             <div v-if="validators.length > 0 || applicantCount > 0" class="flex flex-wrap gap-2 mb-8">
                 <span v-if="applicantCount > 0" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/5 border border-white/15 text-gray-300 text-xs font-bold">
@@ -206,7 +215,7 @@ const submit = () => {
             </div>
 
             <!-- The vote -->
-            <div v-if="voting.open" class="bg-blue-500/5 border border-blue-400/25 rounded-2xl p-6 mb-6">
+            <div v-if="voting.open" class="bg-black/40 backdrop-blur-sm border border-blue-400/30 rounded-2xl p-6 mb-6 shadow-2xl">
                 <div class="flex items-center gap-2 mb-1">
                     <span class="w-2 h-2 rounded-full bg-blue-400 animate-pulse"></span>
                     <h2 class="text-xl font-bold text-white">Voting is open</h2>
@@ -228,14 +237,14 @@ const submit = () => {
                     Nobody else is on the ballot yet.
                 </div>
 
-                <div v-else class="space-y-3">
+                <div v-else class="grid gap-3 xl:grid-cols-2">
                     <div
                         v-for="candidate in voting.candidates"
                         :key="candidate.id"
-                        class="rounded-xl border p-4 transition-colors"
+                        class="rounded-xl border p-4 transition-colors backdrop-blur-sm"
                         :class="votedFor(candidate.id)
                             ? 'bg-green-500/10 border-green-400/40'
-                            : 'bg-black/20 border-white/10'"
+                            : 'bg-black/30 border-white/10'"
                     >
                         <div class="flex items-start justify-between gap-4">
                             <div class="min-w-0">
@@ -257,14 +266,14 @@ const submit = () => {
                         </div>
                     </div>
 
-                    <p class="text-gray-500 text-xs">
+                    <p class="text-gray-500 text-xs xl:col-span-2">
                         Vote for as many people as you think should get it. Click again to take a vote back.
                     </p>
                 </div>
             </div>
 
             <!-- Existing application -->
-            <div v-if="application" class="rounded-2xl border p-5 mb-6" :class="statusClass[application.status] || statusClass.pending">
+            <div v-if="application" class="rounded-2xl border p-5 mb-6 backdrop-blur-sm shadow-2xl" :class="statusClass[application.status] || statusClass.pending">
                 <div class="font-bold mb-1">{{ statusLabel[application.status] || application.status }}</div>
                 <p class="text-sm opacity-90">
                     You applied on {{ new Date(application.created_at).toLocaleDateString() }}.
@@ -273,11 +282,15 @@ const submit = () => {
             </div>
 
             <!-- Form -->
-            <div v-if="user && canApply" class="bg-white/5 border border-white/10 rounded-2xl p-6">
+            <div v-if="user && canApply" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-6 shadow-2xl">
                 <h2 class="text-xl font-bold text-white mb-1">Apply</h2>
                 <p class="text-gray-500 text-sm mb-5">Applying as <span class="font-semibold" v-html="q3tohtml(user.name)"></span>.</p>
 
                 <form @submit.prevent="submit" class="space-y-5">
+                    <!-- The two long answers share a row on wide screens, so
+                         neither becomes a single field stretched across the
+                         whole page. -->
+                    <div class="grid gap-5 lg:grid-cols-2">
                     <div>
                         <label class="block text-sm font-semibold text-gray-300 mb-2">
                             Why do you want to do this?
@@ -303,6 +316,7 @@ const submit = () => {
                             class="w-full px-4 py-3 bg-black/40 border border-white/10 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
                         ></textarea>
                         <p v-if="form.errors.experience" class="text-red-400 text-sm mt-1">{{ form.errors.experience }}</p>
+                    </div>
                     </div>
 
                     <div class="grid md:grid-cols-2 gap-4">
@@ -339,7 +353,7 @@ const submit = () => {
             </div>
 
             <!-- Logged out -->
-            <div v-else-if="!user" class="bg-white/5 border border-white/10 rounded-2xl p-6 text-center">
+            <div v-else-if="!user" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-6 text-center shadow-2xl">
                 <p class="text-gray-300 mb-4">You need an account to apply.</p>
                 <Link :href="route('login')" class="inline-block px-5 py-3 bg-blue-600 hover:bg-blue-500 text-white font-semibold rounded-xl transition-colors">
                     Log in

--- a/resources/js/utils/currency.js
+++ b/resources/js/utils/currency.js
@@ -1,0 +1,17 @@
+// Prize amounts show up on the contest page, the site-wide banner and the OBS
+// overlay, and the page breaks a pool down into base + carried-over parts, so
+// the formatting has to work on arbitrary numbers rather than come ready-made
+// from the server. Keep this list in step with DefragliveContest::CURRENCIES.
+const SYMBOLS = {
+    EUR: '€',
+    USD: '$',
+};
+
+// An unknown currency keeps its code instead of losing the unit: a bad row
+// should read oddly, not silently claim to be in whatever the reader assumes.
+export const formatPrize = (amount, currency) => {
+    const value = Number(amount || 0).toFixed(2);
+    const symbol = SYMBOLS[currency];
+
+    return symbol ? `${symbol}${value}` : `${value} ${currency || ''}`.trim();
+};

--- a/resources/views/defraglive/contest-overlay.blade.php
+++ b/resources/views/defraglive/contest-overlay.blade.php
@@ -127,7 +127,7 @@
             const card = document.getElementById('card');
             if (!d.contest || !d.top.length) { card.style.display = 'none'; return; }
             document.getElementById('prize').textContent =
-                d.contest.prize_amount ? (d.contest.prize_amount + ' ' + d.contest.prize_currency + ' prize') : '';
+                d.contest.prize_amount ? (d.contest.prize_label + ' prize') : '';
             document.getElementById('rows').innerHTML = d.top.map((e, i) =>
                 '<div class="row">'
                 + '<div class="rank r' + (i + 1) + '">' + (i + 1) + '</div>'


### PR DESCRIPTION
Three small things that were left over after #339.

**A link to the validators page.** It shipped with nothing pointing at it,
so you had to know the address. It now sits in the user menu next to Server
hosting, its nearest relative: both are about helping run the place rather
than playing on it.

**Contest prizes in euros.** The prize comes out of one person's pocket and
that pocket is in euros, so that is what a new contest defaults to now.

Adding a second currency meant touching the same expression in seven
places - six on the contest page, one in the sitewide banner, one in the
admin table - and the OBS overlay printed the code with no symbol at all.
Seven copies is seven chances to add euro support to six of them, so there
is now one list of currencies instead: on the model for PHP, in
`utils/currency.js` for the frontend. The overlay is standalone for OBS and
loads no bundle, so it takes the finished string from the controller.

The admin field is a select rather than free text, which was letting "eur",
"Euro" and "EU" into one column - each of which would print without a
symbol.

Existing rows stay in dollars deliberately: they record what was actually
paid out, and relabelling a settled prize would make the hall of fame lie
about what people received. The rollover still copies the previous
contest's currency, because a forwarded pool has to stay in the currency it
was won in, so the running contest needs switching by hand for the chain to
move to euros.

**The validators page reads properly now.** It was capped at `max-w-4xl`
while every comparable page runs at `max-w-8xl`, and its boxes were
`bg-white/5` - a faintly white pane over a light background, leaving body
text with almost no contrast. They are dark glass now, matching the rest of
the site.

Widening alone would have made that worse, since a paragraph stretched
across a monitor is harder to read, not easier. The width goes into the
layout instead: the three explainers sit side by side, the ballot runs two
columns, and the intro paragraph stays capped even though the page is not.

Deploy needs `php artisan migrate` - **8** migrations, the seven from the
validators work plus the currency default.
