### PR TITLE
Ask servers for the players that did not fit in one packet

### DIFF
--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -105,12 +105,26 @@ class DefragServer
     }    
 
     /**
-     * The scraper's primary source. One packet carries score, ping, uid,
-     * country, model and who a spectator is watching. Returns null when the
-     * server does not answer it, and ScrapeServers falls back to rcon.
+     * One getdfstatus round trip, starting from the given player index.
+     *
+     * The index goes in the second argument, so the challenge slot in front of
+     * it has to be filled with something - it is echoed straight back and
+     * nothing here reads it. A server without paging ignores the extra
+     * argument and answers from the start, which is why round zero sends the
+     * bare command exactly as before.
+     *
+     * @return array{0:array<string,string>,1:list<string>}|null
      */
-    public function getDfStatusData() {
-        socket_sendto($this->socket, "\xff\xff\xff\xffgetdfstatus\x00", strlen("\xff\xff\xff\xffgetdfstatus\x00"), 0, $this->ip, $this->port);
+    private function requestDfStatus(int $from): ?array {
+        $command = "\xff\xff\xff\xffgetdfstatus";
+
+        if ($from > 0) {
+            $command .= ' 0 ' . $from;
+        }
+
+        $command .= "\x00";
+
+        socket_sendto($this->socket, $command, strlen($command), 0, $this->ip, $this->port);
         $data = socket_read($this->socket, 8192);
 
         if (empty($data)) {
@@ -123,12 +137,54 @@ class DefragServer
             return null;
         }
 
-        list($serverData, $playerLines) = $this->parseResponseBody(substr($data, $headerEnd + 1));
+        list($serverData, $rawLines) = $this->parseResponseBody(substr($data, $headerEnd + 1));
+
+        $lines = array_values(array_filter($rawLines, fn ($line) => trim($line) !== ''));
+
+        return [$serverData, $lines];
+    }
+
+    /**
+     * The scraper's primary source. One packet carries score, ping, uid,
+     * country, model and who a spectator is watching. Returns null when the
+     * server does not answer it, and ScrapeServers falls back to rcon.
+     */
+    public function getDfStatusData() {
+        $reply = $this->requestDfStatus(0);
+
+        if ($reply === null) {
+            return null;
+        }
+
+        list($serverData, $playerLines) = $reply;
 
         // Reject responses that aren't real statusResponse packets (e.g. "print\nBad command")
         // so the caller can fall back to rcon instead of saving empty data.
         if (empty($serverData['mapname']) || empty($serverData['sv_hostname'])) {
             return null;
+        }
+
+        // The reply is capped at one 1400 byte datagram, and a busy server runs
+        // out of room somewhere around ten players with the rest simply absent.
+        // A server that can be asked for the rest says so by reporting how many
+        // players it has; we then ask again from where the last part ended.
+        //
+        // Absent on a server that has not been updated, in which case $total is
+        // 0, the loop never runs and this behaves exactly as it did before.
+        // The round cap is a backstop against a server that keeps claiming more
+        // players than it ever sends - 5 rounds is roughly 50 players, well
+        // past the 32 slots anyone runs.
+        $total = isset($serverData['clients']) ? (int) $serverData['clients'] : 0;
+        $rounds = 0;
+
+        while ($total > count($playerLines) && $rounds++ < 5) {
+            $more = $this->requestDfStatus(count($playerLines));
+
+            if ($more === null || $more[1] === []) {
+                break;
+            }
+
+            $playerLines = array_merge($playerLines, $more[1]);
         }
 
         // Parse player lines - three formats:

--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -105,9 +105,9 @@ class DefragServer
     }    
 
     /**
-     * One getdfstatus round trip, starting from the given player index.
+     * One getdfstatus round trip, starting from the given client slot.
      *
-     * The index goes in the second argument, so the challenge slot in front of
+     * The slot goes in the second argument, so the challenge slot in front of
      * it has to be filled with something - it is echoed straight back and
      * nothing here reads it. A server without paging ignores the extra
      * argument and answers from the start, which is why round zero sends the
@@ -178,7 +178,16 @@ class DefragServer
         $rounds = 0;
 
         while ($total > count($playerLines) && $rounds++ < 5) {
-            $more = $this->requestDfStatus(count($playerLines));
+            // Continue from one past the last client slot we were given, not
+            // from the number of players we hold. Slots hold still; counts do
+            // not, and somebody leaving between two requests would renumber
+            // everyone behind them and skip whoever landed on the boundary.
+            // Slot is the third field of a line - score, ping, then the slot.
+            if (! preg_match('/^-?\d+\s+\d+\s+(\d+)\s/', end($playerLines), $m)) {
+                break;
+            }
+
+            $more = $this->requestDfStatus((int) $m[1] + 1);
 
             if ($more === null || $more[1] === []) {
                 break;

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -307,6 +307,18 @@ const submitNewCred = () => {
                         nothing to say they exist</strong> - on servers configured for 32 slots. We would be listing
                         your server with a third of its players and matching records against a scoreboard that is not
                         the real one.</p>
+                        <p class="text-gray-400 mt-2">A bigger packet is not the answer - past the network's MTU it
+                        gets split in transit, and losing one piece loses the whole reply instead of just the end of
+                        a list. Neither is a shorter line. As it stands a line cannot go below 25 bytes with every
+                        text field empty (nine spaces, a newline, five pairs of quotes, and five numbers of at least
+                        one digit), and 32 of those on top of a 700 byte server info is already over the limit before
+                        the first character of the first nickname.</p>
+                        <p class="text-gray-400 mt-2">Even throwing the format away entirely does not get there.
+                        With <strong class="text-gray-200">nothing but a slot and a name</strong> - no ping, no
+                        score, no country, no MDD id, no model - 32 players leave about 15 bytes each for the name on
+                        a typical server. Measured against the nicknames online right now, a quarter of them are
+                        already too long for that, and colour codes count (<code>^8</code> is two bytes). So the
+                        reply gets asked for in parts instead.</p>
                         <p class="text-gray-400 mt-2">So the reply has to be askable in parts. Run a current
                         <a href="https://github.com/Defrag-racing/oDFe" target="_blank" rel="noopener"
                            class="text-emerald-300 hover:text-emerald-200 underline decoration-dotted">oDFe</a> or the

--- a/resources/js/Pages/ServerHosting.vue
+++ b/resources/js/Pages/ServerHosting.vue
@@ -300,18 +300,57 @@ const submitNewCred = () => {
                         and record system and may be delisted until updated.</p>
                     </li>
                     <li>
-                        <div class="font-semibold text-gray-100 mb-1">5. Stability and fair play</div>
+                        <div class="font-semibold text-gray-100 mb-1">5. Your engine must answer with the whole player list</div>
+                        <p class="text-gray-400">A <code>getdfstatus</code> reply is one 1400 byte packet. The server
+                        info takes 550-700 of it and each player line another 57-74, so the reply fills up at around
+                        ten players and everyone after that is <strong class="text-gray-200">missing from it with
+                        nothing to say they exist</strong> - on servers configured for 32 slots. We would be listing
+                        your server with a third of its players and matching records against a scoreboard that is not
+                        the real one.</p>
+                        <p class="text-gray-400 mt-2">So the reply has to be askable in parts. Run a current
+                        <a href="https://github.com/Defrag-racing/oDFe" target="_blank" rel="noopener"
+                           class="text-emerald-300 hover:text-emerald-200 underline decoration-dotted">oDFe</a> or the
+                        defrag.racing server bundle and you already have it. On any other engine it is these few lines
+                        in <code>SVC_Status_Defrag</code>, right after the <code>challenge</code> key is set:</p>
+                        <pre class="mt-2 p-3 rounded-lg bg-black/50 border border-white/10 text-xs text-gray-300 overflow-x-auto"><code>// "getdfstatus &lt;challenge&gt; &lt;first&gt;" - answer from that player on
+firstClient = atoi( Cmd_Argv( 2 ) );
+if ( firstClient &lt; 0 ) {
+    firstClient = 0;
+}
+
+for ( i = 0; i &lt; sv.maxclients; i++ ) {
+    if ( svs.clients[i].state &gt;= CS_CONNECTED ) {
+        totalClients++;
+    }
+}
+
+Info_SetValueForKey( infostring, "clients", va( "%i", totalClients ) );
+Info_SetValueForKey( infostring, "clientsFrom", va( "%i", firstClient ) );
+
+// ...and in the loop that writes the player lines, skip the ones
+// an earlier part already carried:
+if ( listedClients++ &lt; firstClient ) {
+    continue;
+}</code></pre>
+                        <p class="text-gray-400 mt-2">It breaks nothing. An engine without it ignores the extra
+                        argument and replies as it always did, and one request is still one reply, so the existing rate
+                        limit bounds it exactly as before. We can see which servers have it - the reply either carries
+                        <code>clients</code> or it does not - and a server that never sends it will be delisted once
+                        its player list starts getting cut off.</p>
+                    </li>
+                    <li>
+                        <div class="font-semibold text-gray-100 mb-1">6. Stability and fair play</div>
                         <p class="text-gray-400">Keep your server reasonably stable and reachable. Do not tamper with
                         recorded demos, timers, or record submission in any way. Any manipulation leads to immediate
                         deactivation.</p>
                     </li>
                     <li>
-                        <div class="font-semibold text-gray-100 mb-1">6. Naming and conduct</div>
+                        <div class="font-semibold text-gray-100 mb-1">7. Naming and conduct</div>
                         <p class="text-gray-400">Server names must not impersonate other servers/communities and must
                         not contain offensive content. Admins are expected to act respectfully towards players.</p>
                     </li>
                     <li>
-                        <div class="font-semibold text-gray-100 mb-1">7. Support</div>
+                        <div class="font-semibold text-gray-100 mb-1">8. Support</div>
                         <p class="text-gray-400">If you have trouble setting up the bundle or the SFTP connection,
                         contact <a href="/profile/8"
                                    class="text-emerald-300 hover:text-emerald-200 underline decoration-dotted">neyo</a>


### PR DESCRIPTION
A `getdfstatus` reply is one 1400 byte datagram. The server info takes
550-700 of it and each player line another 57-74, so it fills up and the
players who did not fit are simply absent - no error, no marker, the scraper
believes what arrived. Every server answering today runs `sv_maxclients 32`.

Measured on the busiest one just now: 10 players, 1144 bytes used, 256 left.
Four more people and the list starts getting cut.

So a server that can be asked for the rest reports how many players it has,
and the fetch becomes a loop: read the first packet, and while the count
falls short, ask again from one past the last client slot seen. Slot rather
than count, because somebody leaving between two requests renumbers everyone
behind them and whoever sat on the boundary would never be sent.

Nothing changes for a server without it, verified against a live one. The
engine half is in oDFe; the hosting rules now require it and carry the code,
and compliance is visible rather than claimed.
