### PR TITLE
Say on the map card when you have already run it

### DIFF
--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -50,7 +50,7 @@ class MapsController extends Controller
             return redirect()->route('maps', ['page' => $maps->lastPage()]);
         }
 
-        return Inertia::render('Maps')->with('maps', $maps);
+        return Inertia::render('Maps')->with('maps', $this->attachPlayed($request, $maps));
     }
 
     public function filters(Request $request) {
@@ -74,8 +74,112 @@ class MapsController extends Controller
         }
 
         return Inertia::render('Maps')
-            ->with('maps', $maps)
+            ->with('maps', $this->attachPlayed($request, $maps))
             ->with('queries', $queries);
+    }
+
+    /**
+     * Mark which maps on this page the logged in player has already run.
+     *
+     * Played means "has an MDD record here", because a record is the only
+     * trace the site ever sees - loading a map and not finishing leaves
+     * nothing behind. Worth saying out loud when someone asks why a map they
+     * remember playing is not marked.
+     *
+     * The badge follows the filters that are on screen. With no physics or
+     * gametype filter, any record counts and the card says nothing about
+     * which one. Filter the list to VQ3 and only a VQ3 record marks the map,
+     * so the badge can never claim a run the filtered list would not show.
+     *
+     * One extra query per page of 16 maps, on (mdd_id, mapname).
+     */
+    private function attachPlayed(Request $request, $maps)
+    {
+        $mddId = $request->user()?->mdd_id;
+
+        if (! $mddId) {
+            return $maps;
+        }
+
+        $names = $maps->getCollection()->pluck('name')->filter();
+
+        if ($names->isEmpty()) {
+            return $maps;
+        }
+
+        $physics = $this->playedPhysics($request);
+        $modes = $this->playedModes($request);
+
+        $played = Record::where('mdd_id', $mddId)
+            ->whereIn('mapname', $names)
+            ->when($physics, fn ($query) => $query->where('physics', $physics))
+            ->when($modes, fn ($query) => $query->whereIn('mode', $modes))
+            ->select('mapname', 'physics')
+            ->distinct()
+            ->get()
+            // Keyed lowercase on both sides. MySQL matched `bardok-2026`
+            // against the map called `BardoK-2026` happily, being
+            // case-insensitive, and then PHP did not - so a map with a
+            // capital in its name never got the badge.
+            ->groupBy(fn ($record) => mb_strtolower($record->mapname));
+
+        $maps->getCollection()->transform(function ($map) use ($played) {
+            $found = $played->get(mb_strtolower($map->name))?->pluck('physics')->unique();
+
+            $map->played = $found !== null;
+            $map->played_physics = match (true) {
+                $found === null => null,
+                $found->count() > 1 => 'both',
+                default => $found->first(),
+            };
+
+            return $map;
+        });
+
+        return $maps;
+    }
+
+    /**
+     * The physics a record has to be in to count, or null for any of them.
+     * Both boxes ticked is the same as neither.
+     */
+    private function playedPhysics(Request $request): ?string
+    {
+        $physics = array_map('strtolower', array_filter((array) $request->input('physics', [])));
+        $physics = array_values(array_intersect($physics, ['vq3', 'cpm']));
+
+        return count($physics) === 1 ? $physics[0] : null;
+    }
+
+    /**
+     * The record modes that count, or an empty list for any of them.
+     *
+     * `records.mode` only ever holds `run` and `ctf1`..`ctf7`, so fastcaps is
+     * the one gametype worth narrowing by, and any of the seven does. Team
+     * and freestyle runs are written as plain `run` rows, and the map list is
+     * already filtered to those maps anyway, so narrowing there would only
+     * hide runs the player really did.
+     */
+    private function playedModes(Request $request): array
+    {
+        $gametypes = array_map('strtolower', array_filter((array) $request->input('gametype', [])));
+        $modes = [];
+
+        foreach ($gametypes as $gametype) {
+            if ($gametype === 'run') {
+                $modes[] = 'run';
+                continue;
+            }
+
+            if ($gametype === 'fastcaps') {
+                $modes = array_merge($modes, ['ctf1', 'ctf2', 'ctf3', 'ctf4', 'ctf5', 'ctf6', 'ctf7']);
+                continue;
+            }
+
+            return [];
+        }
+
+        return array_values(array_unique($modes));
     }
 
     /**

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -89,6 +89,61 @@
     animation: gradient-animation 7s ease infinite;
 }
 
+/* The PLAYED pill. Dark, because every hue on a map card is already spoken
+   for - green by CPM and Easy, blue by VQ3, red by NSFW and Extreme - so the
+   badge is told apart by shape instead. A sheen crosses it every few seconds
+   and a soft glow breathes around it, so it still catches the eye on a page
+   of sixteen. The sweep rests between passes rather than running
+   continuously: a badge that never stops moving is the one people learn to
+   ignore. */
+.played-badge {
+    /* White by default, which is the case where the player has a record in
+       both physics and no single colour would be honest. */
+    --played-sheen: rgba(255, 255, 255, 0.30);
+    --played-glow-dim: rgba(255, 255, 255, 0.25);
+    --played-glow: rgba(255, 255, 255, 0.65);
+
+    background-image: linear-gradient(100deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.78) 42%, var(--played-sheen) 50%, rgba(0, 0, 0, 0.78) 58%, rgba(0, 0, 0, 0.78) 100%);
+    background-size: 300% 100%;
+    background-color: rgba(0, 0, 0, 0.78);
+    animation: played-sheen 3.4s ease-in-out infinite, played-glow 3.4s ease-in-out infinite;
+}
+
+/* The blues and greens the physics badges already use, so the light coming
+   off the badge says which physics the record is in without reading it. */
+.played-badge-vq3 {
+    --played-sheen: rgba(93, 204, 255, 0.45);
+    --played-glow-dim: rgba(93, 204, 255, 0.30);
+    --played-glow: rgba(93, 204, 255, 0.80);
+}
+
+.played-badge-cpm {
+    --played-sheen: rgba(93, 255, 93, 0.45);
+    --played-glow-dim: rgba(93, 255, 93, 0.30);
+    --played-glow: rgba(93, 255, 93, 0.80);
+}
+
+/* Dark pill, white streak. The streak has to contrast with the base or the
+   effect is technically running and nobody can see it - which is what the
+   first white-on-white version did. */
+@keyframes played-sheen {
+    0%, 15% {
+        background-position: 150% 0;
+    }
+    65%, 100% {
+        background-position: -50% 0;
+    }
+}
+
+@keyframes played-glow {
+    0%, 100% {
+        box-shadow: 0 0 6px var(--played-glow-dim);
+    }
+    45% {
+        box-shadow: 0 0 18px var(--played-glow);
+    }
+}
+
 .defrag-scrollbar {
     max-height: 450px;
     overflow-y: auto;

--- a/resources/js/Components/MapCard.vue
+++ b/resources/js/Components/MapCard.vue
@@ -54,6 +54,31 @@
         return difficultyLabels[level - 1] || null;
     });
 
