### PR TITLE
servers: warn on a server that has cheats enabled

### DIFF
--- a/app/Console/Commands/ScrapeServers.php
+++ b/app/Console/Commands/ScrapeServers.php
@@ -155,6 +155,12 @@ class ScrapeServers extends Command
         $this->info('Updating ' . $server->ip . ':' . $server->port);
         $this->info('Found ' . count($data['players']) . ' players');
 
+        // Only getdfstatus carries this, and only from an engine new enough to
+        // send it - sv_cheats is systeminfo, so the rcon fallback cannot ask
+        // for it at all. A server that drops to rcon therefore goes back to
+        // "did not say" instead of keeping a stale answer.
+        $server->cheats = $data['cheats'] ?? null;
+
         $server->name = trim($data['hostname']);
 
         $pattern = '/\^\w/';
@@ -236,6 +242,10 @@ class ScrapeServers extends Command
 
     // there is presumtion that we got some data, therefore the server is considered online
     public function updateServer2($server, $data) {
+        // q3df.org's listing is the last resort and says nothing about cheats,
+        // so this path can only honestly clear it.
+        $server->cheats = null;
+
         $server->name = trim($data['hostname']);
 
         $pattern = '/\^\w/';

--- a/app/External/DefragServer.php
+++ b/app/External/DefragServer.php
@@ -318,6 +318,18 @@ class DefragServer
                 'players' => $scorePlayers,
             ],
             'rcon' => true,
+            // Three states on purpose, and the key is only present when cheats
+            // are actually on - it would otherwise cost twelve bytes of a
+            // packet that already runs out of room, on every reply, to say
+            // what is true of nearly every server.
+            //
+            // clientsFrom is what tells the two silences apart: an engine new
+            // enough to send sv_cheats at all always sends clientsFrom too, so
+            // its absence means the server never told us and null must not be
+            // rendered as "cheats are off".
+            'cheats' => isset($serverData['sv_cheats'])
+                ? ((int) $serverData['sv_cheats'] === 1)
+                : (isset($serverData['clientsFrom']) ? false : null),
             // Legacy GTK getdfstatus lacks uid/country/model - rcon dumpuser
             // still gives richer data there, so the scraper falls back to it.
             'legacy_format' => $legacyFormat,

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -20,6 +20,7 @@ class Server extends Model
         'latitude' => 'float',
         'longitude' => 'float',
         'geo_checked_at' => 'datetime',
+        'cheats' => 'boolean',
     ];
 
     /**

--- a/database/migrations/2026_08_05_000100_add_cheats_to_servers_table.php
+++ b/database/migrations/2026_08_05_000100_add_cheats_to_servers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Nullable on purpose: sv_cheats only reaches the scraper from an engine
+     * that puts it in the getdfstatus reply, so null means "this server never
+     * told us" and is not the same answer as cheats being off.
+     */
+    public function up(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->boolean('cheats')->nullable()->default(null)->after('defrag_gametype');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('cheats');
+        });
+    }
+};

--- a/resources/js/Components/CheatsBanner.vue
+++ b/resources/js/Components/CheatsBanner.vue
@@ -1,0 +1,36 @@
+<script setup>
+// Shown when a server reports sv_cheats 1.
+//
+// Deliberately across the full width of the card rather than a small corner
+// badge: a time set where cheats are enabled is worth nothing, and somebody
+// scanning the list should not have to hunt for that.
+//
+// Renders nothing for false OR null. Null means the server never told us -
+// only an engine new enough to put sv_cheats in its getdfstatus reply does,
+// because the cvar is systeminfo and never reaches a server browser otherwise.
+// Silence there must not be read as "cheats are off".
+defineProps({
+    cheats: { type: Boolean, default: null },
+    compact: { type: Boolean, default: false },
+});
+</script>
+
+<template>
+    <div
+        v-if="cheats === true"
+        :class="[
+            'absolute top-0 inset-x-0 z-20 flex items-center justify-center gap-2',
+            'bg-red-600/90 backdrop-blur-sm border-b border-red-300/40 pointer-events-none',
+            compact ? 'py-0.5' : 'py-1.5',
+        ]"
+        title="This server runs with sv_cheats enabled - times set here do not count"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
+             :class="['text-white flex-shrink-0', compact ? 'w-3 h-3' : 'w-4 h-4']">
+            <path fill-rule="evenodd" d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd" />
+        </svg>
+        <span :class="['font-black uppercase text-white tracking-widest', compact ? 'text-[10px]' : 'text-xs']">
+            Cheats enabled
+        </span>
+    </div>
+</template>

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -5,6 +5,7 @@ import { defineAsyncComponent, onMounted, onUnmounted, ref, computed, watch } fr
 import OnlinePlayer from '@/Components/OnlinePlayer.vue';
 import CopyButton from '@/Components/Basic/CopyButton.vue';
 import LauncherBanner from '@/Components/LauncherBanner.vue';
