### PR TITLE
Never hand a case to anyone who reported it

### DIFF
--- a/app/Filament/Resources/ServerdemoValidationResource.php
+++ b/app/Filament/Resources/ServerdemoValidationResource.php
@@ -39,6 +39,10 @@ class ServerdemoValidationResource extends Resource
      * The admin sees every case. A validator sees only cases handed to them
      * and cases opened to everyone - nothing else is listed, so nothing else
      * can be opened.
+     *
+     * A case reported by this validator, or by anyone who ever shared a clan
+     * with them, is not listed at all. The download route refuses them too,
+     * but a case they may never act on has no business being on their screen.
      */
     public static function getEloquentQuery(): Builder
     {
@@ -51,6 +55,7 @@ class ServerdemoValidationResource extends Resource
 
         return $query
             ->whereNull('validation_closed_at')
+            ->notReportedBy(ServerdemoValidationCase::conflictIdsFor($user))
             ->where(function (Builder $q) use ($user) {
                 $q->where('assigned_to_user_id', $user?->id)
                     ->orWhereIn('validation_stage', ['all_validators', 'admin']);

--- a/app/Http/Controllers/ServerdemoValidationDownloadController.php
+++ b/app/Http/Controllers/ServerdemoValidationDownloadController.php
@@ -43,6 +43,13 @@ class ServerdemoValidationDownloadController extends Controller
         abort_if($case === null, 403);
         abort_unless($case->isOpen() || $user->isAdmin(), 403);
 
+        // Reporting a run must never be a way to get the demo of it. Anyone
+        // who reported this case, and anyone who ever shared a clan with a
+        // reporter, is refused here as well as being skipped by the
+        // assignment - otherwise the everyone-at-once stage would hand them
+        // the demo anyway.
+        abort_if(! $user->isAdmin() && in_array($user->id, $case->conflictedUserIds(), true), 403);
+
         $entitled = $user->isAdmin()
             || $case->assigned_to_user_id === $user->id
             || in_array($case->validation_stage, ['all_validators', 'admin'], true);

--- a/app/Models/ServerdemoValidationCase.php
+++ b/app/Models/ServerdemoValidationCase.php
@@ -80,4 +80,97 @@ class ServerdemoValidationCase extends Model
     {
         return $query->whereNull('validation_closed_at');
     }
+
+    /**
+     * Everyone who must never be handed this case: the people who reported it
+     * and anyone who ever shared a clan with them.
+     *
+     * Without this, being a validator is a way to order up demos. Report a
+     * pile of runs, wait for the random assignment, and a share of them comes
+     * back to you - which is exactly the objection raised when the validator
+     * page went up, and it was a fair one.
+     *
+     * Clan membership is taken with the soft-deleted rows included on both
+     * hops, so it is the whole history rather than the current roster: a clan
+     * the reporter has since left still blocks its members, and a member who
+     * has since left that clan is still blocked. Leaving a clan the day before
+     * reporting therefore buys nothing.
+     */
+    public function conflictedUserIds(): array
+    {
+        $reporters = $this->flags()
+            ->get(['id', 'validation_case_id', 'flagged_by_user_id', 'flagged_by_users'])
+            ->flatMap(fn (RecordFlag $flag) => array_merge(
+                $flag->flagged_by_users ?? [],
+                [$flag->flagged_by_user_id]
+            ))
+            ->filter()
+            ->map(fn ($id) => (int) $id)
+            ->unique();
+
+        if ($reporters->isEmpty()) {
+            return [];
+        }
+
+        return $reporters->merge(self::clanmateIds($reporters->all()))->unique()->values()->all();
+    }
+
+    /**
+     * The mirror of conflictedUserIds(), asked from the other side: which
+     * reporters would disqualify THIS user. Same rule, phrased so the case
+     * list can filter in the database instead of loading every case.
+     */
+    public static function conflictIdsFor(?User $user): array
+    {
+        if ($user === null) {
+            return [];
+        }
+
+        return collect([$user->id])
+            ->merge(self::clanmateIds([$user->id]))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /** Everyone who has ever been in a clan these users have ever been in. */
+    private static function clanmateIds(array $userIds): array
+    {
+        $clanIds = ClanPlayer::withTrashed()
+            ->whereIn('user_id', $userIds)
+            ->pluck('clan_id')
+            ->unique();
+
+        if ($clanIds->isEmpty()) {
+            return [];
+        }
+
+        return ClanPlayer::withTrashed()
+            ->whereIn('clan_id', $clanIds)
+            ->pluck('user_id')
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Cases none of these users reported. `flagged_by_users` holds every
+     * reporter of a report, `flagged_by_user_id` only the first, so both have
+     * to be checked or the person who opened the report slips through.
+     */
+    public function scopeNotReportedBy($query, array $userIds)
+    {
+        if ($userIds === []) {
+            return $query;
+        }
+
+        return $query->whereDoesntHave('flags', function ($flags) use ($userIds) {
+            $flags->whereIn('flagged_by_user_id', $userIds);
+
+            foreach ($userIds as $id) {
+                $flags->orWhereJsonContains('flagged_by_users', (int) $id);
+            }
+        });
+    }
 }

--- a/app/Services/ServerdemoValidationService.php
+++ b/app/Services/ServerdemoValidationService.php
@@ -144,12 +144,18 @@ class ServerdemoValidationService
      *
      * Random rather than a rotation: a predictable order tells a reported
      * player who is about to look at their runs.
+     *
+     * Nobody who reported the case, and nobody who ever shared a clan with a
+     * reporter, is a candidate - see ServerdemoValidationCase::conflictedUserIds().
+     * If that leaves nobody, the case goes to the everyone-at-once stage,
+     * where the same people are still refused the demo itself.
      */
     public function assignNext(ServerdemoValidationCase $case, ?User $actor = null): ?User
     {
         $seen = collect($case->validators_seen ?? []);
+        $conflicted = collect($case->conflictedUserIds());
         $candidate = $this->validators()
-            ->reject(fn (User $user) => $seen->contains($user->id))
+            ->reject(fn (User $user) => $seen->contains($user->id) || $conflicted->contains($user->id))
             ->shuffle()
             ->first();
 


### PR DESCRIPTION
Reporting a run could be a way to order up its serverdemo: report a pile of them, wait for the random assignment, and a share comes back to you. Raised publicly the day the validator page went up, and it was right.

A validator is now skipped for any case they reported, and so is anyone who ever shared a clan with a reporter. Clan membership is read with the soft-deleted rows included on both hops, so leaving a clan first buys nothing: the clan someone has left still blocks them, and someone who has left that clan is still blocked.

Three places, because two of them would have handed the demo over anyway: the assignment skips them, the download route refuses them even at the everyone-at-once stage, and the case list stops showing them a case they may never act on.