### PR TITLE
Two player suggestions, a downloads reshuffle, and a dead scraper path

### DIFF
--- a/app/Console/Commands/ScrapeServers.php
+++ b/app/Console/Commands/ScrapeServers.php
@@ -123,18 +123,14 @@ class ScrapeServers extends Command
                 }
             }
 
-            // getstatus is gone. It only ever returned player NAMES - no uid,
-            // country, model or spectating - and it was unreachable in
-            // practice: measured 2026-08-03 across every online server, four
-            // did not answer getdfstatus and rcon works on all four, so the
-            // branch below never ran.
-            // Nothing is left uncovered either: a null result drops the
-            // server into handle_failed_servers(), which still tries q3df.org
-            // before marking it offline.
-            //
-            // if ($result === null) {
-            //     $result = $connection->getData();
-            // }
+            // There is deliberately no third attempt over plain getstatus for
+            // the player list. It returns names only - no uid, country, model
+            // or spectating - so a server answering it would be saved with
+            // worse data than one treated as unreachable. Leaving $result null
+            // is the better outcome: handle_failed_servers() then tries
+            // q3df.org, and only marks the server offline if that fails too.
+            // (getstatus itself is still in use - getRconData() sends it to
+            // read defrag_gametype, which rcon "score" does not return.)
 
         } catch (\Exception $e) {
             return null;

--- a/app/Console/Commands/ScrapeServers.php
+++ b/app/Console/Commands/ScrapeServers.php
@@ -123,14 +123,12 @@ class ScrapeServers extends Command
                 }
             }
 
-            // There is deliberately no third attempt over plain getstatus for
-            // the player list. It returns names only - no uid, country, model
-            // or spectating - so a server answering it would be saved with
-            // worse data than one treated as unreachable. Leaving $result null
-            // is the better outcome: handle_failed_servers() then tries
-            // q3df.org, and only marks the server offline if that fails too.
-            // (getstatus itself is still in use - getRconData() sends it to
-            // read defrag_gametype, which rcon "score" does not return.)
+            // There is deliberately no third attempt over plain getstatus. It
+            // returns names only - no uid, country, model or spectating - so a
+            // server answering it would be saved with worse data than one
+            // treated as unreachable. Leaving $result null is the better
+            // outcome: handle_failed_servers() then tries q3df.org, and only
+            // marks the server offline if that fails too.
 
         } catch (\Exception $e) {
             return null;

--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -117,51 +117,10 @@ class DefragServer
     }    
 
     /**
-     * Plain Quake3 getstatus. NOT USED by the scraper any more - see the
-     * commented-out branch in ScrapeServers::getServerData().
-     *
-     * It returns score, ping and name per player, of which only the name is
-     * kept: no uid, no country, no model, no spectating. Every engine in the
-     * list answers getdfstatus or rcon, so this was measured to be dead code
-     * on 2026-08-03. Left here rather than deleted because it is the only
-     * implementation of the vanilla protocol we have, and an engine that
-     * speaks nothing else may still turn up one day.
+     * The scraper's primary source. One packet carries score, ping, uid,
+     * country, model and who a spectator is watching. Returns null when the
+     * server does not answer it, and ScrapeServers falls back to rcon.
      */
-    public function getData() {
-        socket_sendto($this->socket, "\xff\xff\xff\xffgetstatus\x00", strlen("\xff\xff\xff\xffgetstatus\x00"), 0, $this->ip, $this->port);
-        $data = socket_read($this->socket, 4096);
-
-        list($serverData, $players) = $this->parseResponseBody(substr($data, 19));
-
-        $serverData['players'] = $this->parsePlayers($players);
-
-        $playerList = [];
-        $i = 0;
-
-        foreach ($serverData['players'] as $player) {
-            $playerList[$i] = $player;
-            $i++;
-        }
-
-        $result = [
-            'players' => $playerList,
-            'map' => $serverData['mapname'],
-            'hostname' => $serverData['sv_hostname'],
-            'defrag' => $this->getGameMode($serverData),
-            'defrag_gametype' => $serverData['defrag_gametype'] ?? '5',
-            'scores' => [
-                'num_players' => count($serverData['players']),
-                'speed' => 0,
-                'speed_player_num' => 0,
-                'speed_player_name' => "",
-                'players' => $serverData['players'],
-            ],
-            'rcon'  =>  false
-        ];
-
-        return $result;
-    }
-
     public function getDfStatusData() {
         socket_sendto($this->socket, "\xff\xff\xff\xffgetdfstatus\x00", strlen("\xff\xff\xff\xffgetdfstatus\x00"), 0, $this->ip, $this->port);
         $data = socket_read($this->socket, 8192);
@@ -179,7 +138,7 @@ class DefragServer
         list($serverData, $playerLines) = $this->parseResponseBody(substr($data, $headerEnd + 1));
 
         // Reject responses that aren't real statusResponse packets (e.g. "print\nBad command")
-        // so the caller can fall back to getstatus instead of saving empty data.
+        // so the caller can fall back to rcon instead of saving empty data.
         if (empty($serverData['mapname']) || empty($serverData['sv_hostname'])) {
             return null;
         }
@@ -413,28 +372,6 @@ class DefragServer
         }
 
         return $scores;
