### PR TITLE
Say why the validator apply button will not send, and fix the client name in the rules

### DIFF
--- a/resources/js/Pages/Rules.vue
+++ b/resources/js/Pages/Rules.vue
@@ -20,7 +20,7 @@ const sections = [
             'You may not modify the Quake 3 or DeFRaG binaries in any way.',
             'You may not modify the memory DeFRaG uses with external programs while it runs.',
             'You may not drop or delay network packets on purpose.',
-            'Allowed clients are oDFe and iodfe. Records set on anything else are not accepted.',
+            'Allowed clients are oDFe and iDFe. Records set on anything else are not accepted.',
         ],
     },
     {

--- a/resources/js/Pages/ServerdemoValidators.vue
+++ b/resources/js/Pages/ServerdemoValidators.vue
@@ -8,7 +8,7 @@ export default {
 
 <script setup>
 import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
-import { computed, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const props = defineProps({
     application: { type: Object, default: null },
@@ -67,14 +67,31 @@ const MOTIVATION_MIN = 60;
 
 const motivationLength = computed(() => form.motivation.trim().length);
 const motivationTooShort = computed(() => motivationLength.value < MOTIVATION_MIN);
+const motivationMissing = computed(() => Math.max(0, MOTIVATION_MIN - motivationLength.value));
+
+// The button is deliberately NOT disabled. A dead button explains nothing: the
+// first person to hit this thought it was greyed out because of who he was -
+// an admin - rather than because of what he had typed. Clicking it now says
+// what is wrong and puts the cursor in the field that is wrong.
+const motivationField = ref(null);
+const blocked = ref(false);
 
 // Inertia keeps errors until the next response, so a "too short" message sat
 // under a long answer the applicant had since rewritten. It read like the
 // validation was broken. Typing clears it, and the counter takes over.
-watch(() => form.motivation, () => form.clearErrors('motivation', 'throttle'));
+watch(() => form.motivation, () => {
+    form.clearErrors('motivation', 'throttle');
+    blocked.value = false;
+});
 
 const submit = () => {
+    // Stopping the short answer here means it never becomes a request. The
+    // rate limit counts every POST, including the ones the server itself
+    // rejects, so a bounced attempt used to cost the applicant one for nothing.
     if (motivationTooShort.value) {
+        blocked.value = true;
+        motivationField.value?.focus();
+        motivationField.value?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         return;
     }
 
@@ -312,16 +329,25 @@ const submit = () => {
                         <label class="block text-sm font-semibold text-gray-300 mb-2">
                             Why do you want to do this?
                             <span class="text-red-400">*</span>
+                            <span class="font-normal text-gray-500">- required, at least {{ MOTIVATION_MIN }} characters</span>
                         </label>
                         <textarea
+                            ref="motivationField"
                             v-model="form.motivation"
                             rows="5"
-                            placeholder="A few sentences is plenty."
-                            class="w-full px-4 py-3 bg-black/40 border border-white/10 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="A couple of sentences is plenty. Why you, and what you would be looking at."
+                            class="w-full px-4 py-3 bg-black/40 border rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            :class="blocked ? 'border-amber-400/60' : 'border-white/10'"
                         ></textarea>
                         <p v-if="form.errors.motivation" class="text-red-400 text-sm mt-1">{{ form.errors.motivation }}</p>
-                        <p v-else-if="motivationTooShort" class="text-gray-500 text-sm mt-1">
-                            {{ MOTIVATION_MIN - motivationLength }} more character{{ MOTIVATION_MIN - motivationLength === 1 ? '' : 's' }} needed.
+                        <p v-else-if="motivationTooShort" class="text-sm mt-1" :class="blocked ? 'text-amber-300 font-semibold' : 'text-amber-400/70'">
+                            This one is the only answer that is required, and it is
+                            {{ motivationMissing }} character{{ motivationMissing === 1 ? '' : 's' }} short of the
+                            {{ MOTIVATION_MIN }} it needs
+                            <span class="text-gray-500 font-normal">({{ motivationLength }} so far)</span>.
+                        </p>
+                        <p v-else class="text-green-400/80 text-sm mt-1">
+                            Long enough - you can send the application.
                         </p>
                     </div>
 
@@ -364,13 +390,39 @@ const submit = () => {
 
                     <p v-if="form.errors.throttle" class="text-red-400 text-sm">{{ form.errors.throttle }}</p>
 
-                    <button
-                        type="submit"
-                        :disabled="form.processing || motivationTooShort"
-                        class="px-5 py-3 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors"
+                    <!-- Spelled out rather than implied by a greyed-out button.
+                         Whoever hits this needs to know it is about the text in
+                         the box and nothing else - not their account, not their
+                         role, not the site being broken. -->
+                    <div
+                        v-if="blocked"
+                        class="rounded-xl border border-amber-400/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
                     >
-                        {{ form.processing ? 'Sending...' : 'Send application' }}
-                    </button>
+                        <span class="font-bold">Nothing was sent yet.</span>
+                        The first question - <span class="font-semibold">Why do you want to do this?</span> - still needs
+                        {{ motivationMissing }} more character{{ motivationMissing === 1 ? '' : 's' }}.
+                        That is the only thing stopping this form: your account is fine, and the other three
+                        answers are optional. Write a sentence or two about why you want to watch these demos
+                        and the button will go through.
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <button
+                            type="submit"
+                            :disabled="form.processing"
+                            class="px-5 py-3 font-semibold rounded-xl transition-colors disabled:cursor-wait"
+                            :class="motivationTooShort
+                                ? 'bg-white/10 hover:bg-white/15 text-gray-300 border border-white/20'
+                                : 'bg-blue-600 hover:bg-blue-500 text-white'"
+                        >
+                            {{ form.processing ? 'Sending...' : 'Send application' }}
+                        </button>
+
+                        <p v-if="motivationTooShort && ! blocked" class="text-gray-400 text-sm">
+                            Waiting on {{ motivationMissing }} more character{{ motivationMissing === 1 ? '' : 's' }}
+                            in the first answer.
+                        </p>
+                    </div>
                 </form>
             </div>
 

--- a/tests/Feature/ServerdemoValidatorApplyTest.php
+++ b/tests/Feature/ServerdemoValidatorApplyTest.php
@@ -123,6 +123,40 @@ class ServerdemoValidatorApplyTest extends TestCase
             ->assertSessionHasErrors('throttle');
     }
 
+    /**
+     * The limit is keyed on the user, not the address. One person exhausting
+     * theirs must not touch anybody else - the announcement means a lot of
+     * people arriving at once, several of them behind the same NAT.
+     */
+    public function test_one_person_hitting_the_limit_does_not_block_anyone_else(): void
+    {
+        $blocked = $this->applicant();
+
+        foreach (range(1, 20) as $ignored) {
+            $this->actingAs($blocked)->post(route('serverdemo-validators.apply'), $this->payload('too short'));
+        }
+
+        $this->actingAs($blocked)
+            ->post(route('serverdemo-validators.apply'), $this->payload())
+            ->assertStatus(429);
+
+        // Nineteen other applicants, each fumbling the form twice first.
+        foreach (range(1, 19) as $ignored) {
+            $other = $this->applicant();
+
+            $this->actingAs($other)->post(route('serverdemo-validators.apply'), $this->payload('too short'));
+            $this->actingAs($other)->post(route('serverdemo-validators.apply'), $this->payload('still too short'));
+
+            $this->actingAs($other)
+                ->post(route('serverdemo-validators.apply'), $this->payload())
+                ->assertSessionHasNoErrors();
+
+            $this->assertDatabaseHas('serverdemo_validator_applications', ['user_id' => $other->id]);
+        }
+
+        $this->assertSame(19, ServerdemoValidatorApplication::count());
+    }
+
     protected function tearDown(): void
     {
         RateLimiter::clear('serverdemo-validators.apply');

--- a/tests/Feature/ServerdemoValidatorApplyTest.php
+++ b/tests/Feature/ServerdemoValidatorApplyTest.php
@@ -123,40 +123,6 @@ class ServerdemoValidatorApplyTest extends TestCase
             ->assertSessionHasErrors('throttle');
     }
 
-    /**
-     * The limit is keyed on the user, not the address. One person exhausting
-     * theirs must not touch anybody else - the announcement means a lot of
-     * people arriving at once, several of them behind the same NAT.
-     */
-    public function test_one_person_hitting_the_limit_does_not_block_anyone_else(): void
-    {
-        $blocked = $this->applicant();
-
-        foreach (range(1, 20) as $ignored) {
-            $this->actingAs($blocked)->post(route('serverdemo-validators.apply'), $this->payload('too short'));
-        }
-
-        $this->actingAs($blocked)
-            ->post(route('serverdemo-validators.apply'), $this->payload())
-            ->assertStatus(429);
-
-        // Nineteen other applicants, each fumbling the form twice first.
-        foreach (range(1, 19) as $ignored) {
-            $other = $this->applicant();
-
-            $this->actingAs($other)->post(route('serverdemo-validators.apply'), $this->payload('too short'));
-            $this->actingAs($other)->post(route('serverdemo-validators.apply'), $this->payload('still too short'));
-
-            $this->actingAs($other)
-                ->post(route('serverdemo-validators.apply'), $this->payload())
-                ->assertSessionHasNoErrors();
-
-            $this->assertDatabaseHas('serverdemo_validator_applications', ['user_id' => $other->id]);
-        }
-
-        $this->assertSame(19, ServerdemoValidatorApplication::count());
-    }
-
     protected function tearDown(): void
     {
         RateLimiter::clear('serverdemo-validators.apply');


### PR DESCRIPTION
Two fixes to what the rules enforcement announcement sent people at.

**The apply form on /serverdemo-validators.** The send button was disabled
while the first answer was under sixty characters, and the only explanation
was a grey line of text next to a different field. The first person who hit
it assumed it was greyed out because he is an admin.

The button is clickable now. Pressing it with a short answer still sends
nothing, but it focuses the field that is short and says what is missing:
how many characters, that this is the only required answer, and that the
account is not the problem. The counter under the field is amber instead of
grey and turns green once the answer is long enough.

The short answer never reaches the server either way, which is the point of
the guard: the rate limit counts rejected posts too.

**/rules** said the allowed clients are oDFe and "iodfe". It is iDFe.

The two other commits are a test added earlier and its revert, already
discussed.
