### PR TITLE
Stop losing serverdemos: the scraper's last key, and two runs that share a name

### DIFF
--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -366,10 +366,20 @@ class DefragServer
         $keys = [];
         $values = [];
         while (strpos($body, '\\') === 0) {
-            if (strpos($body, '\\', 1) !== false) {
-                $elementEnd = strpos($body, '\\', 1);
-            } elseif (strpos($body, '\n', 1) !== false) {
-                $elementEnd = strpos($body, '\n', 1);
+            $nextKey = strpos($body, '\\', 1);
+            $lineEnd = strpos($body, "\n", 1);
+
+            // The last value of the infostring has no backslash after it - it
+            // ends at the newline the player lines start on. This looked for
+            // '\n' in single quotes, which is a literal backslash followed by
+            // n and never matches a real newline, so the loop stopped one
+            // element early and the final key/value pair of every reply was
+            // thrown away. Whichever delimiter comes first wins, so a stray
+            // backslash further down cannot swallow the player lines either.
+            if ($nextKey !== false && ($lineEnd === false || $nextKey < $lineEnd)) {
+                $elementEnd = $nextKey;
+            } elseif ($lineEnd !== false) {
+                $elementEnd = $lineEnd;
             } else {
                 break;
             }

--- a/app/Services/ServerDemoPath.php
+++ b/app/Services/ServerDemoPath.php
@@ -128,7 +128,14 @@ class ServerDemoPath
     {
         $base = preg_replace(self::DEMO_SUFFIX, '', $filename);
 
-        if (preg_match('/^(.+?)\[(\d+)\]\[(\d+)\]$/', $base, $m)) {
+        // The third bracket is a copy number, and it exists because the
+        // recordsystem's name is not unique: one player hitting the same time
+        // twice on the same map writes map[time][mdd] both times. Found on
+        // 2026-08-04, when czsk2009-zerg[24672][12212] turned out to be two
+        // genuinely different runs - one had already overwritten the other.
+        // Both have to survive, so the second is stored as [2], the third as
+        // [3], and they still read as the same map, time and player.
+        if (preg_match('/^(.+?)\[(\d+)\]\[(\d+)\](?:\[(\d+)\])?$/', $base, $m)) {
             return ['map' => $m[1], 'time' => (int) $m[2], 'mdd_id' => (int) $m[3]];
         }
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -125,9 +125,16 @@ if [ -n "$B2_SERVERDEMOS_KEY_ID" ] && [ -n "$B2_SERVERDEMOS_APP_KEY" ] && [ -n "
 
   # --exclude *.part viz serverdemos-mirror.sh: rozdělaný archiv z ingestu
   # se do B2 nesmí dostat, protože odtud už se nikdy nesmaže.
+  #
+  # --immutable taky viz serverdemos-mirror.sh: jméno dema není unikátní a bez
+  # tohohle přepínače by se dvě různé jízdy se stejným časem od jednoho hráče
+  # přepsaly v B2 navzájem. Přejmenování kolizí řeší ten patnáctiminutový běh,
+  # tady jde jen o to nepřepsat nic dřív, než se k tomu dostane. Kolizní
+  # soubor se nenahraje, ostatní projdou.
   rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
     --exclude "*.part" \
-    --transfers 4 --sftp-concurrency 8
+    --immutable \
+    --transfers 4 --sftp-concurrency 8 || true
   echo "[$(date)] Serverdemos mirror na B2 OK"
 else
   echo "[$(date)] Serverdemos přeskočeny (B2_SERVERDEMOS_* / STORAGE_VPS_DL_* není v .env)"

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -94,12 +94,75 @@ export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"
 # --exclude *.part: ingest balí demo do dočasného .7z.part a teprve hotový
 # archiv přejmenuje. Nahrát rozdělaný kus by znamenalo mít ho v B2 navždy,
 # protože copy nikdy nic nemaže.
+RUN_LOG="$(mktemp)"
+trap 'rm -f "$RUN_LOG"' EXIT
+
+# --immutable je tu kvůli tomu, že jméno dema není unikátní. Recordsystem
+# pojmenovává soubor mapa[čas][mdd], takže dvě různé jízdy jednoho hráče se
+# stejným časem na stejné mapě dostanou totožné jméno. Bez tohohle přepínače
+# by rclone objekt v B2 tiše přepsal a starší jízda by zmizela - přesně to se
+# stalo u czsk2009-zerg[24672][12212], kde se syrový upload a uložený archiv
+# lišily obsahem. Teď se takový soubor nenahraje a vypíše se jako ERROR;
+# všechny ostatní projdou normálně a nic se nikde nemaže, copy jen zapisuje.
+#
+# Návratový kód na to nestačí, rclone jím kolizi neodliší od výpadku sítě,
+# proto se rozhoduje podle konkrétní hlášky níž.
+set +e
 rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
   --exclude "*.part" \
+  --immutable \
   ${SELECT_ARGS[@]+"${SELECT_ARGS[@]}"} \
   --transfers 4 \
   --sftp-concurrency 8 \
   --stats-one-line \
-  --stats 0
+  --stats 0 2>&1 | tee "$RUN_LOG"
+rc=${PIPESTATUS[0]}
+set -e
 
-echo "[$(date)] Serverdemos mirror ($MODE_NOTE) OK"
+mapfile -t KOLIZE < <(
+  grep -oP '^ERROR : \K.*(?=: Source and destination exist but do not match: immutable file modified$)' \
+    "$RUN_LOG" | sort -u
+)
+
+# Přejmenovává se na storage, ne až v B2. Odtud si to zbytek řetězu vezme
+# sám: serverdemos:index běží po čtvrthodinách, uvidí nové jméno a založí
+# druhý řádek v server_demos, protože parser čte [2] jako tutéž mapu, čas i
+# hráče. Příští běh zrcadlení pak archiv nahraje bez kolize. Žádný ruční
+# zápis do databáze a žádná zvláštní větev nikde jinde.
+for rel in ${KOLIZE[@]+"${KOLIZE[@]}"}; do
+  if [[ ! "$rel" =~ ^(.*)(\.dm_[0-9]+(\.7z)?)$ ]]; then
+    echo "[$(date)] KOLIZE: neznámý tvar jména, přeskakuji: $rel" >&2
+    continue
+  fi
+  stem="${BASH_REMATCH[1]}"
+  ext="${BASH_REMATCH[2]}"
+
+  # Volné pořadí se hledá na obou stranách. B2 proto, že archivy ze storage
+  # jednou zmizí a trvalou pravdou o tom, co už existuje, zůstane bucket.
+  n=2
+  while [ "$n" -le 20 ] \
+    && { rclone lsf "sdsftp:/var/lib/serverdemos/${stem}[${n}]${ext}" >/dev/null 2>&1 \
+      || rclone lsf "sdb2:$B2_SERVERDEMOS_BUCKET/serverdemos/${stem}[${n}]${ext}" >/dev/null 2>&1; }; do
+    n=$((n + 1))
+  done
+
+  if [ "$n" -gt 20 ]; then
+    echo "[$(date)] KOLIZE: víc než 20 kopií, nechávám být: $rel" >&2
+    continue
+  fi
+
+  if rclone moveto "sdsftp:/var/lib/serverdemos/$rel" \
+                   "sdsftp:/var/lib/serverdemos/${stem}[${n}]${ext}"; then
+    echo "[$(date)] KOLIZE: $rel -> ${stem}[${n}]${ext}"
+  else
+    echo "[$(date)] KOLIZE: přejmenování selhalo, demo zůstává v jedné kopii: $rel" >&2
+  fi
+done
+
+# Nenulový kód bez jediné kolize je skutečná chyba a musí být vidět.
+if [ "$rc" -ne 0 ] && [ "${#KOLIZE[@]}" -eq 0 ]; then
+  echo "[$(date)] Serverdemos mirror ($MODE_NOTE) SELHAL, rclone rc=$rc" >&2
+  exit "$rc"
+fi
+
+echo "[$(date)] Serverdemos mirror ($MODE_NOTE) OK, kolizí: ${#KOLIZE[@]}"


### PR DESCRIPTION
Three fixes found while costing out an unrelated feature.

**The scraper threw away the last key of every server reply.** The infostring
loop looked for `'\n'` in single quotes, which is a literal backslash followed
by n, not a newline. The last value has no backslash after it, so the search
never matched and the loop stopped one element short. Measured against a live
server: 34 keys in the packet, 29 of 30 stored, `.server-location` never
arriving. Whichever delimiter comes first now wins, so a stray backslash below
the infostring cannot swallow the player lines either.

**A demo's name is not unique, and one was overwriting the other.** The
recordsystem writes `map[time][mdd]`, so one player hitting the same time
twice on the same map produces the same name for two different runs.
`czsk2009-zerg[24672][12212]` is one: the raw upload sitting in B2 and the
stored archive held different data, and whichever arrived second had already
replaced the first.

`rclone copy` replaces an object whose key exists, silently. `--immutable`
makes it refuse and report the file instead; everything else transfers as
before and nothing is deleted on either side. The exit code cannot tell a
collision from a dropped connection, so the decision comes off the specific
message in the log, and a non-zero code with no collisions still fails the run.

The rename happens on the storage box rather than in B2, which leaves the rest
of the chain with no special case: `serverdemos:index` runs every fifteen
minutes, sees the new name and writes the second row itself, because the path
parser now reads a third bracket as a copy number. Names that already exist
are unaffected - maps carrying their own brackets (`[dm]4mincreate`) and maps
starting with a hyphen (`-nw-simple`) parse exactly as they did.

The nightly full copy gets `--immutable` too, or it would overwrite in the
hours before the quarter-hourly run reaches the collision.
