### PR TITLE
serverdemos: get the packed archives into B2

### DIFF
--- a/app/Http/Controllers/ServerdemoValidationDownloadController.php
+++ b/app/Http/Controllers/ServerdemoValidationDownloadController.php
@@ -51,8 +51,10 @@ class ServerdemoValidationDownloadController extends Controller
         $demo = $flag->serverDemo();
         abort_if($demo === null, 404);
 
-        $stream = $this->open($demo);
-        abort_unless(is_resource($stream), 404);
+        $opened = $this->open($demo);
+        abort_if($opened === null, 404);
+
+        [$stream, $filename] = $opened;
 
         // Chunked and flushed: Octane/Swoole caps a single buffered body and
         // answers 502 when a Content-Length accompanies chunked writes.
@@ -66,7 +68,7 @@ class ServerdemoValidationDownloadController extends Controller
                 flush();
             }
             fclose($stream);
-        }, basename($demo->path), [
+        }, $filename, [
             'Content-Type' => 'application/octet-stream',
             'X-Accel-Buffering' => 'no',
         ]);
@@ -76,22 +78,42 @@ class ServerdemoValidationDownloadController extends Controller
      * A serverdemo has two homes - the storage VPS and the B2 mirror - and
      * `on_contabo` is a scheduled guess, so both are tried in the order it
      * suggests rather than switched between.
+     *
+     * The mirror only ships files younger than a few hours, so the ~116k demos
+     * that were repacked in bulk on 2026-08-03 are in B2 under their original
+     * `.dm_68` name while the index knows them as `.dm_68.7z`. Both names are
+     * therefore tried on each disk: the same demo, and B2 legitimately holds
+     * either form depending on whether it arrived before or after packing.
+     *
+     * Returns [stream, download name] so the name matches what was actually
+     * opened - handing a raw demo out under a .7z name gives the moderator a
+     * file nothing will open.
      */
-    private function open(ServerDemo $demo)
+    private function open(ServerDemo $demo): ?array
     {
-        $candidates = $demo->on_contabo
-            ? [['serverdemos', $demo->path], ['serverdemos_b2', self::B2_PREFIX . $demo->path]]
-            : [['serverdemos_b2', self::B2_PREFIX . $demo->path], ['serverdemos', $demo->path]];
+        $paths = [$demo->path];
 
-        foreach ($candidates as [$disk, $path]) {
-            try {
-                $stream = Storage::disk($disk)->readStream($path);
-            } catch (\Throwable) {
-                $stream = null;
-            }
+        if (str_ends_with($demo->path, '.7z')) {
+            $paths[] = substr($demo->path, 0, -3);
+        }
 
-            if (is_resource($stream)) {
-                return $stream;
+        $disks = $demo->on_contabo
+            ? ['serverdemos', 'serverdemos_b2']
+            : ['serverdemos_b2', 'serverdemos'];
+
+        foreach ($disks as $disk) {
+            foreach ($paths as $path) {
+                $full = $disk === 'serverdemos_b2' ? self::B2_PREFIX . $path : $path;
+
+                try {
+                    $stream = Storage::disk($disk)->readStream($full);
+                } catch (\Throwable) {
+                    $stream = null;
+                }
+
+                if (is_resource($stream)) {
+                    return [$stream, basename($path)];
+                }
             }
         }
 

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -31,6 +31,25 @@ LOCK_FILE="/run/serverdemos-mirror.lock"
 # nebo pomalý běh nenechal díru.
 MAX_AGE="${MAX_AGE:-6h}"
 
+# CATCH_UP=1 jednorázově vypne obě zrychlení pravidelného běhu.
+#
+# --max-age filtruje podle času souboru, jenže ingest i přebalovací skript
+# archivu schválně nastaví čas původního dema. Archiv tedy vznikne dnes, ale
+# tváří se jako soubor starý týdny a do okna nikdy nespadne. Přesně proto
+# 116 tisíc dem přebalených 3.8.2026 v B2 chybí, zatímco jejich syrové
+# předlohy tam pořád leží - a bez tohohle režimu by se tam nedostala nikdy.
+#
+# --no-traverse se vyplácí, dokud je čerstvých souborů pár: zeptá se cíle na
+# každý zvlášť místo aby ho vypisoval celý. Při dohánění stovek tisíc
+# souborů je to obráceně, tam je jeden výpis mnohem levnější.
+if [ "${CATCH_UP:-0}" = "1" ]; then
+  SELECT_ARGS=()
+  MODE_NOTE="catch-up, bez omezení stáří"
+else
+  SELECT_ARGS=(--max-age "$MAX_AGE" --no-traverse)
+  MODE_NOTE="max-age $MAX_AGE"
+fi
+
 # Druhý běh nemá co dělat, když ten první ještě jede - jen by si sedly
 # na stejné soubory. -n = raději hned skončit než čekat.
 exec 9>"$LOCK_FILE"
@@ -77,11 +96,10 @@ export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"
 # protože copy nikdy nic nemaže.
 rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
   --exclude "*.part" \
-  --max-age "$MAX_AGE" \
-  --no-traverse \
+  ${SELECT_ARGS[@]+"${SELECT_ARGS[@]}"} \
   --transfers 4 \
   --sftp-concurrency 8 \
   --stats-one-line \
   --stats 0
 
-echo "[$(date)] Serverdemos mirror (max-age $MAX_AGE) OK"
+echo "[$(date)] Serverdemos mirror ($MODE_NOTE) OK"


### PR DESCRIPTION
Packing the 116k historical demos on the storage box freed 81 GB there and was meant to do the same in B2 and on the NAS behind it. It did not, and the reason is that two of our own decisions cancelled out.

The mirror only offers rclone files newer than six hours, which is what keeps a run every fifteen minutes cheap. But packing deliberately gives the archive the original demo's timestamp, so an archive written yesterday looks weeks old, falls outside that window and is never offered at all. B2 therefore still holds the raw .dm_68 originals and none of the archives.

Nothing was lost - the demos are all in B2, just unpacked - but none of the saving reached it.

CATCH_UP=1 drops both shortcuts for a one-off run: no --max-age, since the timestamps make any window useless here, and no --no-traverse, because listing the destination once beats asking about a hundred thousand files one at a time.

The download path is fixed too, and stays fixed whatever is done about the backlog: a demo may sit in B2 under either name depending on whether it arrived before or after packing, so both are tried on both disks. It hands back the name it actually opened as well - serving a raw demo as .7z gives a moderator a file that will not open.