### PR TITLE
mirror: keep raw demos out of B2 unless they are the only copy

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -131,8 +131,14 @@ if [ -n "$B2_SERVERDEMOS_KEY_ID" ] && [ -n "$B2_SERVERDEMOS_APP_KEY" ] && [ -n "
   # přepsaly v B2 navzájem. Přejmenování kolizí řeší ten patnáctiminutový běh,
   # tady jde jen o to nepřepsat nic dřív, než se k tomu dostane. Kolizní
   # soubor se nenahraje, ostatní projdou.
+  # --exclude *.dm_68 taky viz serverdemos-mirror.sh: syrové demo je na disku
+  # jen tu chvíli, než ho ingest zabalí, a nahrát ho sem znamená nechat ho v
+  # B2 navždy vedle jeho vlastního archivu. To, co se opravdu nezabalilo,
+  # zálohuje ten patnáctiminutový běh, který si u každého ověří, že vedle
+  # sebe archiv nemá.
   rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
     --exclude "*.part" \
+    --exclude "*.dm_68" \
     --immutable \
     --transfers 4 --sftp-concurrency 8 || true
   echo "[$(date)] Serverdemos mirror na B2 OK"

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -110,6 +110,7 @@ trap 'rm -f "$RUN_LOG"' EXIT
 set +e
 rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
   --exclude "*.part" \
+  --exclude "*.dm_68" \
   --immutable \
   ${SELECT_ARGS[@]+"${SELECT_ARGS[@]}"} \
   --transfers 4 \
@@ -159,10 +160,39 @@ for rel in ${KOLIZE[@]+"${KOLIZE[@]}"}; do
   fi
 done
 
+# Syrová dema se nahrávají jen tehdy, když se nezabalila.
+#
+# Ingest balí demo hned po příchodu, ale zrcadlení jede po čtvrthodinách a
+# dřív nebo později se do toho okna trefí. Pak nahraje syrovou verzi, o pár
+# minut později vedle ní přistane archiv a syrová kopie tam zůstane navždy,
+# protože copy nikdy nic nemaže. Takhle se v bucketu 4.8.2026 našly čtyři a
+# pátý přibyl během hodiny, co se první tři uklízely.
+#
+# Vypnout je natvrdo ale nejde: když se balení nepovede, je ta syrová verze
+# jediná, co existuje, a bez zálohy by visela v jedné kopii na disku, který
+# už jednou došel. Rozhoduje proto přesná podmínka - archiv vedle sebe na
+# storage. Za normálního provozu je tenhle seznam prázdný, takže to nic
+# nestojí.
+mapfile -t SYROVA < <(
+  rclone lsf sdsftp:/var/lib/serverdemos -R --files-only --include "*.dm_68" 2>/dev/null
+)
+
+nezabalenych=0
+for raw in ${SYROVA[@]+"${SYROVA[@]}"}; do
+  if rclone lsf "sdsftp:/var/lib/serverdemos/${raw}.7z" >/dev/null 2>&1; then
+    continue
+  fi
+  nezabalenych=$((nezabalenych + 1))
+  echo "[$(date)] NEZABALENO, zálohuji syrové: $raw" >&2
+  rclone copyto "sdsftp:/var/lib/serverdemos/$raw" \
+                "sdb2:$B2_SERVERDEMOS_BUCKET/serverdemos/$raw" \
+    || echo "[$(date)] záloha syrového selhala: $raw" >&2
+done
+
 # Nenulový kód bez jediné kolize je skutečná chyba a musí být vidět.
 if [ "$rc" -ne 0 ] && [ "${#KOLIZE[@]}" -eq 0 ]; then
   echo "[$(date)] Serverdemos mirror ($MODE_NOTE) SELHAL, rclone rc=$rc" >&2
   exit "$rc"
 fi
 
-echo "[$(date)] Serverdemos mirror ($MODE_NOTE) OK, kolizí: ${#KOLIZE[@]}"
+echo "[$(date)] Serverdemos mirror ($MODE_NOTE) OK, kolizí: ${#KOLIZE[@]}, nezabalených: $nezabalenych"


### PR DESCRIPTION
The ingest daemon packs a demo the moment it lands, but this runs every fifteen minutes and eventually falls inside that window. It then uploads the raw file, the archive arrives beside it minutes later, and the raw stays in the bucket for good, because copy never deletes. Four were sitting there on 2026-08-04 and a fifth appeared during the hour it took to clear the first three.

Sweeping them afterwards treats the symptom. Not uploading them does not, and turning them off outright is worse than either: when packing fails the raw file is the only copy there is, and it would sit alone on a disk that has already run full once.

So the two cases get told apart by the one condition that actually distinguishes them - whether an archive sits next to it on storage. The main pass excludes *.dm_68 (which leaves *.dm_68.7z alone), and a second pass lists the raw files, skips every one that has been packed, and backs up the rest. That list is empty in normal operation, so it costs nothing, and a demo that failed to pack is now called out in the log by name instead of quietly turning into a leftover.

The nightly full copy gets the same exclusion. The quarter-hourly run owns the failure case; the nightly one has no business re-uploading raw files it would only orphan.