+import CheatsBanner from '@/Components/CheatsBanner.vue';
 const AddToMaplistModal = defineAsyncComponent(() => import('@/Components/Maplists/AddToMaplistModal.vue'));
 
 const page = usePage();
@@ -539,7 +540,8 @@ const getFunctionName = (abbr) => {
 
             <!-- Large Card Layout -->
             <div v-else-if="layout === 'large'" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <div v-for="server in filteredAndSortedServers" :key="server.id" class="group relative cursor-default bg-black/40 backdrop-blur-sm rounded-2xl border border-white/10 hover:border-white/20 transition-all duration-300 hover:shadow-2xl hover:shadow-blue-500/20 overflow-hidden player-list-hover-group">
+                <div v-for="server in filteredAndSortedServers" :key="server.id" :class="['group relative cursor-default bg-black/40 backdrop-blur-sm rounded-2xl border transition-all duration-300 hover:shadow-2xl overflow-hidden player-list-hover-group', server.cheats ? 'border-red-500/60 hover:border-red-400/80 hover:shadow-red-500/20' : 'border-white/10 hover:border-white/20 hover:shadow-blue-500/20']">
+                    <CheatsBanner :cheats="server.cheats" />
                     <!-- Background Image - FIXED SIZE, never changes, keeps aspect ratio -->
                     <div class="absolute top-0 left-0 right-0 h-[450px] rounded-t-2xl pointer-events-none">
                         <div class="relative inline-block w-full">
@@ -741,7 +743,8 @@ const getFunctionName = (abbr) => {
                         </div>
                     </div>
 
-                    <div v-for="server in filteredAndSortedServers.filter(s => !s.defrag.toLowerCase().includes('cpm'))" :key="server.id" class="group relative overflow-hidden rounded-xl border border-white/10 hover:border-blue-500/50 transition-all duration-300">
+                    <div v-for="server in filteredAndSortedServers.filter(s => !s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats ? 'border-red-500/60 hover:border-red-400/80 pt-4' : 'border-white/10 hover:border-blue-500/50']">
+                        <CheatsBanner :cheats="server.cheats" compact />
                         <!-- Background Map Thumbnail -->
                         <div v-if="server.mapdata?.thumbnail" class="absolute inset-0 transition-all duration-500">
                             <img
@@ -852,7 +855,8 @@ const getFunctionName = (abbr) => {
                         </div>
                     </div>
 
-                    <div v-for="server in filteredAndSortedServers.filter(s => s.defrag.toLowerCase().includes('cpm'))" :key="server.id" class="group relative overflow-hidden rounded-xl border border-white/10 hover:border-purple-500/50 transition-all duration-300">
+                    <div v-for="server in filteredAndSortedServers.filter(s => s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats ? 'border-red-500/60 hover:border-red-400/80 pt-4' : 'border-white/10 hover:border-purple-500/50']">
+                        <CheatsBanner :cheats="server.cheats" compact />
                         <!-- Background Map Thumbnail -->
                         <div v-if="server.mapdata?.thumbnail" class="absolute inset-0 transition-all duration-500">
                             <img


### PR DESCRIPTION
sv_cheats is systeminfo, so it never travelled in a status reply and no server list has ever been able to show it. A time set where cheats are on is worth nothing, and the only way to find out was to join and try. Engines new enough to say so now put it in their getdfstatus reply, so the listing can warn before anyone connects.

Said across the whole card rather than as a corner badge, with the border turned red to match, in both the large and compact layouts. Somebody scanning for a server to play on should not have to hunt for this.

Three states, and the column is nullable to keep them apart. The key is only sent when cheats are on, so its absence alone means nothing; clientsFrom is what says the engine would have told us. No clientsFrom means the server never said, and that renders as no banner rather than as an all clear. The rcon and q3df.org paths cannot ask at all, so they clear it instead of leaving a stale answer behind.