-    }
-
-    public function parsePlayers($data) {
-        $players = [];
-        foreach ($data as $line) {
-            if ($line == '') {
-                continue;
-            }
-
-            $line = utf8_decode($line);
-
-            $parts = explode(' ', $line, 3);
-
-            if (count($parts) < 3) {
-                continue;
-            }
-
-            $player = array_combine(['score', 'ping', 'name'], $parts);
-            $players[] = ['name' => $player['name']];
-        }
-
-        return $players;
     }
 
     public function parseResponseBody($body) {

--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -92,23 +92,11 @@ class DefragServer
             }
         }
     
-        // Extract defrag_gametype - rcon score doesn't include it, so we need to get it via getstatus
-        $defrag_gametype = '5'; // default
-
-        // Send getstatus to get server CVARs including defrag_gametype
-        socket_sendto($this->socket, "\xff\xff\xff\xffgetstatus\x00", strlen("\xff\xff\xff\xffgetstatus\x00"), 0, $this->ip, $this->port);
-        $statusData = socket_read($this->socket, 4096);
-
-        if ($statusData && preg_match('/defrag_gametype\\\\(\d+)/', $statusData, $matches)) {
-            $defrag_gametype = $matches[1];
-        }
-
         $result = [
             'players' => $players,
             'map' => explode(':', $data[0])[1],
             'hostname' => explode(':', $data[1])[1],
             'defrag' => explode(':', $data[2])[1],
-            'defrag_gametype' => $defrag_gametype,
             'scores' => $scores,
             'rcon'   => true
         ];
@@ -257,7 +245,6 @@ class DefragServer
             'map' => $serverData['mapname'] ?? '',
             'hostname' => $serverData['sv_hostname'] ?? '',
             'defrag' => $this->getGameMode($serverData),