+    // The pill itself stays dark, because every hue on a card is taken -
+    // green by CPM and Easy, blue by VQ3, red by NSFW and Extreme - and the
+    // physics shows in the light coming off it instead: blue for a VQ3
+    // record, green for CPM, white when there are both and no single colour
+    // would be honest. Fastcaps records are physics like any other here, the
+    // ctf mode does not change the colour.
+    const playedBadge = computed(() => {
+        const badges = {
+            vq3: 'played-badge played-badge-vq3',
+            cpm: 'played-badge played-badge-cpm',
+        };
+
+        return badges[props.map.played_physics] ?? 'played-badge';
+    });
+
+    const playedDots = computed(() => {
+        const dots = {
+            vq3: ['bg-sky-400'],
+            cpm: ['bg-green-400'],
+            both: ['bg-sky-400', 'bg-green-400'],
+        };
+
+        return dots[props.map.played_physics] ?? [];
+    });
+
     const background = computed(() => {
         const physics = props.map.physics.toLowerCase()
         const bgs = {
@@ -114,6 +139,16 @@
                 <div v-if="difficultyBadge" class="absolute top-2 left-2">
                     <div :class="`px-2 py-0.5 rounded text-[11px] font-bold uppercase text-white ${difficultyBadge.color}`">
                         {{ difficultyBadge.label }}
+                    </div>
+                </div>
+                <!-- Played Badge (top centre) - only ever shown to a player
+                     whose account is paired to an MDD id, since it is their
+                     own records it is built from -->
+                <div v-if="map.played" class="absolute top-2 left-1/2 -translate-x-1/2">
+                    <div :class="`${playedBadge} flex items-center gap-1 px-2.5 py-1 rounded border border-white/25 backdrop-blur-sm text-[12px] font-black uppercase tracking-wide text-white`">
+                        <span>&check;</span>
+                        Played
+                        <span v-for="dot in playedDots" :key="dot" :class="['w-2 h-2 rounded-full ring-1 ring-black/30', dot]"></span>
                     </div>
                 </div>
                 <!-- Physics Badge (top right) -->


### PR DESCRIPTION
Browsing for something new meant opening maps to find out. The card now carries a PLAYED badge, centred on the thumbnail, for anyone whose account is paired to an MDD id.

Played means "has a record here", which is the only thing the site can know - loading a map and not finishing leaves no trace. Worth remembering when somebody asks why a map they remember playing is not marked.

The badge follows the filters on screen rather than ignoring them. With no filter, any record counts and the badge says nothing about which. Filter to VQ3 and a CPM record stops marking the map, so the badge can never claim a run the filtered list would not show. Fastcaps narrows to the ctf modes, any of the seven; team and freestyle runs are written as ordinary run rows and the list is already restricted to those maps, so narrowing there would only hide real runs.

It is a dark pill rather than a coloured one. Every hue on a card is already taken - green by CPM and Easy, blue by VQ3, red by NSFW and Extreme - so it is told apart by shape, and the physics sits on it as dots, blue for VQ3 and green for CPM. A sheen crosses it every few seconds with a glow breathing around it, resting between passes, because a badge that never stops moving is the one people stop seeing.

One extra query per page of sixteen maps, on (mdd_id, mapname), and none at all for a guest.