-            'defrag_gametype' => $serverData['defrag_gametype'] ?? '5',
             'scores' => [
                 'num_players' => count($players),
                 'speed' => 0,

--- a/app/Http/Middleware/RememberIntendedUrl.php
+++ b/app/Http/Middleware/RememberIntendedUrl.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Remember the page somebody was on when they went to log in.
+ *
+ * `redirect()->intended()` already works, but only the `auth` middleware ever
+ * fills the session key it reads - so being bounced off a protected page
+ * brings you back afterwards, while clicking Login from an ordinary page has
+ * always dumped you on the front page. That is the case people actually hit:
+ * reading a map page, logging in to report a run, and losing their place.
+ *
+ * Runs on the Fortify routes, so it covers every way in - the nav link, a
+ * prompt on a page, a bookmark - rather than one link that has to be found
+ * and updated everywhere.
+ */
+class RememberIntendedUrl
+{
+    /**
+     * Paths that must never become a destination. Landing back on the login
+     * form after logging in, or on the logout route, is worse than the front
+     * page - and a failed attempt makes the login page its own referrer.
+     */
+    private const SKIP = [
+        'login',
+        'register',
+        'logout',
+        'forgot-password',
+        'reset-password',
+        'two-factor-challenge',
+        'user/confirm-password',
+        'user/confirmed-password-status',
+        'email/verify',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->isMethod('GET') && ! $request->session()->has('url.intended')) {
+            $previous = url()->previous();
+
+            if ($this->isWorthReturningTo($request, $previous)) {
+                $request->session()->put('url.intended', $previous);
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Only same-host pages, and never an auth page. `url()->previous()` falls
+     * back to the app root when there is no referrer at all, which is what we
+     * would have done anyway - so storing it costs nothing and saves a branch.
+     */
+    private function isWorthReturningTo(Request $request, string $previous): bool
+    {
+        $parts = parse_url($previous);
+
+        if ($parts === false || ($parts['host'] ?? null) !== $request->getHost()) {
+            return false;
+        }
+
+        $path = trim($parts['path'] ?? '', '/');
+
+        foreach (self::SKIP as $skip) {
+            if ($path === $skip || str_starts_with($path, $skip . '/')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Services/DemosTopService.php
+++ b/app/Services/DemosTopService.php
@@ -34,7 +34,11 @@ class DemosTopService
         $offline = OfflineRecord::where('map_name', $mapName)
             ->where('physics', 'LIKE', $physicsPattern)
             ->with([
-                'demo:id,q3df_login_name,q3df_login_name_colored,file_hash,country,user_id,suggested_user_id',
+                // Whole row, not a column list: the record chips hand this demo
+                // to the details panel, which needs physics, gametype, time,
+                // size and validity as well. A trimmed select made those fields
+                // silently null and the panel came up empty.
+                'demo',
                 'demo.suggestedUser',
                 'user',
                 'renderedVideos' => fn ($q) => $q->visible()->latest(),

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -102,7 +102,9 @@ return [
     |
     */
 
-    'middleware' => ['web'],
+    // RememberIntendedUrl notes where somebody came from when they open the
+    // login page, so logging in puts them back rather than on the front page.
+    'middleware' => ['web', \App\Http\Middleware\RememberIntendedUrl::class],
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/js/Components/DemoDetails.vue
+++ b/resources/js/Components/DemoDetails.vue
@@ -1,0 +1,139 @@
+<script setup>
+    import { computed } from 'vue';
+    // q3tohtml is a global property registered in app.js, like everywhere else.
+    import { describeGametype, describePhysics, describeValidity } from '@/utils/demoDetails';
+
+    const props = defineProps({
+        demo: {
+            type: Object,
+            required: true,
+        },
+    });
+
+    const gametype = computed(() => describeGametype(props.demo.gametype));
+    const physics = computed(() => describePhysics(props.demo.physics));
+    const flags = computed(() => describeValidity(props.demo.validity));
+
+    const fileSize = computed(() => {
+        const bytes = props.demo.file_size;
+
+        if (!bytes) {
+            return null;
+        }
+
+        return bytes < 1024 * 1024
+            ? `${(bytes / 1024).toFixed(0)} KB`
+            : `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    });
+
+    const recordedOn = computed(() => {
+        const date = props.demo.record_date || props.demo.created_at;
+
+        return date ? new Date(date).toLocaleDateString() : null;
+    });
+
+    /**
+     * The run itself, in the order somebody deciding whether to download would
+     * ask: what kind of run, in which physics, on what.
+     */
+    const summary = computed(() => {
+        const rows = [];
+
+        if (gametype.value) {
+            rows.push({ label: 'Mode', value: gametype.value.label });
+        }
+
+        if (physics.value) {
+            rows.push({ label: 'Physics', value: physics.value.base });
+
+            if (physics.value.teamrun) {
+                rows.push({ label: 'Type', value: 'Teamrun - more than one player in the run' });
+            }
+
+            if (physics.value.ctf !== null) {
+                rows.push({ label: 'Capture mode', value: `CTF ${physics.value.ctf}` });
+            }
+        }
+
+        if (props.demo.country) {
+            rows.push({ label: 'Country', value: props.demo.country });
+        }
+
+        if (recordedOn.value) {
+            rows.push({ label: props.demo.record_date ? 'Recorded' : 'Uploaded', value: recordedOn.value });
+        }
+
+        return rows;
+    });
+
+    const file = computed(() => {
+        const rows = [];
+
+        if (fileSize.value) {
+            rows.push({ label: 'Size', value: fileSize.value });
+        }
+
+        if (props.demo.download_count) {
+            rows.push({ label: 'Downloads', value: String(props.demo.download_count) });
+        }
+
+        if (props.demo.source) {
+            rows.push({ label: 'Source', value: props.demo.source === 'demome' ? 'Demome archive' : 'Uploaded here' });
+        }
+
+        return rows;
+    });
+</script>
+
+<template>
+    <div class="rounded-lg border border-white/10 bg-white/[0.04] backdrop-blur-sm px-4 py-3">
+        <div class="grid gap-4 md:grid-cols-3">
+            <div>
+                <h4 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">The run</h4>
+                <dl class="space-y-1">
+                    <div v-for="row in summary" :key="row.label" class="flex gap-2 text-xs">
+                        <dt class="text-gray-500 w-24 flex-shrink-0">{{ row.label }}</dt>
+                        <dd class="text-gray-200">{{ row.value }}</dd>
+                    </div>
+                    <div v-if="demo.player_name" class="flex gap-2 text-xs">
+                        <dt class="text-gray-500 w-24 flex-shrink-0">Player</dt>
+                        <dd class="text-gray-200" v-html="q3tohtml(demo.q3df_login_name_colored || demo.player_name)"></dd>
+                    </div>
+                </dl>
+            </div>
+
+            <div>
+                <h4 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">The file</h4>
+                <dl class="space-y-1">
+                    <div v-for="row in file" :key="row.label" class="flex gap-2 text-xs">
+                        <dt class="text-gray-500 w-24 flex-shrink-0">{{ row.label }}</dt>
+                        <dd class="text-gray-200">{{ row.value }}</dd>
+                    </div>
+                </dl>
+                <p v-if="demo.original_filename" class="mt-2 text-[11px] text-gray-500 break-all font-mono">
+                    {{ demo.original_filename }}
+                </p>
+            </div>
+
+            <div>
+                <h4 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">Flagged settings</h4>
+
+                <ul v-if="flags.length" class="space-y-1">
+                    <li v-for="flag in flags" :key="flag.key" class="text-xs">
+                        <span class="font-mono text-orange-300">{{ flag.key }}</span>
+                        <span class="text-gray-300"> = {{ flag.value }}</span>
+                        <span v-if="flag.note" class="block text-[11px] text-gray-500">{{ flag.note }}</span>
+                    </li>
+                </ul>
+
+                <p v-else class="text-xs text-gray-500">
+                    Nothing flagged - the parser found no unusual server or client settings.
+                </p>
+            </div>
+        </div>
+
+        <p class="mt-3 text-[11px] text-gray-500">
+            Everything here comes from the demo itself. Packet jump is not among it - the parser does not read it yet.
+        </p>
+    </div>
+</template>

--- a/resources/js/Components/DemoDetails.vue
+++ b/resources/js/Components/DemoDetails.vue
@@ -92,11 +92,11 @@
                 <h4 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">The run</h4>
                 <dl class="space-y-1">
                     <div v-for="row in summary" :key="row.label" class="flex gap-2 text-xs">
-                        <dt class="text-gray-500 w-24 flex-shrink-0">{{ row.label }}</dt>
+                        <dt class="text-gray-500 w-20 flex-shrink-0">{{ row.label }}</dt>
                         <dd class="text-gray-200">{{ row.value }}</dd>
                     </div>
                     <div v-if="demo.player_name" class="flex gap-2 text-xs">
-                        <dt class="text-gray-500 w-24 flex-shrink-0">Player</dt>
+                        <dt class="text-gray-500 w-20 flex-shrink-0">Player</dt>
                         <dd class="text-gray-200" v-html="q3tohtml(demo.q3df_login_name_colored || demo.player_name)"></dd>
                     </div>
                 </dl>
@@ -106,7 +106,7 @@
                 <h4 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">The file</h4>
                 <dl class="space-y-1">
                     <div v-for="row in file" :key="row.label" class="flex gap-2 text-xs">
-                        <dt class="text-gray-500 w-24 flex-shrink-0">{{ row.label }}</dt>
+                        <dt class="text-gray-500 w-20 flex-shrink-0">{{ row.label }}</dt>
                         <dd class="text-gray-200">{{ row.value }}</dd>
                     </div>
                 </dl>

--- a/resources/js/Components/DemoPhysicsBadges.vue
+++ b/resources/js/Components/DemoPhysicsBadges.vue
@@ -1,0 +1,44 @@
+<script setup>
+    import { computed } from 'vue';
+    import { describePhysics } from '@/utils/demoDetails';
+
+    const props = defineProps({
+        physics: {
+            type: String,
+            default: null,
+        },
+    });
+
+    const parsed = computed(() => describePhysics(props.physics));
+</script>
+
+<template>
+    <div v-if="parsed" class="flex flex-wrap items-center gap-1">
+        <!-- Colouring on the base, not on the whole string - CPM.TR and VQ3.2
+             used to fall through to the CPM colour whatever they were. -->
+        <span
+            class="inline-flex items-center px-1 py-0.5 rounded text-[10px] font-medium"
+            :class="parsed.base === 'VQ3' ? 'bg-blue-900/50 text-blue-200' : 'bg-purple-900/50 text-purple-200'"
+        >
+            {{ parsed.base }}
+        </span>
+
+        <span
+            v-if="parsed.teamrun"
+            class="inline-flex items-center px-1 py-0.5 rounded text-[10px] font-medium bg-amber-900/50 text-amber-200"
+            title="Teamrun - more than one player in the run"
+        >
+            TR
+        </span>
+
+        <span
+            v-if="parsed.ctf !== null"
+            class="inline-flex items-center px-1 py-0.5 rounded text-[10px] font-medium bg-teal-900/50 text-teal-200"
+            :title="`Capture mode ${parsed.ctf}`"
+        >
+            CTF {{ parsed.ctf }}
+        </span>
+    </div>
+
+    <span v-else class="text-gray-500">-</span>
+</template>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -1063,7 +1063,7 @@
     <!-- What this demo is, before a download is spent on it -->
     <Teleport to="body" v-if="showDemoInfo && getDemoForReport">
         <div class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 p-4" @click.self="showDemoInfo = false">
-            <div class="bg-gray-900 border border-white/10 rounded-xl shadow-2xl w-full max-w-3xl max-h-[85vh] overflow-y-auto">
+            <div class="bg-gray-900 border border-white/10 rounded-xl shadow-2xl w-full max-w-5xl max-h-[85vh] overflow-y-auto">
                 <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-3">
                     <div class="min-w-0">
                         <h3 class="text-sm font-bold text-white truncate">

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -5,6 +5,7 @@
     import DemoReportModal from '@/Components/DemoReportModal.vue';
     import DemoFlagModal from '@/Components/DemoFlagModal.vue';
     import DemoRenderButton from '@/Components/DemoRenderButton.vue';
+    import DemoDetails from '@/Components/DemoDetails.vue';
 
     const props = defineProps({
         record: Object,
@@ -74,6 +75,24 @@
     const renderError = ref(null);
     const showRenderConfirm = ref(false);
     const etiquetteAccepted = ref(false);
+
+    // Clicking a download chip shows what the demo is first. The chip stays a
+    // real link, so middle-click and ctrl-click still download straight away -
+    // only a plain left click is intercepted.
+    const showDemoInfo = ref(false);
+
+    const openDemoInfo = (event) => {
+        if (event.ctrlKey || event.metaKey || event.shiftKey || event.button === 1) {
+            return;
+        }
+
+        if (! getDemoForReport.value) {
+            return;
+        }
+
+        event.preventDefault();
+        showDemoInfo.value = true;
+    };
 
     const renderedVideo = computed(() => {
         const videos = props.record.rendered_videos;
@@ -515,7 +534,7 @@
                     <component
                         :is="demoDownloadUrl ? 'a' : 'span'"
                         :href="demoDownloadUrl"
-                        @click.stop
+                        @click.stop="openDemoInfo"
                         class="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-500/20 text-blue-400"
                         :class="{ 'hover:bg-blue-500/30 hover:text-blue-300 transition-colors': demoDownloadUrl }"
                         :title="demoDownloadUrl ? 'Download online demo' : ''"
@@ -543,7 +562,7 @@
                     <component
                         :is="demoDownloadUrl ? 'a' : 'span'"
                         :href="demoDownloadUrl"
-                        @click.stop
+                        @click.stop="openDemoInfo"
                         class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-500/20 text-gray-400"
                         :class="{ 'hover:bg-gray-500/30 hover:text-gray-300 transition-colors': demoDownloadUrl }"
                         :title="demoDownloadUrl ? 'Download offline demo' : ''"
@@ -607,7 +626,7 @@
                 >
                     <a
                         :href="demoDownloadUrl"
-                        @click.stop
+                        @click.stop="openDemoInfo"
                         class="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-500/10 text-blue-300 hover:bg-blue-500/20 hover:text-blue-200 transition-colors"
                         :class="{ 'rounded-r': !canRequestRender || renderedVideo }"
                         title="Download demo"
@@ -670,7 +689,7 @@
                     <a
                         v-if="demoDownloadUrl"
                         :href="demoDownloadUrl"
-                        @click.stop
+                        @click.stop="openDemoInfo"
                         class="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-500/10 text-blue-300 hover:bg-blue-500/20 hover:text-blue-200 transition-colors"
                         :class="{ 'rounded-r': !canRequestRender || renderedVideo }"
                         title="Download demo"
@@ -699,7 +718,7 @@
                     <component
                         :is="demoDownloadUrl ? 'a' : 'span'"
                         :href="demoDownloadUrl"
-                        @click.stop
+                        @click.stop="openDemoInfo"
                         class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-500/20 text-gray-400"
                         :class="{ 'hover:bg-gray-500/30 hover:text-gray-300 transition-colors': demoDownloadUrl }"
                         :title="demoDownloadUrl ? 'Download offline demo' : ''"
@@ -728,7 +747,7 @@
                     <component
                         :is="demoDownloadUrl ? 'a' : 'span'"
                         :href="demoDownloadUrl"
-                        @click.stop
+                        @click.stop="openDemoInfo"
                         class="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-500/20 text-blue-400"
                         :class="{ 'hover:bg-blue-500/30 hover:text-blue-300 transition-colors': demoDownloadUrl }"
                         :title="demoDownloadUrl ? 'Download online demo' : ''"
@@ -1040,6 +1059,49 @@
             ></iframe>
         </div>
     </div>
+
+    <!-- What this demo is, before a download is spent on it -->
+    <Teleport to="body" v-if="showDemoInfo && getDemoForReport">
+        <div class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 p-4" @click.self="showDemoInfo = false">
+            <div class="bg-gray-900 border border-white/10 rounded-xl shadow-2xl w-full max-w-3xl max-h-[85vh] overflow-y-auto">
+                <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-3">
+                    <div class="min-w-0">
+                        <h3 class="text-sm font-bold text-white truncate">
+                            {{ getDemoForReport.map_name || record.mapname }}
+                        </h3>
+                        <p class="text-xs text-gray-500 mt-0.5">Demo details</p>
+                    </div>
+                    <button
+                        @click="showDemoInfo = false"
+                        class="flex-shrink-0 p-1 text-gray-500 hover:text-white transition-colors"
+                        aria-label="Close">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div class="px-5">
+                    <DemoDetails :demo="getDemoForReport" />
+                </div>
+
+                <div class="flex justify-end gap-2 px-5 py-4">
+                    <button
+                        @click="showDemoInfo = false"
+                        class="px-3 py-1.5 text-xs font-medium text-gray-400 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors">
+                        Cancel
+                    </button>
+                    <a
+                        :href="demoDownloadUrl"
+                        @click="showDemoInfo = false"
+                        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-blue-200 bg-blue-600/30 hover:bg-blue-600/40 border border-blue-500/40 rounded-lg transition-colors">
+                        <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
+                        Download
+                    </a>
+                </div>
+            </div>
+        </div>
+    </Teleport>
 
     <!-- Demo Report Modal -->
     <DemoReportModal

--- a/resources/js/Pages/Demos/Index.vue
+++ b/resources/js/Pages/Demos/Index.vue
@@ -12,6 +12,8 @@ import { Head, Link, useForm, router, usePage } from '@inertiajs/vue3';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import Pagination from '@/Components/Basic/Pagination.vue';
 import LauncherBanner from '@/Components/LauncherBanner.vue';
+import DemoDetails from '@/Components/DemoDetails.vue';
+import DemoPhysicsBadges from '@/Components/DemoPhysicsBadges.vue';
 
 const $page = usePage();
 
@@ -281,6 +283,17 @@ const updateTooltipPosition = (event) => {
         x: event.clientX,
         y: event.clientY
     };
+};
+
+// Which rows have their details panel open. A set rather than a single id so
+// two demos can be compared side by side, which is the point of looking.
+const expandedDemos = ref(new Set());
+
+const toggleDetails = (id) => {
+    const next = new Set(expandedDemos.value);
+
+    next.has(id) ? next.delete(id) : next.add(id);
+    expandedDemos.value = next;
 };
 
 // Manual assignment state
@@ -2214,7 +2227,8 @@ watch(selectedPhysics, () => {
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-gray-700/50">
-                                <tr v-for="demo in filteredDemos" :key="demo.id" class="hover:bg-gray-700/30 transition-colors duration-200">
+                                <template v-for="demo in filteredDemos" :key="demo.id">
+                                <tr class="hover:bg-gray-700/30 transition-colors duration-200">
                                     <td class="px-2 py-1.5 text-xs text-gray-500 font-mono">
                                         {{ demo.id }}
                                     </td>
@@ -2264,10 +2278,7 @@ watch(selectedPhysics, () => {
                                         <span v-else class="text-gray-500">-</span>
                                     </td>
                                     <td class="px-1 py-1.5 text-xs text-gray-300">
-                                        <span v-if="demo.physics" class="inline-flex items-center px-1 py-0.5 rounded text-[10px] font-medium" :class="demo.physics === 'VQ3' ? 'bg-blue-900/50 text-blue-200' : 'bg-purple-900/50 text-purple-200'">
-                                            {{ demo.physics }}
-                                        </span>
-                                        <span v-else class="text-gray-500">-</span>
+                                        <DemoPhysicsBadges :physics="demo.physics" />
                                     </td>
                                     <td class="px-2 py-1.5 text-xs text-gray-300 font-mono">
                                         {{ formatTime(demo.time_ms) }}
@@ -2325,6 +2336,16 @@ watch(selectedPhysics, () => {
                                     <td class="px-2 py-1.5 text-xs">
                                         <div class="flex flex-wrap gap-1">
                                             <button
+                                                @click.stop="toggleDetails(demo.id)"
+                                                class="inline-flex items-center px-2 py-1 text-[11px] font-medium rounded transition-colors"
+                                                :class="expandedDemos.has(demo.id) ? 'bg-amber-600/30 text-amber-200' : 'bg-white/[0.06] text-gray-300 hover:bg-white/10'"
+                                                :title="expandedDemos.has(demo.id) ? 'Hide details' : 'What is in this demo'"
+                                            >
+                                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                </svg>
+                                            </button>
+                                            <button
                                                 @click.stop="downloadDemo(demo.id)"
                                                 class="inline-flex items-center px-2 py-1 bg-blue-600/20 text-blue-300 text-[11px] font-medium rounded hover:bg-blue-600/30 transition-colors"
                                                 title="Download"
@@ -2377,6 +2398,12 @@ watch(selectedPhysics, () => {
                                         </div>
                                     </td>
                                 </tr>
+                                <tr v-if="expandedDemos.has(demo.id)" class="bg-gray-900/40">
+                                    <td colspan="8" class="px-2 pb-3 pt-0">
+                                        <DemoDetails :demo="demo" />
+                                    </td>
+                                </tr>
+                                </template>
                             </tbody>
                         </table>
                     </div>
@@ -2623,7 +2650,8 @@ watch(selectedPhysics, () => {
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-gray-700/50">
-                                <tr v-for="demo in publicDemos.data" :key="demo.id" class="hover:bg-gray-700/30 transition-colors duration-200">
+                                <template v-for="demo in publicDemos.data" :key="demo.id">
+                                <tr class="hover:bg-gray-700/30 transition-colors duration-200">
                                     <td class="px-2 py-1.5 text-xs">
                                         <span class="text-gray-200 font-medium">{{ demo.processed_filename || demo.original_filename }}</span>
                                     </td>
@@ -2646,10 +2674,7 @@ watch(selectedPhysics, () => {
                                         <span v-else class="text-gray-500">-</span>
                                     </td>
                                     <td class="px-1 py-1.5 text-xs text-gray-300">
-                                        <span v-if="demo.physics" class="inline-flex items-center px-1 py-0.5 rounded text-[10px] font-medium" :class="demo.physics === 'VQ3' ? 'bg-blue-900/50 text-blue-200' : 'bg-purple-900/50 text-purple-200'">
-                                            {{ demo.physics }}
-                                        </span>
-                                        <span v-else class="text-gray-500">-</span>
+                                        <DemoPhysicsBadges :physics="demo.physics" />
                                     </td>
                                     <td class="px-2 py-1.5 text-xs text-gray-300 font-mono">
                                         {{ formatTime(demo.time_ms) }}
@@ -2690,6 +2715,16 @@ watch(selectedPhysics, () => {
                                     <td class="px-2 py-1.5 text-xs">
                                         <div class="flex items-center space-x-1">
                                             <button
+                                                @click.stop="toggleDetails(demo.id)"
+                                                class="inline-flex items-center px-2 py-1 text-[11px] font-medium rounded transition-colors"
+                                                :class="expandedDemos.has(demo.id) ? 'bg-amber-600/30 text-amber-200' : 'bg-white/[0.06] text-gray-300 hover:bg-white/10'"
+                                                :title="expandedDemos.has(demo.id) ? 'Hide details' : 'What is in this demo'"
+                                            >
+                                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                </svg>
+                                            </button>
+                                            <button
                                                 @click.stop="downloadDemo(demo.id)"
                                                 class="inline-flex items-center px-2 py-1 bg-blue-600/20 text-blue-300 text-[11px] font-medium rounded hover:bg-blue-600/30 transition-colors"
                                                 title="Download"
@@ -2712,6 +2747,12 @@ watch(selectedPhysics, () => {
                                         </div>
                                     </td>
                                 </tr>
+                                <tr v-if="expandedDemos.has(demo.id)" class="bg-gray-900/40">
+                                    <td colspan="8" class="px-2 pb-3 pt-0">
+                                        <DemoDetails :demo="demo" />
+                                    </td>
+                                </tr>
+                                </template>
                             </tbody>
                         </table>
                     </div>

--- a/resources/js/Pages/Demos/Index.vue
+++ b/resources/js/Pages/Demos/Index.vue
@@ -2399,7 +2399,8 @@ watch(selectedPhysics, () => {
                                     </td>
                                 </tr>
                                 <tr v-if="expandedDemos.has(demo.id)" class="bg-gray-900/40">
-                                    <td colspan="8" class="px-2 pb-3 pt-0">
+                                    <!-- Nine columns here; the browse table below has eight. -->
+                                    <td colspan="9" class="px-2 pb-3 pt-0">
                                         <DemoDetails :demo="demo" />
                                     </td>
                                 </tr>

--- a/resources/js/Pages/Downloads/Index.vue
+++ b/resources/js/Pages/Downloads/Index.vue
@@ -26,6 +26,12 @@ const sort = ref(props.filters.sort ?? 'newest');
 // Ancestors of the selected category, so its branch renders already expanded.
 const openIds = computed(() => (props.current?.breadcrumb ?? []).map((c) => c.id));
 
+// The locked categories are the ones people actually come here for - the mod,
+// the server bundle - and by position they sat at the bottom, under thirty
+// folders of maps and sounds. They go on top, in their own group.
+const pinned = computed(() => props.tree.filter((n) => n.is_locked || n.auto_source));
+const browsable = computed(() => props.tree.filter((n) => ! n.is_locked && ! n.auto_source));
+
 const baseUrl = computed(() =>
     props.current ? `/downloads/${props.current.id}/${props.current.slug}` : '/downloads'
 );
@@ -138,9 +144,40 @@ const isNew = (d) => {
                             </span>
                         </Link>
 
-                        <div class="border-t border-white/5 max-h-[70vh] overflow-y-auto py-1">
+                        <!-- The things you came for: the mod, the bundle, the
+                             launcher. Kept apart from the browsable folders. -->
+                        <div class="border-t border-white/5 py-1 bg-amber-500/[0.03]">
                             <DownloadCategoryNode
-                                v-for="node in tree"
+                                v-for="node in pinned"
+                                :key="node.id"
+                                :node="node"
+                                :current-id="current?.id"
+                                :open-ids="openIds" />
+
+                            <!-- The launcher is not a category - it has its own
+                                 page - but this is where people look for it. -->
+                            <a
+                                href="/launcher"
+                                class="group flex items-center border-l-2 border-transparent hover:bg-cyan-500/5 hover:border-cyan-500/20 transition-all">
+                                <span class="flex-shrink-0 w-5"></span>
+                                <span class="flex-1 flex items-center justify-between min-w-0 py-2 pr-3">
+                                    <span class="flex items-center gap-1.5 min-w-0">
+                                        <svg class="w-3 h-3 flex-shrink-0 text-cyan-400/70"
+                                             fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                                        </svg>
+                                        <span class="text-sm truncate text-gray-400 group-hover:text-white transition-colors">
+                                            Defrag Launcher
+                                        </span>
+                                    </span>
+                                </span>
+                            </a>
+                        </div>
+
+                        <div class="border-t border-white/10 max-h-[70vh] overflow-y-auto py-1">
+                            <DownloadCategoryNode
+                                v-for="node in browsable"
                                 :key="node.id"
                                 :node="node"
                                 :current-id="current?.id"

--- a/resources/js/utils/demoDetails.js
+++ b/resources/js/utils/demoDetails.js
@@ -1,0 +1,95 @@
+/**
+ * Says what a demo actually is, in words.
+ *
+ * Everything here was already in the database - the browse list just showed
+ * the raw column, so `VQ3.2` sat there meaning nothing to anyone who did not
+ * already know the format. A player asked to see what a demo is before
+ * spending a download on it, and this is the decoding half of that.
+ */
+
+const GAMETYPES = {
+    df: { mode: 'Defrag run', online: false },
+    mdf: { mode: 'Defrag run', online: true },
+    fc: { mode: 'Fastcap', online: false },
+    mfc: { mode: 'Fastcap', online: true },
+    fs: { mode: 'Freestyle', online: false },
+    mfs: { mode: 'Freestyle', online: true },
+    unlagged: { mode: 'Unlagged', online: true },
+};
+
+/**
+ * `gametype` is the mode word, with an `m` prefix for the online variant.
+ * Unknown values keep their own spelling rather than being dropped - a demo
+ * from a mode we have not seen is still worth listing.
+ */
+export const describeGametype = (gametype) => {
+    if (!gametype) {
+        return null;
+    }
+
+    const key = gametype.toLowerCase();
+    const known = GAMETYPES[key];
+
+    if (!known) {
+        return {
+            mode: gametype.toUpperCase(),
+            online: key.startsWith('m'),
+            label: gametype.toUpperCase(),
+        };
+    }
+
+    return {
+        ...known,
+        label: `${known.mode}, ${known.online ? 'online' : 'offline'}`,
+    };
+};
+
+/**
+ * `physics` carries more than the physics. The parser writes the demo's
+ * `<mode>.<physics>[.<variant>]` string and we keep it from the physics
+ * onwards, so `CPM.TR` is a teamrun and `VQ3.2` is capture mode 2.
+ */
+export const describePhysics = (physics) => {
+    if (!physics) {
+        return null;
+    }
+
+    const [base, ...rest] = physics.split('.');
+    const variant = rest.join('.').toUpperCase();
+    const ctf = /^\d+$/.test(variant) ? Number(variant) : null;
+
+    return {
+        base: base.toUpperCase(),
+        teamrun: variant === 'TR',
+        ctf,
+        raw: physics,
+    };
+};
+
+/**
+ * What the parser noticed about the run. Deliberately descriptive rather than
+ * a verdict: the notes name the setting, and the panel around them says these
+ * are the things that were flagged. Which of them voids a record is a rule,
+ * and rules live on /rules, not in a tooltip.
+ */
+const VALIDITY_NOTES = {
+    sv_cheats: 'Cheats were enabled on the server',
+    pmove_fixed: 'pmove_fixed setting',
+    sv_fps: 'Server tickrate',
+    com_maxfps: 'Client framerate cap',
+    client_finish: 'The client never registered the finish',
+};
+
+export const describeValidity = (validity) => {
+    if (!validity || typeof validity !== 'object') {
+        return [];
+    }
+
+    return Object.entries(validity).map(([key, value]) => ({
+        key,
+        // The parser stores everything as a float, so 1.0 and 120.0 come back
+        // for what are conceptually a flag and a whole number.
+        value: String(value).replace(/\.0$/, ''),
+        note: VALIDITY_NOTES[key] ?? null,
+    }));
+};

--- a/resources/js/utils/demoDetails.js
+++ b/resources/js/utils/demoDetails.js
@@ -74,10 +74,19 @@ export const describePhysics = (physics) => {
  */
 const VALIDITY_NOTES = {
     sv_cheats: 'Cheats were enabled on the server',
-    pmove_fixed: 'pmove_fixed setting',
-    sv_fps: 'Server tickrate',
-    com_maxfps: 'Client framerate cap',
+    sv_fps: 'Server tickrate, normally 125',
+    df_mp_interferenceoff: 'Player interference setting, normally 3',
+    timescale: 'Game speed, normally 1',
+    com_maxfps: 'Client framerate cap, normally 125',
     client_finish: 'The client never registered the finish',
+    tool_assisted: 'The run looks tool-assisted',
+    pmove_fixed: 'pmove_fixed, normally 1',
+    g_speed: 'Movement speed, normally 320',
+    g_gravity: 'Gravity, normally 800',
+    g_knockback: 'Knockback, normally 1000',
+    pmove_msec: 'pmove_msec, normally 8',
+    handicap: 'Handicap, normally 100',
+    g_killWallbug: 'Wallbug kill setting, normally 1',
 };
 
 export const describeValidity = (validity) => {


### PR DESCRIPTION
**Logging in brings you back.** `redirect()->intended()` only ever got filled
by the `auth` middleware, so clicking Login from an ordinary page lost your
place. `RememberIntendedUrl` runs on the Fortify routes, same-host GET only,
and never overwrites a real auth bounce.

**See what a demo is before downloading it.** The data was already stored - the
list just printed the raw column, so `VQ3.2` meant nothing. Physics now decodes
into badges and an info button opens a panel with the mode in words, the file,
and the twelve settings the parser flags, `tool_assisted` among them. Same panel
opens from the demo chip on map detail with the download button inside; the
chips stay real links so ctrl-click still downloads in one action. Packet jump
is not stored anywhere and the panel says so.

Two bugs found on the way: the physics badge coloured on the whole string, so
`CPM.TR` came out in the CPM colour whatever it was; and `DemosTopService`
eager-loaded the demo with a seven-column select, which left the panel blank on
Demos Top.

**Downloads.** The mod, server bundle and family-friendly build sat at the
bottom of the sidebar under thirty folders of maps. They move to their own group
on top, with the launcher linking out to `/launcher`.

**Scraper.** The commented-out getstatus branch goes, and with it a real find:
`getRconData()` was sending a getstatus packet just to read `defrag_gametype`,
which both save paths explicitly ignore. Four servers got an extra packet every
run for a field that never reached the database. The chain is now getdfstatus,
rcon, q3df.org - verified live on all 37 online servers.
