### PR TITLE
Public validation log, player amnesty, wishlist, and a fastcap demo fix

### DIFF
--- a/app/Console/Commands/RematchAllDemos.php
+++ b/app/Console/Commands/RematchAllDemos.php
@@ -28,8 +28,19 @@ class RematchAllDemos extends Command
         // Single-demo mode bypasses chunking/preload entirely — one demo
         // doesn't justify loading ~650k Records into memory, and verbose
         // per-field output only makes sense for a targeted run.
+        // Demos a player withdrew through the amnesty. Rematching one would
+        // file it as an offline record under their name and undo the whole
+        // point of the withdrawal - see PlayerSelfReport::withheldDemoIds.
+        $withheld = \App\Models\PlayerSelfReport::withheldDemoIds();
+
         if ($demoId) {
             $this->info("Rematching demo ID {$demoId}...");
+
+            if (in_array((int) $demoId, $withheld, true)) {
+                $this->warn("Demo {$demoId} belongs to a withdrawn run and is off limits.");
+                return 0;
+            }
+
             $demo = UploadedDemo::where('id', $demoId)->whereNotNull('player_name')->first();
             if (!$demo) {
                 $this->warn("Demo {$demoId} not found or has no player_name");
@@ -50,6 +61,12 @@ class RematchAllDemos extends Command
             // fuzzy-match to do anything useful.
             $query = UploadedDemo::where('status', '!=', 'assigned')->whereNotNull('player_name');
         }
+
+        if (!empty($withheld)) {
+            $query->whereNotIn('id', $withheld);
+            $this->info('Skipping ' . count($withheld) . ' demo(s) held down by the amnesty');
+        }
+
         $total = (clone $query)->count();
         $this->info("Found {$total} demos to rematch");
 

--- a/app/Console/Commands/ResolveBeatenAmnestyRequests.php
+++ b/app/Console/Commands/ResolveBeatenAmnestyRequests.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PlayerSelfReport;
+use App\Models\Record;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Close the amnesty requests their own author settled by running again.
+ *
+ * MDD reports personal bests only, so a faster run replaces the old record in
+ * our table by itself: the disowned time is already off the board and its row
+ * has moved to the history. An admin pressing "hide" on that would be hiding
+ * something that is not there, so the request resolves itself as beaten.
+ *
+ * A slower run is invisible to us and changes nothing here - that is why this
+ * only ever fires on an improvement, and why beating the time is the only
+ * version of "I fixed it myself" we can actually see.
+ *
+ * The row is kept. After the MDD merge we get the full time history, and the
+ * fact that a player disowned one of those old times is what makes the history
+ * cleanable rather than just long.
+ */
+class ResolveBeatenAmnestyRequests extends Command
+{
+    protected $signature = 'amnesty:resolve-beaten';
+
+    protected $description = 'Mark amnesty requests as resolved when the player has beaten the time themselves';
+
+    public function handle(): int
+    {
+        $resolved = 0;
+
+        PlayerSelfReport::pending()
+            ->whereNotNull('record_id')
+            ->whereNotNull('mdd_id')
+            ->cursor()
+            ->each(function (PlayerSelfReport $report) use (&$resolved) {
+                $live = Record::where('mdd_id', $report->mdd_id)
+                    ->where('mapname', $report->mapname)
+                    ->where('physics', $report->physics)
+                    ->where('mode', $report->mode)
+                    ->first();
+
+                // Still the same row: nothing has happened on that map.
+                if (! $live || (int) $live->id === (int) $report->record_id) {
+                    return;
+                }
+
+                // A different row that is not an improvement is not the player
+                // fixing anything - it is the record having been replaced for
+                // some other reason, and that still needs an admin.
+                if ($report->time !== null && (int) $live->time >= (int) $report->time) {
+                    return;
+                }
+
+                $report->update([
+                    'processed_at' => now(),
+                    'resolution' => 'beaten',
+                ]);
+
+                $resolved++;
+
+                Log::info('Amnesty request resolved by a new run', [
+                    'self_report_id' => $report->id,
+                    'mdd_id' => $report->mdd_id,
+                    'mapname' => $report->mapname,
+                    'old_time' => $report->time,
+                    'new_time' => $live->time,
+                ]);
+            });
+
+        $this->info("Resolved {$resolved} request(s) beaten by a new run.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -42,6 +42,10 @@ class Kernel extends ConsoleKernel
         // Update last_activity in player_ratings from records (~20s)
         $schedule->command('ratings:update-activity')->withoutOverlapping()->hourly();
 
+        // Close amnesty requests whose author has since beaten the time: the new
+        // run already replaced the old record, so there is nothing left to hide.
+        $schedule->command('amnesty:resolve-beaten')->withoutOverlapping()->hourly();
+
         // Cache WR/Top3 counts for clan statistics (updates cached_wr_count and cached_top3_count on users table)
         $schedule->command('rankings:cache')->withoutOverlapping()->hourly();
 

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -61,30 +61,6 @@ class PlayerSelfReportResource extends Resource
         return 'warning';
     }
 
-    /**
-     * Which reasons each player has used, for the summary row.
-     *
-     * One query for the whole page rather than one per row. Static because a
-     * Livewire request renders the table once and the answer must not change
-     * halfway down it.
-     */
-    public static function reasonsByPlayer(): array
-    {
-        static $reasons = null;
-
-        if ($reasons === null) {
-            $reasons = PlayerSelfReport::query()
-                ->select('mdd_id', 'reason')
-                ->distinct()
-                ->get()
-                ->groupBy('mdd_id')
-                ->map(fn ($rows) => $rows->pluck('reason')->all())
-                ->all();
-        }
-
-        return $reasons;
-    }
-
     /** The name of one player, for the heading of their page. */
     public static function playerName(?string $mdd): string
     {
@@ -109,6 +85,11 @@ class PlayerSelfReportResource extends Resource
                 ->selectRaw('min(id) as id, mdd_id, max(user_id) as user_id, max(player_name) as player_name')
                 ->selectRaw('count(*) as runs')
                 ->selectRaw('count(distinct reason) as reason_count')
+                // The reasons themselves come out of the same aggregate. They
+                // used to be a second query memoised in a static, which under
+                // Octane outlives the request and freezes on whatever the
+                // worker saw first.
+                ->selectRaw("group_concat(distinct reason order by reason separator ',') as reason_list")
                 // Open splits in two, because the two halves are different
                 // jobs: one is waiting on an admin, the other is waiting on
                 // the MDD merge and needs nobody.
@@ -162,7 +143,7 @@ class PlayerSelfReportResource extends Resource
                     ->color('gray')
                     ->sortable()
                     ->description(function (PlayerSelfReport $record) {
-                        $reasons = static::reasonsByPlayer()[$record->mdd_id] ?? [];
+                        $reasons = array_filter(explode(',', (string) $record->reason_list));
                         $labels = array_map(fn ($r) => RecordFlagController::FLAG_TYPES[$r] ?? $r, $reasons);
 
                         return implode(', ', array_slice($labels, 0, 3))
@@ -393,7 +374,7 @@ class PlayerSelfReportResource extends Resource
                     ->color('warning')
                     ->requiresConfirmation()
                     ->modalDescription('Puts the record back on the leaderboard, with its demo and video, and drops the request. Use it when the wrong run was sent.')
-                    ->visible(fn (PlayerSelfReport $record) => $record->record_id
+                    ->visible(fn (PlayerSelfReport $record) => $record->hidRun()
                         && Record::onlyTrashed()->whereKey($record->record_id)->exists())
                     ->action(function (PlayerSelfReport $record) {
                         $record->restoreRun(auth()->id());

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PlayerSelfReportResource\Pages;
+use App\Http\Controllers\RecordFlagController;
+use App\Models\PlayerSelfReport;
+use App\Models\Record;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * Times players took down themselves, and the one way back.
+ *
+ * Nothing here needs approving - the amnesty is unconditional and that is what
+ * makes people use it. The reason this list exists at all is the mistake case:
+ * somebody withdraws the wrong run, and without a button the only fix is a
+ * hand-written database update.
+ *
+ * Restoring undoes both halves, the record and the log entry, because a
+ * withdrawal that was a misclick did not happen and the public log should not
+ * claim it did.
+ */
+class PlayerSelfReportResource extends Resource
+{
+    protected static ?string $model = PlayerSelfReport::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-uturn-left';
+
+    protected static ?string $navigationGroup = 'Validators';
+
+    protected static ?string $navigationLabel = 'Withdrawn times (private)';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->striped()
+            ->defaultSort('created_at', 'desc')
+            ->modifyQueryUsing(fn ($query) => $query->with('user:id,name,plain_name,amnesty_blocked_at'))
+            ->columns([
+                Tables\Columns\TextColumn::make('player_name')
+                    ->label('Player')
+                    ->searchable()
+                    ->formatStateUsing(fn (?string $state) => UserResource::q3tohtml($state ?? ''))
+                    ->html()
+                    ->description(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at
+                        ? 'BLOCKED from the amnesty'
+                        : ($record->mdd_id ? 'MDD #' . $record->mdd_id : null))
+                    ->color(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at ? 'danger' : null),
+
+                Tables\Columns\TextColumn::make('mapname')
+                    ->label('Map')
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('physics')
+                    ->label('Physics')
+                    ->formatStateUsing(fn (?string $state, PlayerSelfReport $record) => trim(($state ?? '') . ' ' . ($record->mode ?? ''))),
+
+                Tables\Columns\TextColumn::make('time')
+                    ->label('Time'),
+
+                Tables\Columns\TextColumn::make('reason')
+                    ->label('Reason')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => RecordFlagController::FLAG_TYPES[$state] ?? $state),
+
+                Tables\Columns\TextColumn::make('note')
+                    ->label('Note')
+                    ->wrap()
+                    ->limit(120)
+                    ->toggleable(),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Withdrawn')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->actions([
+                // Abuse is spotted here and nowhere else, so the switch that
+                // answers it lives here too. It does not touch the withdrawal
+                // it was noticed on: taking a run back and taking the right
+                // away are separate decisions.
+                Tables\Actions\Action::make('block')
+                    ->label(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at
+                        ? 'Give the amnesty back'
+                        : 'Block from the amnesty')
+                    ->icon('heroicon-o-no-symbol')
+                    ->color('danger')
+                    ->visible(fn (PlayerSelfReport $record) => $record->user !== null)
+                    ->requiresConfirmation()
+                    ->form(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at ? [] : [
+                        \Filament\Forms\Components\TextInput::make('reason')
+                            ->label('Reason (shown to the player)')
+                            ->required()
+                            ->maxLength(255),
+                    ])
+                    ->action(function (PlayerSelfReport $record, array $data) {
+                        $user = $record->user;
+                        if (! $user) {
+                            return;
+                        }
+
+                        if ($user->amnesty_blocked_at) {
+                            $user->amnesty_blocked_at = null;
+                            $user->amnesty_blocked_reason = null;
+                            $user->save();
+
+                            Notification::make()->success()->title('Amnesty restored')->send();
+
+                            return;
+                        }
+
+                        $user->amnesty_blocked_at = now();
+                        $user->amnesty_blocked_reason = $data['reason'] ?? null;
+                        $user->save();
+
+                        Notification::make()->success()->title('Player blocked from the amnesty')->send();
+                    }),
+
+                Tables\Actions\Action::make('restore')
+                    ->label('Put the run back')
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription('This puts the record back on the leaderboard and removes it from the public log. Use it when the wrong run was withdrawn.')
+                    ->visible(fn (PlayerSelfReport $record) => $record->record_id
+                        && Record::onlyTrashed()->whereKey($record->record_id)->exists())
+                    ->action(function (PlayerSelfReport $record) {
+                        Record::onlyTrashed()->whereKey($record->record_id)->first()?->restore();
+                        $record->delete();
+
+                        Notification::make()->success()->title('Run restored')->send();
+                    }),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPlayerSelfReports::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -348,13 +348,7 @@ class PlayerSelfReportResource extends Resource
                     ->requiresConfirmation()
                     ->modalDescription('Takes the run off the leaderboard here. Until the MDD databases are merged it still stands on q3df.org.')
                     ->action(function (PlayerSelfReport $record) {
-                        $run = Record::find($record->record_id);
-
-                        // Soft delete: the model's hooks detach uploaded demos
-                        // and clear the profile and listing caches.
-                        $run?->delete();
-
-                        $record->update(['processed_at' => now(), 'processed_by' => auth()->id()]);
+                        $record->hideRun(auth()->id());
 
                         Notification::make()->success()->title('Run hidden')->send();
                     }),
@@ -364,11 +358,11 @@ class PlayerSelfReportResource extends Resource
                     ->icon('heroicon-o-arrow-uturn-left')
                     ->color('warning')
                     ->requiresConfirmation()
-                    ->modalDescription('Puts the record back on the leaderboard and drops the request. Use it when the wrong run was sent.')
+                    ->modalDescription('Puts the record back on the leaderboard, with its demo and video, and drops the request. Use it when the wrong run was sent.')
                     ->visible(fn (PlayerSelfReport $record) => $record->record_id
                         && Record::onlyTrashed()->whereKey($record->record_id)->exists())
                     ->action(function (PlayerSelfReport $record) {
-                        Record::onlyTrashed()->whereKey($record->record_id)->first()?->restore();
+                        $record->restoreRun();
                         $record->delete();
 
                         Notification::make()->success()->title('Run restored')->send();
@@ -392,9 +386,9 @@ class PlayerSelfReportResource extends Resource
                                 continue;
                             }
 
-                            Record::find($record->record_id)?->delete();
-                            $record->update(['processed_at' => now(), 'processed_by' => auth()->id()]);
-                            $done++;
+                            if ($record->hideRun(auth()->id())) {
+                                $done++;
+                            }
                         }
 
                         Notification::make()->success()
@@ -413,13 +407,10 @@ class PlayerSelfReportResource extends Resource
                         $done = 0;
 
                         foreach ($records as $record) {
-                            $run = Record::onlyTrashed()->whereKey($record->record_id)->first();
-
-                            if (! $run) {
+                            if (! $record->restoreRun()) {
                                 continue;
                             }
 
-                            $run->restore();
                             $record->delete();
                             $done++;
                         }

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -54,6 +54,29 @@ class PlayerSelfReportResource extends Resource
         return 'warning';
     }
 
+    /**
+     * How many requests each player has, and how many of those are still open.
+     *
+     * One query for the whole page rather than one per group header. Static
+     * because a Livewire request renders the table once and the numbers must
+     * not change halfway down the list.
+     */
+    protected static function playerTotals(): array
+    {
+        static $totals = null;
+
+        if ($totals === null) {
+            $totals = PlayerSelfReport::query()
+                ->selectRaw('player_name, count(*) as total, sum(processed_at is null) as waiting')
+                ->groupBy('player_name')
+                ->get()
+                ->keyBy('player_name')
+                ->all();
+        }
+
+        return $totals;
+    }
+
     public static function table(Table $table): Table
     {
         return $table
@@ -63,13 +86,77 @@ class PlayerSelfReportResource extends Resource
                 ->with('user:id,name,plain_name,amnesty_blocked_at')
                 // Anything still waiting on a decision first, whatever the sort.
                 ->orderByRaw('processed_at is null desc'))
+            // One player at a time. Withdrawals arrive in batches - somebody
+            // reads the rules and sends six runs at once - and reading those
+            // six interleaved with everyone else's is how a mistake gets made.
+            ->groups([
+                Tables\Grouping\Group::make('player_name')
+                    ->label('Player')
+                    ->collapsible()
+                    ->titlePrefixedWithLabel(false)
+                    ->getTitleFromRecordUsing(fn (PlayerSelfReport $record) => trim(preg_replace('/\^[0-9A-Za-z]/', '', $record->player_name ?? '')) ?: 'Unknown player')
+                    ->getDescriptionFromRecordUsing(function (PlayerSelfReport $record) {
+                        $totals = static::playerTotals()[$record->player_name] ?? null;
+                        $parts = [];
+
+                        if ($totals) {
+                            $parts[] = $totals->total . ' ' . ($totals->total == 1 ? 'run' : 'runs');
+
+                            if ($totals->waiting > 0) {
+                                $parts[] = $totals->waiting . ' still open';
+                            }
+                        }
+
+                        if ($record->mdd_id) {
+                            $parts[] = 'MDD #' . $record->mdd_id;
+                        }
+
+                        if ($record->user?->amnesty_blocked_at) {
+                            $parts[] = 'BLOCKED from the amnesty';
+                        }
+
+                        return implode(' - ', $parts);
+                    }),
+                Tables\Grouping\Group::make('reason')
+                    ->label('Reason')
+                    ->collapsible()
+                    ->getTitleFromRecordUsing(fn (PlayerSelfReport $record) => RecordFlagController::FLAG_TYPES[$record->reason] ?? $record->reason),
+                Tables\Grouping\Group::make('mapname')
+                    ->label('Map')
+                    ->collapsible(),
+            ])
+            ->defaultGroup('player_name')
             ->filters([
-                Tables\Filters\Filter::make('pending')
-                    ->label('Waiting to be handled')
-                    ->query(fn ($query) => $query->whereNull('processed_at')),
-                Tables\Filters\SelectFilter::make('handling')
-                    ->label('When')
-                    ->options(PlayerSelfReport::HANDLING),
+                Tables\Filters\SelectFilter::make('state')
+                    ->label('State')
+                    ->options([
+                        'waiting' => 'Waiting on you',
+                        'queued' => 'Queued for the merge',
+                        'open' => 'Anything still open',
+                        'hidden' => 'Off the board',
+                        'beaten' => 'Beaten - resolved',
+                    ])
+                    ->query(fn ($query, array $data) => match ($data['value'] ?? null) {
+                        'waiting' => $query->whereNull('processed_at')->where('handling', 'immediate'),
+                        'queued' => $query->whereNull('processed_at')->where('handling', 'on_merge'),
+                        'open' => $query->whereNull('processed_at'),
+                        'hidden' => $query->whereNotNull('processed_at')->where('resolution', '!=', 'beaten'),
+                        'beaten' => $query->where('resolution', 'beaten'),
+                        default => $query,
+                    }),
+
+                Tables\Filters\SelectFilter::make('reason')
+                    ->label('Reason')
+                    ->multiple()
+                    ->options(RecordFlagController::FLAG_TYPES),
+
+                Tables\Filters\SelectFilter::make('physics')
+                    ->options(['cpm' => 'CPM', 'vq3' => 'VQ3']),
+
+                // Whoever is already blocked is the one worth re-reading.
+                Tables\Filters\Filter::make('blocked')
+                    ->label('Blocked players only')
+                    ->query(fn ($query) => $query->whereHas('user', fn ($q) => $q->whereNotNull('amnesty_blocked_at'))),
             ])
             ->columns([
                 Tables\Columns\TextColumn::make('player_name')
@@ -199,6 +286,61 @@ class PlayerSelfReportResource extends Resource
                         $record->delete();
 
                         Notification::make()->success()->title('Run restored')->send();
+                    }),
+            ])
+            // A batch arrives as a batch and is usually decided as one. Doing
+            // six of them one modal at a time is where the seventh gets missed.
+            ->bulkActions([
+                Tables\Actions\BulkAction::make('hideSelected')
+                    ->label('Approve and hide the selected runs')
+                    ->icon('heroicon-o-eye-slash')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->modalDescription('Takes every selected run off the leaderboard here. Until the MDD databases are merged they still stand on q3df.org.')
+                    ->deselectRecordsAfterCompletion()
+                    ->action(function ($records) {
+                        $done = 0;
+
+                        foreach ($records as $record) {
+                            if ($record->isProcessed() || ! $record->record_id) {
+                                continue;
+                            }
+
+                            Record::find($record->record_id)?->delete();
+                            $record->update(['processed_at' => now(), 'processed_by' => auth()->id()]);
+                            $done++;
+                        }
+
+                        Notification::make()->success()
+                            ->title($done . ' ' . ($done === 1 ? 'run' : 'runs') . ' hidden')
+                            ->send();
+                    }),
+
+                Tables\Actions\BulkAction::make('restoreSelected')
+                    ->label('Put the selected runs back')
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription('Puts the records back on the leaderboard and drops the requests.')
+                    ->deselectRecordsAfterCompletion()
+                    ->action(function ($records) {
+                        $done = 0;
+
+                        foreach ($records as $record) {
+                            $run = Record::onlyTrashed()->whereKey($record->record_id)->first();
+
+                            if (! $run) {
+                                continue;
+                            }
+
+                            $run->restore();
+                            $record->delete();
+                            $done++;
+                        }
+
+                        Notification::make()->success()
+                            ->title($done . ' ' . ($done === 1 ? 'run' : 'runs') . ' restored')
+                            ->send();
                     }),
             ]);
     }

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -10,6 +10,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Times players took down themselves, and the one way back.
@@ -22,6 +23,12 @@ use Filament\Tables\Table;
  * Restoring undoes both halves, the record and the log entry, because a
  * withdrawal that was a misclick did not happen and the public log should not
  * claim it did.
+ *
+ * TWO LEVELS. The index is one row per player - how many runs, how many
+ * different reasons, how much is still open - and the runs themselves live one
+ * click deeper. Withdrawals arrive in batches, so a flat list of runs is a list
+ * where the same person appears six times and the shape of what they sent is
+ * invisible.
  */
 class PlayerSelfReportResource extends Resource
 {
@@ -55,108 +62,70 @@ class PlayerSelfReportResource extends Resource
     }
 
     /**
-     * How many requests each player has, and how many of those are still open.
+     * Which reasons each player has used, for the summary row.
      *
-     * One query for the whole page rather than one per group header. Static
-     * because a Livewire request renders the table once and the numbers must
-     * not change halfway down the list.
+     * One query for the whole page rather than one per row. Static because a
+     * Livewire request renders the table once and the answer must not change
+     * halfway down it.
      */
-    protected static function playerTotals(): array
+    public static function reasonsByPlayer(): array
     {
-        static $totals = null;
+        static $reasons = null;
 
-        if ($totals === null) {
-            $totals = PlayerSelfReport::query()
-                ->selectRaw('player_name, count(*) as total, sum(processed_at is null) as waiting')
-                ->groupBy('player_name')
+        if ($reasons === null) {
+            $reasons = PlayerSelfReport::query()
+                ->select('mdd_id', 'reason')
+                ->distinct()
                 ->get()
-                ->keyBy('player_name')
+                ->groupBy('mdd_id')
+                ->map(fn ($rows) => $rows->pluck('reason')->all())
                 ->all();
         }
 
-        return $totals;
+        return $reasons;
     }
 
+    /** The name of one player, for the heading of their page. */
+    public static function playerName(?string $mdd): string
+    {
+        $name = PlayerSelfReport::where('mdd_id', $mdd)->value('player_name');
+
+        return trim(preg_replace('/\^[0-9A-Za-z]/', '', $name ?? '')) ?: ('MDD #' . $mdd);
+    }
+
+    /**
+     * The index: one row per player.
+     *
+     * Grouped in SQL, with min(id) kept as the key so every row still has a
+     * real primary key for Filament to hang actions off.
+     */
     public static function table(Table $table): Table
     {
         return $table
             ->striped()
-            ->defaultSort('created_at', 'desc')
-            ->modifyQueryUsing(fn ($query) => $query
+            ->heading('Who has used the amnesty')
+            ->description('One row per player. Open a player to see the runs they sent and act on them.')
+            ->modifyQueryUsing(fn (Builder $query) => $query
+                ->selectRaw('min(id) as id, mdd_id, max(user_id) as user_id, max(player_name) as player_name')
+                ->selectRaw('count(*) as runs')
+                ->selectRaw('count(distinct reason) as reason_count')
+                ->selectRaw('sum(processed_at is null) as open_count')
+                ->selectRaw("sum(processed_at is not null and coalesce(resolution, '') <> 'beaten') as hidden_count")
+                ->selectRaw("sum(coalesce(resolution, '') = 'beaten') as beaten_count")
+                ->selectRaw('max(created_at) as last_request')
                 ->with('user:id,name,plain_name,amnesty_blocked_at')
-                // Anything still waiting on a decision first, whatever the sort.
-                ->orderByRaw('processed_at is null desc'))
-            // One player at a time. Withdrawals arrive in batches - somebody
-            // reads the rules and sends six runs at once - and reading those
-            // six interleaved with everyone else's is how a mistake gets made.
-            ->groups([
-                Tables\Grouping\Group::make('player_name')
-                    ->label('Player')
-                    ->collapsible()
-                    ->titlePrefixedWithLabel(false)
-                    ->getTitleFromRecordUsing(fn (PlayerSelfReport $record) => trim(preg_replace('/\^[0-9A-Za-z]/', '', $record->player_name ?? '')) ?: 'Unknown player')
-                    ->getDescriptionFromRecordUsing(function (PlayerSelfReport $record) {
-                        $totals = static::playerTotals()[$record->player_name] ?? null;
-                        $parts = [];
-
-                        if ($totals) {
-                            $parts[] = $totals->total . ' ' . ($totals->total == 1 ? 'run' : 'runs');
-
-                            if ($totals->waiting > 0) {
-                                $parts[] = $totals->waiting . ' still open';
-                            }
-                        }
-
-                        if ($record->mdd_id) {
-                            $parts[] = 'MDD #' . $record->mdd_id;
-                        }
-
-                        if ($record->user?->amnesty_blocked_at) {
-                            $parts[] = 'BLOCKED from the amnesty';
-                        }
-
-                        return implode(' - ', $parts);
-                    }),
-                Tables\Grouping\Group::make('reason')
-                    ->label('Reason')
-                    ->collapsible()
-                    ->getTitleFromRecordUsing(fn (PlayerSelfReport $record) => RecordFlagController::FLAG_TYPES[$record->reason] ?? $record->reason),
-                Tables\Grouping\Group::make('mapname')
-                    ->label('Map')
-                    ->collapsible(),
-            ])
-            ->defaultGroup('player_name')
+                ->groupBy('mdd_id')
+                // Whoever is waiting on a decision comes first, whatever the sort.
+                ->orderByRaw('sum(processed_at is null) > 0 desc'))
+            ->defaultSort('last_request', 'desc')
             ->filters([
-                Tables\Filters\SelectFilter::make('state')
-                    ->label('State')
-                    ->options([
-                        'waiting' => 'Waiting on you',
-                        'queued' => 'Queued for the merge',
-                        'open' => 'Anything still open',
-                        'hidden' => 'Off the board',
-                        'beaten' => 'Beaten - resolved',
-                    ])
-                    ->query(fn ($query, array $data) => match ($data['value'] ?? null) {
-                        'waiting' => $query->whereNull('processed_at')->where('handling', 'immediate'),
-                        'queued' => $query->whereNull('processed_at')->where('handling', 'on_merge'),
-                        'open' => $query->whereNull('processed_at'),
-                        'hidden' => $query->whereNotNull('processed_at')->where('resolution', '!=', 'beaten'),
-                        'beaten' => $query->where('resolution', 'beaten'),
-                        default => $query,
-                    }),
+                Tables\Filters\Filter::make('open')
+                    ->label('Has something still open')
+                    ->query(fn (Builder $query) => $query->havingRaw('sum(processed_at is null) > 0')),
 
-                Tables\Filters\SelectFilter::make('reason')
-                    ->label('Reason')
-                    ->multiple()
-                    ->options(RecordFlagController::FLAG_TYPES),
-
-                Tables\Filters\SelectFilter::make('physics')
-                    ->options(['cpm' => 'CPM', 'vq3' => 'VQ3']),
-
-                // Whoever is already blocked is the one worth re-reading.
                 Tables\Filters\Filter::make('blocked')
-                    ->label('Blocked players only')
-                    ->query(fn ($query) => $query->whereHas('user', fn ($q) => $q->whereNotNull('amnesty_blocked_at'))),
+                    ->label('Blocked from the amnesty')
+                    ->query(fn (Builder $query) => $query->whereHas('user', fn ($q) => $q->whereNotNull('amnesty_blocked_at'))),
             ])
             ->columns([
                 Tables\Columns\TextColumn::make('player_name')
@@ -169,9 +138,117 @@ class PlayerSelfReportResource extends Resource
                         : ($record->mdd_id ? 'MDD #' . $record->mdd_id : null))
                     ->color(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at ? 'danger' : null),
 
+                Tables\Columns\TextColumn::make('runs')
+                    ->label('Runs')
+                    ->badge()
+                    ->color('gray')
+                    ->sortable(),
+
+                // The count is the number worth sorting on; the reasons
+                // themselves say whether it was one mistake repeated or a
+                // scattering of different ones.
+                Tables\Columns\TextColumn::make('reason_count')
+                    ->label('Reasons')
+                    ->badge()
+                    ->color('gray')
+                    ->sortable()
+                    ->description(function (PlayerSelfReport $record) {
+                        $reasons = static::reasonsByPlayer()[$record->mdd_id] ?? [];
+                        $labels = array_map(fn ($r) => RecordFlagController::FLAG_TYPES[$r] ?? $r, $reasons);
+
+                        return implode(', ', array_slice($labels, 0, 3))
+                            . (count($labels) > 3 ? ' +' . (count($labels) - 3) . ' more' : '');
+                    })
+                    ->wrap(),
+
+                Tables\Columns\TextColumn::make('open_count')
+                    ->label('Still open')
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'warning' : 'gray')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('hidden_count')
+                    ->label('Hidden')
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'success' : 'gray')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('beaten_count')
+                    ->label('Beaten')
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'info' : 'gray')
+                    ->sortable()
+                    ->tooltip('Closed by the player beating the time themselves'),
+
+                Tables\Columns\TextColumn::make('last_request')
+                    ->label('Last request')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('open')
+                    ->label('Open')
+                    ->icon('heroicon-o-arrow-right')
+                    ->url(fn (PlayerSelfReport $record) => Pages\PlayerAmnesty::getUrl(['mdd' => $record->mdd_id])),
+
+                static::blockAction(),
+            ]);
+    }
+
+    /**
+     * One player's runs. Same rows as before, minus the player column - the
+     * heading already says whose page this is.
+     */
+    public static function detailTable(Table $table, ?string $mdd): Table
+    {
+        return $table
+            ->striped()
+            ->defaultSort('created_at', 'desc')
+            ->modifyQueryUsing(fn (Builder $query) => $query
+                ->where('mdd_id', $mdd)
+                ->with('user:id,name,plain_name,amnesty_blocked_at')
+                ->orderByRaw('processed_at is null desc'))
+            ->groups([
+                Tables\Grouping\Group::make('reason')
+                    ->label('Reason')
+                    ->collapsible()
+                    ->getTitleFromRecordUsing(fn (PlayerSelfReport $record) => RecordFlagController::FLAG_TYPES[$record->reason] ?? $record->reason),
+                Tables\Grouping\Group::make('mapname')
+                    ->label('Map')
+                    ->collapsible(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('state')
+                    ->label('State')
+                    ->options([
+                        'waiting' => 'Waiting on you',
+                        'queued' => 'Queued for the merge',
+                        'open' => 'Anything still open',
+                        'hidden' => 'Off the board',
+                        'beaten' => 'Beaten - resolved',
+                    ])
+                    ->query(fn (Builder $query, array $data) => match ($data['value'] ?? null) {
+                        'waiting' => $query->whereNull('processed_at')->where('handling', 'immediate'),
+                        'queued' => $query->whereNull('processed_at')->where('handling', 'on_merge'),
+                        'open' => $query->whereNull('processed_at'),
+                        'hidden' => $query->whereNotNull('processed_at')->where(fn ($q) => $q->whereNull('resolution')->orWhere('resolution', '!=', 'beaten')),
+                        'beaten' => $query->where('resolution', 'beaten'),
+                        default => $query,
+                    }),
+
+                Tables\Filters\SelectFilter::make('reason')
+                    ->label('Reason')
+                    ->multiple()
+                    ->options(RecordFlagController::FLAG_TYPES),
+
+                Tables\Filters\SelectFilter::make('physics')
+                    ->options(['cpm' => 'CPM', 'vq3' => 'VQ3']),
+            ])
+            ->columns([
                 Tables\Columns\TextColumn::make('mapname')
                     ->label('Map')
-                    ->searchable(),
+                    ->searchable()
+                    ->sortable(),
 
                 Tables\Columns\TextColumn::make('physics')
                     ->label('Physics')
@@ -202,8 +279,7 @@ class PlayerSelfReportResource extends Resource
                 Tables\Columns\TextColumn::make('note')
                     ->label('Note')
                     ->wrap()
-                    ->limit(120)
-                    ->toggleable(),
+                    ->limit(120),
 
                 Tables\Columns\TextColumn::make('created_at')
                     ->label('Withdrawn')
@@ -230,47 +306,6 @@ class PlayerSelfReportResource extends Resource
                         $record->update(['processed_at' => now(), 'processed_by' => auth()->id()]);
 
                         Notification::make()->success()->title('Run hidden')->send();
-                    }),
-
-                // Abuse is spotted here and nowhere else, so the switch that
-                // answers it lives here too. It does not touch the withdrawal
-                // it was noticed on: taking a run back and taking the right
-                // away are separate decisions.
-                Tables\Actions\Action::make('block')
-                    ->label(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at
-                        ? 'Give the amnesty back'
-                        : 'Block from the amnesty')
-                    ->icon('heroicon-o-no-symbol')
-                    ->color('danger')
-                    ->visible(fn (PlayerSelfReport $record) => $record->user !== null)
-                    ->requiresConfirmation()
-                    ->form(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at ? [] : [
-                        \Filament\Forms\Components\TextInput::make('reason')
-                            ->label('Reason (shown to the player)')
-                            ->required()
-                            ->maxLength(255),
-                    ])
-                    ->action(function (PlayerSelfReport $record, array $data) {
-                        $user = $record->user;
-                        if (! $user) {
-                            return;
-                        }
-
-                        if ($user->amnesty_blocked_at) {
-                            $user->amnesty_blocked_at = null;
-                            $user->amnesty_blocked_reason = null;
-                            $user->save();
-
-                            Notification::make()->success()->title('Amnesty restored')->send();
-
-                            return;
-                        }
-
-                        $user->amnesty_blocked_at = now();
-                        $user->amnesty_blocked_reason = $data['reason'] ?? null;
-                        $user->save();
-
-                        Notification::make()->success()->title('Player blocked from the amnesty')->send();
                     }),
 
                 Tables\Actions\Action::make('restore')
@@ -345,10 +380,57 @@ class PlayerSelfReportResource extends Resource
             ]);
     }
 
+    /**
+     * Abuse is spotted here and nowhere else, so the switch that answers it
+     * lives here too. It does not touch the withdrawal it was noticed on:
+     * taking a run back and taking the right away are separate decisions.
+     */
+    public static function blockAction(): Tables\Actions\Action
+    {
+        return Tables\Actions\Action::make('block')
+            ->label(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at
+                ? 'Give the amnesty back'
+                : 'Block from the amnesty')
+            ->icon('heroicon-o-no-symbol')
+            ->color('danger')
+            ->visible(fn (PlayerSelfReport $record) => $record->user !== null)
+            ->requiresConfirmation()
+            ->form(fn (PlayerSelfReport $record) => $record->user?->amnesty_blocked_at ? [] : [
+                \Filament\Forms\Components\TextInput::make('reason')
+                    ->label('Reason (shown to the player)')
+                    ->required()
+                    ->maxLength(255),
+            ])
+            ->action(function (PlayerSelfReport $record, array $data) {
+                $user = $record->user;
+
+                if (! $user) {
+                    return;
+                }
+
+                if ($user->amnesty_blocked_at) {
+                    $user->amnesty_blocked_at = null;
+                    $user->amnesty_blocked_reason = null;
+                    $user->save();
+
+                    Notification::make()->success()->title('Amnesty restored')->send();
+
+                    return;
+                }
+
+                $user->amnesty_blocked_at = now();
+                $user->amnesty_blocked_reason = $data['reason'] ?? null;
+                $user->save();
+
+                Notification::make()->success()->title('Player blocked from the amnesty')->send();
+            });
+    }
+
     public static function getPages(): array
     {
         return [
             'index' => Pages\ListPlayerSelfReports::route('/'),
+            'player' => Pages\PlayerAmnesty::route('/{mdd}'),
         ];
     }
 }

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -109,7 +109,11 @@ class PlayerSelfReportResource extends Resource
                 ->selectRaw('min(id) as id, mdd_id, max(user_id) as user_id, max(player_name) as player_name')
                 ->selectRaw('count(*) as runs')
                 ->selectRaw('count(distinct reason) as reason_count')
-                ->selectRaw('sum(processed_at is null) as open_count')
+                // Open splits in two, because the two halves are different
+                // jobs: one is waiting on an admin, the other is waiting on
+                // the MDD merge and needs nobody.
+                ->selectRaw("sum(processed_at is null and handling = 'immediate') as waiting_count")
+                ->selectRaw("sum(processed_at is null and handling = 'on_merge') as queued_count")
                 ->selectRaw("sum(processed_at is not null and coalesce(resolution, '') not in ('beaten', 'restored')) as hidden_count")
                 ->selectRaw("sum(coalesce(resolution, '') = 'beaten') as beaten_count")
                 ->selectRaw("sum(coalesce(resolution, '') = 'restored') as restored_count")
@@ -120,9 +124,13 @@ class PlayerSelfReportResource extends Resource
                 ->orderByRaw('sum(processed_at is null) > 0 desc'))
             ->defaultSort('last_request', 'desc')
             ->filters([
-                Tables\Filters\Filter::make('open')
-                    ->label('Has something still open')
-                    ->query(fn (Builder $query) => $query->havingRaw('sum(processed_at is null) > 0')),
+                Tables\Filters\Filter::make('waiting')
+                    ->label('Waiting on you')
+                    ->query(fn (Builder $query) => $query->havingRaw("sum(processed_at is null and handling = 'immediate') > 0")),
+
+                Tables\Filters\Filter::make('queued')
+                    ->label('Queued for the merge')
+                    ->query(fn (Builder $query) => $query->havingRaw("sum(processed_at is null and handling = 'on_merge') > 0")),
 
                 Tables\Filters\Filter::make('blocked')
                     ->label('Blocked from the amnesty')
@@ -162,11 +170,19 @@ class PlayerSelfReportResource extends Resource
                     })
                     ->wrap(),
 
-                Tables\Columns\TextColumn::make('open_count')
-                    ->label('Still open')
+                Tables\Columns\TextColumn::make('waiting_count')
+                    ->label('Waiting on you')
                     ->badge()
                     ->color(fn ($state) => $state > 0 ? 'warning' : 'gray')
-                    ->sortable(),
+                    ->sortable()
+                    ->tooltip('Asked to be hidden now'),
+
+                Tables\Columns\TextColumn::make('queued_count')
+                    ->label('Queued')
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'info' : 'gray')
+                    ->sortable()
+                    ->tooltip('Waiting for the MDD merge - nothing to do until then'),
 
                 Tables\Columns\TextColumn::make('hidden_count')
                     ->label('Hidden')

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -276,6 +276,32 @@ class PlayerSelfReportResource extends Resource
                             ? 'success'
                             : ($record->handling === 'immediate' ? 'warning' : 'gray'))),
 
+                // What evidence exists for this run, before deciding anything
+                // about it. A withdrawal with a serverdemo behind it can be
+                // checked; one with nothing cannot, and that is worth seeing
+                // at a glance rather than by clicking every row.
+                Tables\Columns\TextColumn::make('evidence')
+                    ->label('Available')
+                    ->badge()
+                    ->state(function (PlayerSelfReport $record) {
+                        $has = [];
+
+                        if ($record->serverDemo()) {
+                            $has[] = 'Serverdemo';
+                        }
+
+                        if ($record->uploadedDemo()) {
+                            $has[] = 'Public demo';
+                        }
+
+                        if ($record->video()) {
+                            $has[] = 'Video';
+                        }
+
+                        return $has ?: ['Nothing'];
+                    })
+                    ->color(fn (string $state) => $state === 'Nothing' ? 'gray' : 'success'),
+
                 Tables\Columns\TextColumn::make('note')
                     ->label('Note')
                     ->wrap()
@@ -287,6 +313,31 @@ class PlayerSelfReportResource extends Resource
                     ->sortable(),
             ])
             ->actions([
+                Tables\Actions\Action::make('serverdemo')
+                    ->label('Serverdemo')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('info')
+                    ->visible(fn (PlayerSelfReport $record) => $record->serverDemo() !== null)
+                    ->url(fn (PlayerSelfReport $record) => \Illuminate\Support\Facades\URL::signedRoute(
+                        'defraghq.amnesty-demo',
+                        ['report' => $record->getKey()],
+                        now()->addHour(),
+                    ), shouldOpenInNewTab: true),
+
+                Tables\Actions\Action::make('publicdemo')
+                    ->label('Public demo')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('info')
+                    ->visible(fn (PlayerSelfReport $record) => $record->uploadedDemo() !== null)
+                    ->url(fn (PlayerSelfReport $record) => route('demos.download', $record->uploadedDemo()), shouldOpenInNewTab: true),
+
+                Tables\Actions\Action::make('video')
+                    ->label('Watch on YouTube')
+                    ->icon('heroicon-o-play')
+                    ->color('danger')
+                    ->visible(fn (PlayerSelfReport $record) => $record->video() !== null)
+                    ->url(fn (PlayerSelfReport $record) => $record->video()->youtube_url, shouldOpenInNewTab: true),
+
                 // The hide itself. Nothing leaves the leaderboard until this
                 // is pressed, which is also what the player was promised.
                 Tables\Actions\Action::make('hide')

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -101,12 +101,16 @@ class PlayerSelfReportResource extends Resource
                 Tables\Columns\TextColumn::make('processed_at')
                     ->label('State')
                     ->badge()
-                    ->state(fn (PlayerSelfReport $record) => $record->isProcessed()
-                        ? 'Off the board'
-                        : ($record->handling === 'immediate' ? 'Waiting on you' : 'Queued for the merge'))
-                    ->color(fn (PlayerSelfReport $record) => $record->isProcessed()
-                        ? 'success'
-                        : ($record->handling === 'immediate' ? 'warning' : 'gray')),
+                    ->state(fn (PlayerSelfReport $record) => $record->wasBeaten()
+                        ? 'Beaten - resolved'
+                        : ($record->isProcessed()
+                            ? 'Off the board'
+                            : ($record->handling === 'immediate' ? 'Waiting on you' : 'Queued for the merge')))
+                    ->color(fn (PlayerSelfReport $record) => $record->wasBeaten()
+                        ? 'info'
+                        : ($record->isProcessed()
+                            ? 'success'
+                            : ($record->handling === 'immediate' ? 'warning' : 'gray'))),
 
                 Tables\Columns\TextColumn::make('note')
                     ->label('Note')

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -110,8 +110,9 @@ class PlayerSelfReportResource extends Resource
                 ->selectRaw('count(*) as runs')
                 ->selectRaw('count(distinct reason) as reason_count')
                 ->selectRaw('sum(processed_at is null) as open_count')
-                ->selectRaw("sum(processed_at is not null and coalesce(resolution, '') <> 'beaten') as hidden_count")
+                ->selectRaw("sum(processed_at is not null and coalesce(resolution, '') not in ('beaten', 'restored')) as hidden_count")
                 ->selectRaw("sum(coalesce(resolution, '') = 'beaten') as beaten_count")
+                ->selectRaw("sum(coalesce(resolution, '') = 'restored') as restored_count")
                 ->selectRaw('max(created_at) as last_request')
                 ->with('user:id,name,plain_name,amnesty_blocked_at')
                 ->groupBy('mdd_id')
@@ -180,6 +181,13 @@ class PlayerSelfReportResource extends Resource
                     ->sortable()
                     ->tooltip('Closed by the player beating the time themselves'),
 
+                Tables\Columns\TextColumn::make('restored_count')
+                    ->label('Put back')
+                    ->badge()
+                    ->color(fn ($state) => $state > 0 ? 'danger' : 'gray')
+                    ->sortable()
+                    ->tooltip('Hidden and then put back on the board by an admin'),
+
                 Tables\Columns\TextColumn::make('last_request')
                     ->label('Last request')
                     ->dateTime()
@@ -226,13 +234,15 @@ class PlayerSelfReportResource extends Resource
                         'open' => 'Anything still open',
                         'hidden' => 'Off the board',
                         'beaten' => 'Beaten - resolved',
+                        'restored' => 'Put back',
                     ])
                     ->query(fn (Builder $query, array $data) => match ($data['value'] ?? null) {
                         'waiting' => $query->whereNull('processed_at')->where('handling', 'immediate'),
                         'queued' => $query->whereNull('processed_at')->where('handling', 'on_merge'),
                         'open' => $query->whereNull('processed_at'),
-                        'hidden' => $query->whereNotNull('processed_at')->where(fn ($q) => $q->whereNull('resolution')->orWhere('resolution', '!=', 'beaten')),
+                        'hidden' => $query->whereNotNull('processed_at')->where(fn ($q) => $q->whereNull('resolution')->orWhereNotIn('resolution', ['beaten', 'restored'])),
                         'beaten' => $query->where('resolution', 'beaten'),
+                        'restored' => $query->where('resolution', 'restored'),
                         default => $query,
                     }),
 
@@ -265,16 +275,20 @@ class PlayerSelfReportResource extends Resource
                 Tables\Columns\TextColumn::make('processed_at')
                     ->label('State')
                     ->badge()
-                    ->state(fn (PlayerSelfReport $record) => $record->wasBeaten()
-                        ? 'Beaten - resolved'
-                        : ($record->isProcessed()
-                            ? 'Off the board'
-                            : ($record->handling === 'immediate' ? 'Waiting on you' : 'Queued for the merge')))
-                    ->color(fn (PlayerSelfReport $record) => $record->wasBeaten()
-                        ? 'info'
-                        : ($record->isProcessed()
-                            ? 'success'
-                            : ($record->handling === 'immediate' ? 'warning' : 'gray'))),
+                    ->state(fn (PlayerSelfReport $record) => match (true) {
+                        $record->wasBeaten() => 'Beaten - resolved',
+                        $record->wasRestored() => 'Put back',
+                        $record->isProcessed() => 'Off the board',
+                        $record->handling === 'immediate' => 'Waiting on you',
+                        default => 'Queued for the merge',
+                    })
+                    ->color(fn (PlayerSelfReport $record) => match (true) {
+                        $record->wasBeaten() => 'info',
+                        $record->wasRestored() => 'danger',
+                        $record->isProcessed() => 'success',
+                        $record->handling === 'immediate' => 'warning',
+                        default => 'gray',
+                    }),
 
                 // What evidence exists for this run, before deciding anything
                 // about it. A withdrawal with a serverdemo behind it can be
@@ -344,7 +358,11 @@ class PlayerSelfReportResource extends Resource
                     ->label('Approve and hide the run')
                     ->icon('heroicon-o-eye-slash')
                     ->color('success')
-                    ->visible(fn (PlayerSelfReport $record) => ! $record->isProcessed() && $record->record_id)
+                    // Offered again after a restore: putting a run back can
+                    // itself be the mistake, and then there is no way forward.
+                    ->visible(fn (PlayerSelfReport $record) => $record->record_id
+                        && (! $record->isProcessed() || $record->wasRestored())
+                        && Record::whereKey($record->record_id)->exists())
                     ->requiresConfirmation()
                     ->modalDescription('Takes the run off the leaderboard here. Until the MDD databases are merged it still stands on q3df.org.')
                     ->action(function (PlayerSelfReport $record) {
@@ -362,8 +380,7 @@ class PlayerSelfReportResource extends Resource
                     ->visible(fn (PlayerSelfReport $record) => $record->record_id
                         && Record::onlyTrashed()->whereKey($record->record_id)->exists())
                     ->action(function (PlayerSelfReport $record) {
-                        $record->restoreRun();
-                        $record->delete();
+                        $record->restoreRun(auth()->id());
 
                         Notification::make()->success()->title('Run restored')->send();
                     }),
@@ -407,12 +424,9 @@ class PlayerSelfReportResource extends Resource
                         $done = 0;
 
                         foreach ($records as $record) {
-                            if (! $record->restoreRun()) {
-                                continue;
+                            if ($record->restoreRun(auth()->id())) {
+                                $done++;
                             }
-
-                            $record->delete();
-                            $done++;
                         }
 
                         Notification::make()->success()

--- a/app/Filament/Resources/PlayerSelfReportResource.php
+++ b/app/Filament/Resources/PlayerSelfReportResource.php
@@ -43,12 +43,34 @@ class PlayerSelfReportResource extends Resource
         return false;
     }
 
+    /** Requests nobody has acted on yet. */
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) PlayerSelfReport::pending()->count() ?: null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
+    }
+
     public static function table(Table $table): Table
     {
         return $table
             ->striped()
             ->defaultSort('created_at', 'desc')
-            ->modifyQueryUsing(fn ($query) => $query->with('user:id,name,plain_name,amnesty_blocked_at'))
+            ->modifyQueryUsing(fn ($query) => $query
+                ->with('user:id,name,plain_name,amnesty_blocked_at')
+                // Anything still waiting on a decision first, whatever the sort.
+                ->orderByRaw('processed_at is null desc'))
+            ->filters([
+                Tables\Filters\Filter::make('pending')
+                    ->label('Waiting to be handled')
+                    ->query(fn ($query) => $query->whereNull('processed_at')),
+                Tables\Filters\SelectFilter::make('handling')
+                    ->label('When')
+                    ->options(PlayerSelfReport::HANDLING),
+            ])
             ->columns([
                 Tables\Columns\TextColumn::make('player_name')
                     ->label('Player')
@@ -76,6 +98,16 @@ class PlayerSelfReportResource extends Resource
                     ->badge()
                     ->formatStateUsing(fn (string $state) => RecordFlagController::FLAG_TYPES[$state] ?? $state),
 
+                Tables\Columns\TextColumn::make('processed_at')
+                    ->label('State')
+                    ->badge()
+                    ->state(fn (PlayerSelfReport $record) => $record->isProcessed()
+                        ? 'Off the board'
+                        : ($record->handling === 'immediate' ? 'Waiting on you' : 'Queued for the merge'))
+                    ->color(fn (PlayerSelfReport $record) => $record->isProcessed()
+                        ? 'success'
+                        : ($record->handling === 'immediate' ? 'warning' : 'gray')),
+
                 Tables\Columns\TextColumn::make('note')
                     ->label('Note')
                     ->wrap()
@@ -88,6 +120,27 @@ class PlayerSelfReportResource extends Resource
                     ->sortable(),
             ])
             ->actions([
+                // The hide itself. Nothing leaves the leaderboard until this
+                // is pressed, which is also what the player was promised.
+                Tables\Actions\Action::make('hide')
+                    ->label('Approve and hide the run')
+                    ->icon('heroicon-o-eye-slash')
+                    ->color('success')
+                    ->visible(fn (PlayerSelfReport $record) => ! $record->isProcessed() && $record->record_id)
+                    ->requiresConfirmation()
+                    ->modalDescription('Takes the run off the leaderboard here. Until the MDD databases are merged it still stands on q3df.org.')
+                    ->action(function (PlayerSelfReport $record) {
+                        $run = Record::find($record->record_id);
+
+                        // Soft delete: the model's hooks detach uploaded demos
+                        // and clear the profile and listing caches.
+                        $run?->delete();
+
+                        $record->update(['processed_at' => now(), 'processed_by' => auth()->id()]);
+
+                        Notification::make()->success()->title('Run hidden')->send();
+                    }),
+
                 // Abuse is spotted here and nowhere else, so the switch that
                 // answers it lives here too. It does not touch the withdrawal
                 // it was noticed on: taking a run back and taking the right
@@ -134,7 +187,7 @@ class PlayerSelfReportResource extends Resource
                     ->icon('heroicon-o-arrow-uturn-left')
                     ->color('warning')
                     ->requiresConfirmation()
-                    ->modalDescription('This puts the record back on the leaderboard and removes it from the public log. Use it when the wrong run was withdrawn.')
+                    ->modalDescription('Puts the record back on the leaderboard and drops the request. Use it when the wrong run was sent.')
                     ->visible(fn (PlayerSelfReport $record) => $record->record_id
                         && Record::onlyTrashed()->whereKey($record->record_id)->exists())
                     ->action(function (PlayerSelfReport $record) {

--- a/app/Filament/Resources/PlayerSelfReportResource/Pages/ListPlayerSelfReports.php
+++ b/app/Filament/Resources/PlayerSelfReportResource/Pages/ListPlayerSelfReports.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\PlayerSelfReportResource\Pages;
+
+use App\Filament\Resources\PlayerSelfReportResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPlayerSelfReports extends ListRecords
+{
+    protected static string $resource = PlayerSelfReportResource::class;
+
+    public function getMaxContentWidth(): string | null
+    {
+        return 'full';
+    }
+}

--- a/app/Filament/Resources/PlayerSelfReportResource/Pages/ListPlayerSelfReports.php
+++ b/app/Filament/Resources/PlayerSelfReportResource/Pages/ListPlayerSelfReports.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\PlayerSelfReportResource\Pages;
 
 use App\Filament\Resources\PlayerSelfReportResource;
+use App\Filament\Resources\PlayerSelfReportResource\Widgets\AmnestyOverview;
 use Filament\Resources\Pages\ListRecords;
 
 class ListPlayerSelfReports extends ListRecords
@@ -12,5 +13,12 @@ class ListPlayerSelfReports extends ListRecords
     public function getMaxContentWidth(): string | null
     {
         return 'full';
+    }
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            AmnestyOverview::class,
+        ];
     }
 }

--- a/app/Filament/Resources/PlayerSelfReportResource/Pages/PlayerAmnesty.php
+++ b/app/Filament/Resources/PlayerSelfReportResource/Pages/PlayerAmnesty.php
@@ -3,9 +3,12 @@
 namespace App\Filament\Resources\PlayerSelfReportResource\Pages;
 
 use App\Filament\Resources\PlayerSelfReportResource;
+use App\Models\PlayerSelfReport;
 use Filament\Actions;
+use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * One player's withdrawals.
@@ -45,6 +48,66 @@ class PlayerAmnesty extends ListRecords
     public function table(Table $table): Table
     {
         return PlayerSelfReportResource::detailTable($table, $this->mdd);
+    }
+
+    /**
+     * The three things a request can be, in the order they happen.
+     *
+     * Waiting is work; queued is not work until the databases merge; done is
+     * over. Keeping them in one list means the four runs that need nothing
+     * from you sit among the ones that do.
+     */
+    public function getTabs(): array
+    {
+        $count = fn (\Closure $scope) => $scope(PlayerSelfReport::where('mdd_id', $this->mdd))->count() ?: null;
+
+        $waiting = fn (Builder $query) => $query
+            ->whereNull('processed_at')->where('handling', 'immediate');
+
+        $queued = fn (Builder $query) => $query
+            ->whereNull('processed_at')->where('handling', 'on_merge');
+
+        $done = fn (Builder $query) => $query
+            ->whereNotNull('processed_at');
+
+        return [
+            'waiting' => Tab::make('Waiting on you')
+                ->modifyQueryUsing($waiting)
+                ->badge(fn () => $count($waiting))
+                ->badgeColor('warning'),
+
+            'queued' => Tab::make('Queued for the merge')
+                ->modifyQueryUsing($queued)
+                ->badge(fn () => $count($queued))
+                ->badgeColor('info'),
+
+            'done' => Tab::make('Done')
+                ->modifyQueryUsing($done)
+                ->badge(fn () => $count($done))
+                ->badgeColor('success'),
+
+            'all' => Tab::make('All'),
+        ];
+    }
+
+    /**
+     * Open on the first tab that has anything in it. A player whose requests
+     * are all settled would otherwise land on an empty Waiting tab, which
+     * reads as the page having lost them.
+     */
+    public function getDefaultActiveTab(): string | int | null
+    {
+        $base = fn () => PlayerSelfReport::where('mdd_id', $this->mdd);
+
+        if ((clone $base())->whereNull('processed_at')->where('handling', 'immediate')->exists()) {
+            return 'waiting';
+        }
+
+        if ((clone $base())->whereNull('processed_at')->exists()) {
+            return 'queued';
+        }
+
+        return 'done';
     }
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/PlayerSelfReportResource/Pages/PlayerAmnesty.php
+++ b/app/Filament/Resources/PlayerSelfReportResource/Pages/PlayerAmnesty.php
@@ -67,8 +67,13 @@ class PlayerAmnesty extends ListRecords
         $queued = fn (Builder $query) => $query
             ->whereNull('processed_at')->where('handling', 'on_merge');
 
+        // Done is what stayed down. A run that was put back is the opposite of
+        // done, so it gets its own tab rather than sitting among the settled.
         $done = fn (Builder $query) => $query
-            ->whereNotNull('processed_at');
+            ->whereNotNull('processed_at')
+            ->where(fn ($q) => $q->whereNull('resolution')->orWhere('resolution', '!=', 'restored'));
+
+        $restored = fn (Builder $query) => $query->where('resolution', 'restored');
 
         return [
             'waiting' => Tab::make('Waiting on you')
@@ -85,6 +90,11 @@ class PlayerAmnesty extends ListRecords
                 ->modifyQueryUsing($done)
                 ->badge(fn () => $count($done))
                 ->badgeColor('success'),
+
+            'restored' => Tab::make('Put back')
+                ->modifyQueryUsing($restored)
+                ->badge(fn () => $count($restored))
+                ->badgeColor('danger'),
 
             'all' => Tab::make('All'),
         ];
@@ -107,7 +117,13 @@ class PlayerAmnesty extends ListRecords
             return 'queued';
         }
 
-        return 'done';
+        if ((clone $base())->whereNotNull('processed_at')
+            ->where(fn ($q) => $q->whereNull('resolution')->orWhere('resolution', '!=', 'restored'))
+            ->exists()) {
+            return 'done';
+        }
+
+        return 'restored';
     }
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/PlayerSelfReportResource/Pages/PlayerAmnesty.php
+++ b/app/Filament/Resources/PlayerSelfReportResource/Pages/PlayerAmnesty.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources\PlayerSelfReportResource\Pages;
+
+use App\Filament\Resources\PlayerSelfReportResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+use Filament\Tables\Table;
+
+/**
+ * One player's withdrawals.
+ *
+ * The mdd id is held in a public property rather than read from the route on
+ * every call: Livewire's follow-up requests go to its own endpoint, where the
+ * route parameters of this page do not exist.
+ */
+class PlayerAmnesty extends ListRecords
+{
+    protected static string $resource = PlayerSelfReportResource::class;
+
+    public ?string $mdd = null;
+
+    public function mount(): void
+    {
+        $this->mdd = request()->route('mdd');
+
+        parent::mount();
+    }
+
+    public function getMaxContentWidth(): string | null
+    {
+        return 'full';
+    }
+
+    public function getTitle(): string
+    {
+        return PlayerSelfReportResource::playerName($this->mdd);
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'MDD #' . $this->mdd . ' - everything this player took down';
+    }
+
+    public function table(Table $table): Table
+    {
+        return PlayerSelfReportResource::detailTable($table, $this->mdd);
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('back')
+                ->label('Back to the list of players')
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray')
+                ->url(PlayerSelfReportResource::getUrl('index')),
+        ];
+    }
+}

--- a/app/Filament/Resources/PlayerSelfReportResource/Widgets/AmnestyOverview.php
+++ b/app/Filament/Resources/PlayerSelfReportResource/Widgets/AmnestyOverview.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filament\Resources\PlayerSelfReportResource\Widgets;
+
+use App\Models\PlayerSelfReport;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/**
+ * The four numbers worth knowing before opening a single request: how much is
+ * waiting, how many people it is spread over, and how much of it is queued
+ * behind the MDD merge rather than behind an admin.
+ */
+class AmnestyOverview extends StatsOverviewWidget
+{
+    protected static ?string $pollingInterval = null;
+
+    protected function getStats(): array
+    {
+        $waiting = PlayerSelfReport::pending()->count();
+        $players = PlayerSelfReport::distinct()->count('mdd_id');
+        $onMerge = PlayerSelfReport::pending()->where('handling', 'on_merge')->count();
+        $done = PlayerSelfReport::whereNotNull('processed_at')->count();
+
+        return [
+            Stat::make('Waiting on you', $waiting - $onMerge)
+                ->description($waiting ? 'Asked to be hidden now' : 'Nothing to do')
+                ->color($waiting - $onMerge > 0 ? 'warning' : 'success'),
+
+            Stat::make('Queued for the merge', $onMerge)
+                ->description('No action needed until the databases merge')
+                ->color('gray'),
+
+            Stat::make('Players', $players)
+                ->description('People who have used the amnesty'),
+
+            Stat::make('Runs taken down', $done)
+                ->description('Hidden or resolved by a better run')
+                ->color('success'),
+        ];
+    }
+}

--- a/app/Filament/Resources/WishResource.php
+++ b/app/Filament/Resources/WishResource.php
@@ -39,6 +39,17 @@ class WishResource extends Resource
         return false;
     }
 
+    /** Waiting wishes are the only thing here that needs doing. */
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) Wish::whereNull('approved_at')->count() ?: null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([
@@ -68,8 +79,20 @@ class WishResource extends Resource
     {
         return $table
             ->striped()
+            // Waiting first, whatever the sort: they are the queue, the rest
+            // is archive.
             ->defaultSort('score', 'desc')
+            ->modifyQueryUsing(fn ($query) => $query->orderByRaw('approved_at is null desc'))
             ->columns([
+                Tables\Columns\IconColumn::make('approved_at')
+                    ->label('Live')
+                    ->alignCenter()
+                    ->boolean()
+                    ->trueIcon('heroicon-o-check-circle')
+                    ->falseIcon('heroicon-o-clock')
+                    ->trueColor('success')
+                    ->falseColor('warning'),
+
                 Tables\Columns\TextColumn::make('score')
                     ->label('Score')
                     ->badge()
@@ -107,10 +130,37 @@ class WishResource extends Resource
                     ->sortable(),
             ])
             ->filters([
+                Tables\Filters\TernaryFilter::make('approved_at')
+                    ->label('Approval')
+                    ->placeholder('All')
+                    ->trueLabel('Live on the list')
+                    ->falseLabel('Waiting for approval')
+                    ->nullable(),
                 Tables\Filters\SelectFilter::make('project')->options(Wish::PROJECTS),
                 Tables\Filters\SelectFilter::make('status')->options(Wish::STATUSES),
             ])
             ->actions([
+                // Approval is the gate: until this is pressed the wish is not
+                // on the public list and cannot be voted on.
+                Tables\Actions\Action::make('approve')
+                    ->label(fn (Wish $record) => $record->isApproved() ? 'Take off the list' : 'Approve')
+                    ->icon(fn (Wish $record) => $record->isApproved() ? 'heroicon-o-eye-slash' : 'heroicon-o-check-circle')
+                    ->color(fn (Wish $record) => $record->isApproved() ? 'gray' : 'success')
+                    ->requiresConfirmation(fn (Wish $record) => $record->isApproved())
+                    ->action(function (Wish $record) {
+                        if ($record->isApproved()) {
+                            $record->update(['approved_at' => null, 'approved_by' => null]);
+
+                            Notification::make()->success()->title('Taken off the list')->send();
+
+                            return;
+                        }
+
+                        $record->update(['approved_at' => now(), 'approved_by' => auth()->id()]);
+
+                        Notification::make()->success()->title('Wish approved')->send();
+                    }),
+
                 Tables\Actions\EditAction::make(),
 
                 // The common case is answering a wish without rewriting it, so
@@ -140,6 +190,15 @@ class WishResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\BulkAction::make('approveAll')
+                        ->label('Approve selected')
+                        ->icon('heroicon-o-check-circle')
+                        ->color('success')
+                        ->action(fn ($records) => $records->each->update([
+                            'approved_at' => now(),
+                            'approved_by' => auth()->id(),
+                        ])),
+
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ]);

--- a/app/Filament/Resources/WishResource.php
+++ b/app/Filament/Resources/WishResource.php
@@ -39,10 +39,12 @@ class WishResource extends Resource
         return false;
     }
 
-    /** Waiting wishes are the only thing here that needs doing. */
+    /** Everything here that needs a decision: waiting, or asked to be taken down. */
     public static function getNavigationBadge(): ?string
     {
-        return (string) Wish::whereNull('approved_at')->count() ?: null;
+        return (string) Wish::query()
+            ->where(fn ($query) => $query->whereNull('approved_at')->orWhereNotNull('removal_requested_at'))
+            ->count() ?: null;
     }
 
     public static function getNavigationBadgeColor(): ?string
@@ -79,10 +81,12 @@ class WishResource extends Resource
     {
         return $table
             ->striped()
-            // Waiting first, whatever the sort: they are the queue, the rest
-            // is archive.
+            // Anything needing a decision first, whatever the sort: those are
+            // the queue, the rest is archive.
             ->defaultSort('score', 'desc')
-            ->modifyQueryUsing(fn ($query) => $query->orderByRaw('approved_at is null desc'))
+            ->modifyQueryUsing(fn ($query) => $query
+                ->orderByRaw('removal_requested_at is not null desc')
+                ->orderByRaw('approved_at is null desc'))
             ->columns([
                 Tables\Columns\IconColumn::make('approved_at')
                     ->label('Live')
@@ -109,7 +113,10 @@ class WishResource extends Resource
                 Tables\Columns\TextColumn::make('title')
                     ->searchable()
                     ->wrap()
-                    ->description(fn (Wish $record) => str($record->body)->limit(140)),
+                    ->description(fn (Wish $record) => $record->removal_requested_at
+                        ? 'REMOVAL REQUESTED' . ($record->removal_reason ? ': ' . $record->removal_reason : '')
+                        : str($record->body)->limit(140))
+                    ->color(fn (Wish $record) => $record->removal_requested_at ? 'warning' : null),
 
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Author')
@@ -136,6 +143,9 @@ class WishResource extends Resource
                     ->trueLabel('Live on the list')
                     ->falseLabel('Waiting for approval')
                     ->nullable(),
+                Tables\Filters\Filter::make('removal_requested')
+                    ->label('Removal requested')
+                    ->query(fn ($query) => $query->whereNotNull('removal_requested_at')),
                 Tables\Filters\SelectFilter::make('project')->options(Wish::PROJECTS),
                 Tables\Filters\SelectFilter::make('status')->options(Wish::STATUSES),
             ])
@@ -159,6 +169,20 @@ class WishResource extends Resource
                         $record->update(['approved_at' => now(), 'approved_by' => auth()->id()]);
 
                         Notification::make()->success()->title('Wish approved')->send();
+                    }),
+
+                // The author asked for it to go. Either it goes, or the request
+                // is turned down and the wish stays exactly as it was.
+                Tables\Actions\Action::make('declineRemoval')
+                    ->label('Keep it (decline)')
+                    ->icon('heroicon-o-hand-raised')
+                    ->color('gray')
+                    ->visible(fn (Wish $record) => $record->removal_requested_at !== null)
+                    ->requiresConfirmation()
+                    ->action(function (Wish $record) {
+                        $record->update(['removal_requested_at' => null, 'removal_reason' => null]);
+
+                        Notification::make()->success()->title('Removal request declined')->send();
                     }),
 
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/WishResource.php
+++ b/app/Filament/Resources/WishResource.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\WishResource\Pages;
+use App\Models\Wish;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * The admin side of the wishlist: answering wishes and removing the ones that
+ * do not belong.
+ *
+ * There is no create action. A wish written from the admin panel would carry
+ * the weight of the site behind it while sitting in a list that is supposed to
+ * measure what other people want.
+ */
+class WishResource extends Resource
+{
+    protected static ?string $model = Wish::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-sparkles';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Wishlist';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('title')
+                ->required()
+                ->maxLength(120),
+
+            Forms\Components\Textarea::make('body')
+                ->rows(5)
+                ->required(),
+
+            Forms\Components\Select::make('status')
+                ->options(Wish::STATUSES)
+                ->required(),
+
+            Forms\Components\Textarea::make('status_note')
+                ->label('Your answer (shown publicly under the wish)')
+                ->rows(3),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->striped()
+            ->defaultSort('score', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('score')
+                    ->label('Score')
+                    ->badge()
+                    ->alignCenter()
+                    ->sortable()
+                    ->color(fn ($state) => $state > 0 ? 'success' : ($state < 0 ? 'danger' : 'gray'))
+                    ->description(fn (Wish $record) => "+{$record->upvotes} / -{$record->downvotes}"),
+
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->wrap()
+                    ->description(fn (Wish $record) => str($record->body)->limit(140)),
+
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Author')
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => Wish::STATUSES[$state] ?? $state)
+                    ->color(fn (string $state) => match ($state) {
+                        'planned' => 'info',
+                        'done' => 'success',
+                        'rejected' => 'danger',
+                        default => 'gray',
+                    }),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')->options(Wish::STATUSES),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+
+                // The common case is answering a wish without rewriting it, so
+                // it gets its own one-field action instead of the full form.
+                Tables\Actions\Action::make('answer')
+                    ->label('Set status')
+                    ->icon('heroicon-o-chat-bubble-left-right')
+                    ->form([
+                        Forms\Components\Select::make('status')
+                            ->options(Wish::STATUSES)
+                            ->required(),
+                        Forms\Components\Textarea::make('status_note')
+                            ->label('Answer (public, optional)')
+                            ->rows(3),
+                    ])
+                    ->fillForm(fn (Wish $record) => [
+                        'status' => $record->status,
+                        'status_note' => $record->status_note,
+                    ])
+                    ->action(function (Wish $record, array $data) {
+                        $record->update($data);
+
+                        Notification::make()->success()->title('Wish updated')->send();
+                    }),
+
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListWishes::route('/'),
+            'edit' => Pages\EditWish::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/WishResource.php
+++ b/app/Filament/Resources/WishResource.php
@@ -42,6 +42,10 @@ class WishResource extends Resource
     public static function form(Form $form): Form
     {
         return $form->schema([
+            Forms\Components\Select::make('project')
+                ->options(Wish::PROJECTS)
+                ->required(),
+
             Forms\Components\TextInput::make('title')
                 ->required()
                 ->maxLength(120),
@@ -74,6 +78,11 @@ class WishResource extends Resource
                     ->color(fn ($state) => $state > 0 ? 'success' : ($state < 0 ? 'danger' : 'gray'))
                     ->description(fn (Wish $record) => "+{$record->upvotes} / -{$record->downvotes}"),
 
+                Tables\Columns\TextColumn::make('project')
+                    ->badge()
+                    ->color('info')
+                    ->formatStateUsing(fn (?string $state) => Wish::PROJECTS[$state] ?? $state),
+
                 Tables\Columns\TextColumn::make('title')
                     ->searchable()
                     ->wrap()
@@ -98,6 +107,7 @@ class WishResource extends Resource
                     ->sortable(),
             ])
             ->filters([
+                Tables\Filters\SelectFilter::make('project')->options(Wish::PROJECTS),
                 Tables\Filters\SelectFilter::make('status')->options(Wish::STATUSES),
             ])
             ->actions([

--- a/app/Filament/Resources/WishResource/Pages/EditWish.php
+++ b/app/Filament/Resources/WishResource/Pages/EditWish.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WishResource\Pages;
+
+use App\Filament\Resources\WishResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWish extends EditRecord
+{
+    protected static string $resource = WishResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WishResource/Pages/ListWishes.php
+++ b/app/Filament/Resources/WishResource/Pages/ListWishes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\WishResource\Pages;
+
+use App\Filament\Resources\WishResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWishes extends ListRecords
+{
+    protected static string $resource = WishResource::class;
+
+    public function getMaxContentWidth(): string | null
+    {
+        return 'full';
+    }
+}

--- a/app/Http/Controllers/AmnestyDemoDownloadController.php
+++ b/app/Http/Controllers/AmnestyDemoDownloadController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PlayerSelfReport;
+use App\Models\ServerDemo;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * The serverdemo of a withdrawn run, for an admin.
+ *
+ * Admins only, deliberately - not validators. A withdrawal is private, and the
+ * demo of it says which run was withdrawn just as loudly as the row does.
+ */
+class AmnestyDemoDownloadController extends Controller
+{
+    /** rclone mirrors /var/lib/serverdemos into this prefix of the bucket. */
+    private const B2_PREFIX = 'serverdemos/';
+
+    public function __invoke(Request $request, PlayerSelfReport $report)
+    {
+        abort_unless($request->user()?->isAdmin(), 403);
+
+        $demo = $report->serverDemo();
+        abort_if($demo === null, 404);
+
+        $opened = $this->open($demo);
+        abort_if($opened === null, 404);
+
+        [$stream, $filename] = $opened;
+
+        // Chunked and flushed: Octane/Swoole caps a single buffered body and
+        // answers 502 when a Content-Length accompanies chunked writes.
+        return response()->streamDownload(function () use ($stream) {
+            while (! feof($stream)) {
+                $chunk = fread($stream, 64 * 1024);
+
+                if ($chunk === false) {
+                    break;
+                }
+
+                echo $chunk;
+                flush();
+            }
+
+            fclose($stream);
+        }, $filename, [
+            'Content-Type' => 'application/octet-stream',
+            'X-Accel-Buffering' => 'no',
+        ]);
+    }
+
+    /**
+     * Same two homes and the same packed/unpacked ambiguity as the validation
+     * download - see ServerdemoValidationDownloadController::open for why both
+     * names are tried on both disks.
+     */
+    private function open(ServerDemo $demo): ?array
+    {
+        $paths = [$demo->path];
+
+        if (str_ends_with($demo->path, '.7z')) {
+            $paths[] = substr($demo->path, 0, -3);
+        }
+
+        $disks = $demo->on_contabo
+            ? ['serverdemos', 'serverdemos_b2']
+            : ['serverdemos_b2', 'serverdemos'];
+
+        foreach ($disks as $disk) {
+            foreach ($paths as $path) {
+                $full = $disk === 'serverdemos_b2' ? self::B2_PREFIX . $path : $path;
+
+                try {
+                    $stream = Storage::disk($disk)->readStream($full);
+                } catch (\Throwable) {
+                    $stream = null;
+                }
+
+                if (is_resource($stream)) {
+                    return [$stream, basename($path)];
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -191,6 +191,39 @@ class MapsController extends Controller
      *   demo_id : int — UploadedDemo.id to use as seed
      *   physics : 'vq3' | 'cpm'
      */
+    /**
+     * The fastcap a demo belongs to, or null for a normal run.
+     *
+     * uploaded_demos.physics carries the mode in a suffix: "CPM" for a run,
+     * "CPM.TR" for a trick run, "CPM.0" through "CPM.8" for the fastcaps.
+     */
+    private static function fastcapOf(?string $demoPhysics): ?string
+    {
+        return preg_match('/\.(\d)$/', (string) $demoPhysics, $m) ? $m[1] : null;
+    }
+
+    /**
+     * Narrow a demo query to one gametype.
+     *
+     * A ctf2 list must not see CPM.1, and a defrag run must not see fastcaps
+     * at all - they are different gametypes, not variants of one.
+     */
+    private function scopeDemoPhysics($query, string $physics, ?string $fastcap)
+    {
+        $base = strtoupper($physics);
+
+        if ($fastcap !== null) {
+            return $query->where('physics', $base . '.' . $fastcap);
+        }
+
+        // A run, so everything except the numbered fastcaps. ".TR" stays: a
+        // trick run is the same run, recorded by somebody showing off.
+        return $query->where(function ($q) use ($base) {
+            $q->where('physics', $base)
+                ->orWhere('physics', $base . '.TR');
+        });
+    }
+
     public function timeHistory(Request $request, $mapname)
     {
         $demoId = (int) $request->input('demo_id');
@@ -208,7 +241,11 @@ class MapsController extends Controller
         // cluster member shows in the drawer.
         if (!$demoId && ($userId || $mddId)) {
             $profileKey = $userId ? ('user:' . $userId) : ('mdd:' . $mddId);
-            return $this->timeHistoryForProfile($mapname, $physics, $profileKey);
+            // No seed demo to read the fastcap off, so the caller says which
+            // one it is looking at. Absent, it behaves as before.
+            $viewed = preg_match('/^ctf(\d)/', (string) $request->input('gametype'), $ctf) ? $ctf[1] : null;
+
+            return $this->timeHistoryForProfile($mapname, $physics, $profileKey, $viewed);
         }
 
         $seed = UploadedDemo::find($demoId);
@@ -216,15 +253,12 @@ class MapsController extends Controller
             return response()->json(['history' => [], 'signals' => 0]);
         }
 
-        // Fetch all demos on this map+physics (both online-assigned and offline-only)
-        // uploaded_demos.physics is uppercase ("CPM", "VQ3", possibly with ".TR"),
-        // so match case-insensitively on the leading segment.
-        $physicsUpper = strtoupper($physics);
+        // Fetch all demos on this map+physics (both online-assigned and offline-only).
+        // The fastcap the seed belongs to decides the set: a ctf1 attempt has
+        // nothing to do with the same player's ctf2 attempt, and before this
+        // they landed in one history together.
         $demos = UploadedDemo::where('map_name', $mapname)
-            ->where(function ($q) use ($physicsUpper) {
-                $q->where('physics', $physicsUpper)
-                  ->orWhere('physics', 'LIKE', $physicsUpper . '.%');
-            })
+            ->where(fn ($q) => $this->scopeDemoPhysics($q, $physics, self::fastcapOf($seed->physics)))
             ->with(['renderedVideo', 'user', 'record.user'])
             ->get();
 
@@ -376,7 +410,7 @@ class MapsController extends Controller
      * Resolves demos via approved aliases against the profile key
      * ("user:<id>" or "mdd:<id>") and returns every online cluster member.
      */
-    private function timeHistoryForProfile(string $mapname, string $physics, string $profileKey)
+    private function timeHistoryForProfile(string $mapname, string $physics, string $profileKey, ?string $fastcap = null)
     {
         $user = null;
         if (str_starts_with($profileKey, 'user:')) {
@@ -388,12 +422,8 @@ class MapsController extends Controller
             return response()->json(['history' => [], 'signals' => 0]);
         }
 
-        $physicsUpper = strtoupper($physics);
         $demos = UploadedDemo::where('map_name', $mapname)
-            ->where(function ($q) use ($physicsUpper) {
-                $q->where('physics', $physicsUpper)
-                  ->orWhere('physics', 'LIKE', $physicsUpper . '.%');
-            })
+            ->where(fn ($q) => $this->scopeDemoPhysics($q, $physics, $fastcap))
             ->with(['renderedVideo', 'user', 'record.user'])
             ->get();
 
@@ -705,11 +735,14 @@ class MapsController extends Controller
         // Physics patterns are needed for both the unified leaderboard (when
         // showOffline is on) and the standalone Demos Top fallback, so pull
         // them out of the if-block.
-        $offlineGametype = (str_starts_with($map->name, 'actf') || str_starts_with($map->name, 'ctf')) ? 'fc' : 'df';
-        if ($offlineGametype === 'fc' && strpos($gametype, 'ctf') === 0) {
-            $ctfNumber = substr($gametype, 3, 1);
-            $cpmPattern = "CPM.{$ctfNumber}%";
-            $vq3Pattern = "VQ3.{$ctfNumber}%";
+        // Which fastcap the page is showing decides this, NOT the map's name.
+        // Only 66 of the 1584 maps that hold fastcap records are called ctf*
+        // or actf* - q3ctf1, q3wcp16 and rtctf5 are fastcap maps too - and for
+        // every other one the name test fell through to CPM%, which matches
+        // CPM.1 through CPM.7. That put a ctf1 demo in the ctf2 leaderboard.
+        if (preg_match('/^ctf(\d)/', $gametype, $ctf)) {
+            $cpmPattern = "CPM.{$ctf[1]}%";
+            $vq3Pattern = "VQ3.{$ctf[1]}%";
         } else {
             $cpmPattern = 'CPM%';
             $vq3Pattern = 'VQ3%';
@@ -796,8 +829,9 @@ class MapsController extends Controller
                 $r->user_id ? 'user:' . (int) $r->user_id : null,
                 $r->mdd_id ? 'mdd:' . (int) $r->mdd_id : null,
             ]))->unique()->values()->toArray();
-        $clusterMetaVq3 = $this->computeClusterMetadataForMap($map->name, 'vq3', $vq3MainKeys);
-        $clusterMetaCpm = $this->computeClusterMetadataForMap($map->name, 'cpm', $cpmMainKeys);
+        $viewedFastcap = preg_match('/^ctf(\d)/', $gametype, $ctfViewed) ? $ctfViewed[1] : null;
+        $clusterMetaVq3 = $this->computeClusterMetadataForMap($map->name, 'vq3', $vq3MainKeys, $viewedFastcap);
+        $clusterMetaCpm = $this->computeClusterMetadataForMap($map->name, 'cpm', $cpmMainKeys, $viewedFastcap);
 
         // Get servers currently playing this map
         $servers = \App\Models\Server::where('map', $map->name)
@@ -878,14 +912,12 @@ class MapsController extends Controller
      * Returns a map: ['<demo_id>' => ['count' => int, 'signals' => int]]
      * so the frontend can look up per-row badge data in O(1).
      */
-    private function computeClusterMetadataForMap(string $mapname, string $physics, array $priorityProfileKeys = []): array
+    private function computeClusterMetadataForMap(string $mapname, string $physics, array $priorityProfileKeys = [], ?string $fastcap = null): array
     {
-        $physicsUpper = strtoupper($physics);
+        // Same gametype rule as the drawer itself, or the badge would promise
+        // a count the drawer then refuses to show.
         $demos = UploadedDemo::where('map_name', $mapname)
-            ->where(function ($q) use ($physicsUpper) {
-                $q->where('physics', $physicsUpper)
-                  ->orWhere('physics', 'LIKE', $physicsUpper . '.%');
-            })
+            ->where(fn ($q) => $this->scopeDemoPhysics($q, $physics, $fastcap))
             ->get(['id', 'player_name', 'q3df_login_name', 'q3df_login_name_colored',
                    'time_ms', 'gametype', 'record_date', 'record_id', 'file_hash', 'created_at']);
 

--- a/app/Http/Controllers/RecordFlagController.php
+++ b/app/Http/Controllers/RecordFlagController.php
@@ -22,6 +22,11 @@ class RecordFlagController extends Controller
         'pmove_fixed' => 'Non-standard pmove_fixed',
         'pmove_msec' => 'Non-standard pmove_msec',
         'df_mp_interferenceoff' => 'Interference setting modified',
+        'left_right' => '+left / +right turn binds',
+        'scripts' => 'Scripted movement',
+        'upmove' => 'Upmove script',
+        'replay_cheat' => 'Replay cheat',
+        'engine_cheat' => 'Modified engine',
         'other' => 'Other validity issue',
     ];
 

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -77,12 +77,22 @@ class SelfReportController extends Controller
 
             $total = Record::where('mdd_id', $user->mdd_id)->count();
 
+            // Runs already waiting on an admin drop out of the pickable list -
+            // they are in "runs you have sent" below, and offering them again
+            // only invites a duplicate request.
+            $pending = PlayerSelfReport::pending()
+                ->where('user_id', $user->id)
+                ->pluck('record_id')
+                ->filter()
+                ->all();
+
             $records = Record::query()
                 // Left join, not a relation: the list sorts by the map's own
                 // date, and a record whose map is missing from the maps table
                 // still has to appear rather than being silently dropped.
                 ->leftJoin('maps', 'maps.name', '=', 'records.mapname')
                 ->where('records.mdd_id', $user->mdd_id)
+                ->when($pending, fn ($query) => $query->whereNotIn('records.id', $pending))
                 ->when($search !== '', fn ($query) => $query->where('records.mapname', 'like', '%' . $search . '%'))
                 ->orderBy($column, $direction)
                 // Paginated rather than capped: with a thousand runs behind it,
@@ -125,9 +135,10 @@ class SelfReportController extends Controller
             // rest of it, but you are allowed to see what you did and why -
             // months later "which runs did I take down" is a fair question and
             // the answer should not only exist in the admin panel.
+            'handlingOptions' => PlayerSelfReport::HANDLING,
             'mine' => PlayerSelfReport::where('user_id', $user->id)
                 ->orderByDesc('created_at')
-                ->get(['id', 'mapname', 'physics', 'mode', 'time', 'reason', 'note', 'created_at'])
+                ->get()
                 ->map(fn (PlayerSelfReport $report) => [
                     'id' => $report->id,
                     'mapname' => $report->mapname,
@@ -135,7 +146,9 @@ class SelfReportController extends Controller
                     'mode' => $report->mode,
                     'time' => $report->time,
                     'reason' => RecordFlagController::FLAG_TYPES[$report->reason] ?? $report->reason,
+                    'handling' => $report->handling,
                     'note' => $report->note,
+                    'processed' => $report->isProcessed(),
                     'created_at' => $report->created_at?->toIso8601String(),
                 ]),
         ]);
@@ -160,11 +173,12 @@ class SelfReportController extends Controller
             'record_ids' => ['required', 'array', 'min:1', 'max:100'],
             'record_ids.*' => ['integer'],
             'reason' => ['required', 'string', 'in:' . implode(',', array_keys(RecordFlagController::FLAG_TYPES))],
+            'handling' => ['required', 'string', 'in:' . implode(',', array_keys(PlayerSelfReport::HANDLING))],
             'note' => ['nullable', 'string', 'max:500'],
             'confirm' => ['accepted'],
         ], [
             'record_ids.required' => 'Pick at least one run.',
-            'confirm.accepted' => 'Tick the box - the times come off the leaderboard straight away.',
+            'confirm.accepted' => 'Tick the box to send it.',
         ]);
 
         // Yours means yours. The MDD id is what ties a record to a person, so
@@ -181,7 +195,24 @@ class SelfReportController extends Controller
             ]);
         }
 
+        // Already asked about, so asking again would only duplicate the queue.
+        $alreadyAsked = PlayerSelfReport::pending()
+            ->whereIn('record_id', $records->pluck('id'))
+            ->pluck('record_id')
+            ->all();
+
+        $records = $records->reject(fn (Record $record) => in_array($record->id, $alreadyAsked, true));
+
+        if ($records->isEmpty()) {
+            return back()->withErrors([
+                'record_ids' => 'Those runs are already waiting to be handled.',
+            ]);
+        }
+
         foreach ($records as $record) {
+            // The record is NOT touched here. It comes off the board when an
+            // admin approves the hide, which is also when the player is no
+            // longer told one thing while q3df.org shows another.
             PlayerSelfReport::create([
                 'user_id' => $user->id,
                 'mdd_id' => $record->mdd_id,
@@ -193,26 +224,23 @@ class SelfReportController extends Controller
                 'gametype' => $record->gametype,
                 'time' => $record->time,
                 'reason' => $data['reason'],
+                'handling' => $data['handling'],
                 'note' => $data['note'] ?? null,
             ]);
-
-            // Soft delete: the model's own hooks detach uploaded demos and
-            // clear the profile and listing caches, which is exactly what has
-            // to happen and is what the admin-side deletions already do.
-            $record->delete();
         }
 
-        Log::info('Self-reported records withdrawn', [
+        Log::info('Self-report requests filed', [
             'user_id' => $user->id,
             'mdd_id' => $user->mdd_id,
             'record_ids' => $records->pluck('id')->all(),
             'reason' => $data['reason'],
+            'handling' => $data['handling'],
         ]);
 
         $count = $records->count();
 
         return back()->with('success', $count === 1
-            ? 'Time withdrawn. It is off the leaderboard, and nobody but the site admin is told about it.'
-            : $count . ' times withdrawn. They are off the leaderboard, and nobody but the site admin is told about it.');
+            ? 'Sent. The run stays on the board until an admin handles it, and nobody but the admin is told about it.'
+            : $count . ' runs sent. They stay on the board until an admin handles them, and nobody but the admin is told about it.');
     }
 }

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -149,6 +149,8 @@ class SelfReportController extends Controller
                     'handling' => $report->handling,
                     'note' => $report->note,
                     'processed' => $report->isProcessed(),
+                    'beaten' => $report->wasBeaten(),
+                    'state' => $report->stateLabel(),
                     'created_at' => $report->created_at?->toIso8601String(),
                 ]),
         ]);

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -42,8 +42,8 @@ class SelfReportController extends Controller
         'map_added' => ['maps.date_added', 'desc'],
     ];
 
-    /** Rows sent at once. Past this, searching beats scrolling. */
-    private const PAGE_SIZE = 120;
+    /** Rows per page. Thumbnails make a longer page heavy for no gain. */
+    private const PAGE_SIZE = 60;
 
     public function index(Request $request)
     {
@@ -59,7 +59,7 @@ class SelfReportController extends Controller
                     'since' => $user->amnesty_blocked_at?->toIso8601String(),
                     'reason' => $user->amnesty_blocked_reason,
                 ],
-                'records' => [],
+                'records' => ['data' => []],
                 'reasons' => RecordFlagController::FLAG_TYPES,
                 'mine' => [],
             ]);
@@ -69,7 +69,7 @@ class SelfReportController extends Controller
         $sort = $request->input('sort');
         $sort = isset(self::SORTS[$sort]) ? $sort : 'date';
 
-        $records = collect();
+        $records = ['data' => []];
         $total = 0;
 
         if ($user->mdd_id) {
@@ -85,8 +85,9 @@ class SelfReportController extends Controller
                 ->where('records.mdd_id', $user->mdd_id)
                 ->when($search !== '', fn ($query) => $query->where('records.mapname', 'like', '%' . $search . '%'))
                 ->orderBy($column, $direction)
-                ->limit(self::PAGE_SIZE)
-                ->get([
+                // Paginated rather than capped: with a thousand runs behind it,
+                // "search for the rest" is not a way to reach the rest.
+                ->paginate(self::PAGE_SIZE, [
                     'records.id',
                     'records.mapname',
                     'records.physics',
@@ -98,7 +99,8 @@ class SelfReportController extends Controller
                     'maps.thumbnail as map_thumbnail',
                     'maps.date_added as map_added',
                 ])
-                ->map(fn ($record) => [
+                ->withQueryString()
+                ->through(fn ($record) => [
                     'id' => $record->id,
                     'mapname' => $record->mapname,
                     'physics' => $record->physics,
@@ -118,7 +120,6 @@ class SelfReportController extends Controller
             'search' => $search,
             'sort' => $sort,
             'totalRecords' => $total,
-            'shown' => $records->count(),
             'reasons' => RecordFlagController::FLAG_TYPES,
             // Your own withdrawals, with the reason you gave. Private like the
             // rest of it, but you are allowed to see what you did and why -

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -25,10 +25,12 @@ use Inertia\Inertia;
  * a week, and the player has already told us it does not belong there - there
  * is nothing left to establish.
  *
- * The delete is a SOFT delete, so a misclick is recoverable: an admin can put
- * the run back from the withdrawn-times list, which also drops the entry from
- * the public log. Nothing about this is destructive, and the page says so
- * rather than threatening people into hesitating.
+ * The delete is a SOFT delete, so a misclick IS recoverable from the
+ * withdrawn-times list in the admin panel. The page deliberately does not
+ * mention that: told there is a way back, people stop reading what they ticked
+ * and start asking for reversals, and the safety net turns into a queue. What
+ * it says instead is true from where the player stands - they cannot take it
+ * back themselves.
  */
 class SelfReportController extends Controller
 {
@@ -118,9 +120,23 @@ class SelfReportController extends Controller
             'totalRecords' => $total,
             'shown' => $records->count(),
             'reasons' => RecordFlagController::FLAG_TYPES,
+            // Your own withdrawals, with the reason you gave. Private like the
+            // rest of it, but you are allowed to see what you did and why -
+            // months later "which runs did I take down" is a fair question and
+            // the answer should not only exist in the admin panel.
             'mine' => PlayerSelfReport::where('user_id', $user->id)
                 ->orderByDesc('created_at')
-                ->get(['id', 'mapname', 'physics', 'mode', 'time', 'reason', 'created_at']),
+                ->get(['id', 'mapname', 'physics', 'mode', 'time', 'reason', 'note', 'created_at'])
+                ->map(fn (PlayerSelfReport $report) => [
+                    'id' => $report->id,
+                    'mapname' => $report->mapname,
+                    'physics' => $report->physics,
+                    'mode' => $report->mode,
+                    'time' => $report->time,
+                    'reason' => RecordFlagController::FLAG_TYPES[$report->reason] ?? $report->reason,
+                    'note' => $report->note,
+                    'created_at' => $report->created_at?->toIso8601String(),
+                ]),
         ]);
     }
 

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -14,32 +14,89 @@ use Inertia\Inertia;
  * The amnesty is the point. Somebody who set a time years ago with the wrong
  * cvar has, right now, two options: say nothing and hope, or be reported and
  * argued over. Neither ends with the leaderboard being correct. This is a
- * third one, and it only works while it stays free: no validator, no verdict,
- * no mark on the account. The time goes, and the log says who took it down
- * and why.
+ * third one, and it only works while it stays free AND private: no validator,
+ * no verdict, no mark on the account, and nobody told. A withdrawal that shows
+ * up anywhere others can read it is a confession, and people do not volunteer
+ * confessions - so this is visible to the admin alone, not even to the
+ * validators, and never on the public log.
  *
- * It deletes the record on the spot for the same reason. A queue would mean
- * the honest answer still leaves the wrong time standing for a week, and the
- * player has already told us it does not belong there - there is nothing left
- * to establish.
+ * It takes the record off the leaderboard on the spot for the same reason. A
+ * queue would mean the honest answer still leaves the wrong time standing for
+ * a week, and the player has already told us it does not belong there - there
+ * is nothing left to establish.
+ *
+ * The delete is a SOFT delete, so a misclick is recoverable: an admin can put
+ * the run back from the withdrawn-times list, which also drops the entry from
+ * the public log. Nothing about this is destructive, and the page says so
+ * rather than threatening people into hesitating.
  */
 class SelfReportController extends Controller
 {
+    /** How the list can be ordered, and what that means in SQL. */
+    private const SORTS = [
+        'date' => ['records.date_set', 'desc'],
+        'rank' => ['records.rank', 'asc'],
+        'name' => ['records.mapname', 'asc'],
+        'map_added' => ['maps.date_added', 'desc'],
+    ];
+
+    /** Rows sent at once. Past this, searching beats scrolling. */
+    private const PAGE_SIZE = 120;
+
     public function index(Request $request)
     {
         $user = $request->user();
+
+        // Blocked players still get the page, with the reason on it. Silently
+        // hiding the feature would leave somebody clicking a dead link and
+        // guessing, and the point of the block is that it was earned.
+        if ($user->amnesty_blocked_at) {
+            return Inertia::render('SelfReport', [
+                'hasMddAccount' => (bool) $user->mdd_id,
+                'blocked' => [
+                    'since' => $user->amnesty_blocked_at?->toIso8601String(),
+                    'reason' => $user->amnesty_blocked_reason,
+                ],
+                'records' => [],
+                'reasons' => RecordFlagController::FLAG_TYPES,
+                'mine' => [],
+            ]);
+        }
+
         $search = trim((string) $request->input('search', ''));
+        $sort = $request->input('sort');
+        $sort = isset(self::SORTS[$sort]) ? $sort : 'date';
 
         $records = collect();
+        $total = 0;
 
         if ($user->mdd_id) {
+            [$column, $direction] = self::SORTS[$sort];
+
+            $total = Record::where('mdd_id', $user->mdd_id)->count();
+
             $records = Record::query()
-                ->where('mdd_id', $user->mdd_id)
-                ->when($search !== '', fn ($query) => $query->where('mapname', 'like', '%' . $search . '%'))
-                ->orderByDesc('date_set')
-                ->limit(60)
-                ->get(['id', 'mapname', 'physics', 'mode', 'gametype', 'time', 'date_set', 'rank'])
-                ->map(fn (Record $record) => [
+                // Left join, not a relation: the list sorts by the map's own
+                // date, and a record whose map is missing from the maps table
+                // still has to appear rather than being silently dropped.
+                ->leftJoin('maps', 'maps.name', '=', 'records.mapname')
+                ->where('records.mdd_id', $user->mdd_id)
+                ->when($search !== '', fn ($query) => $query->where('records.mapname', 'like', '%' . $search . '%'))
+                ->orderBy($column, $direction)
+                ->limit(self::PAGE_SIZE)
+                ->get([
+                    'records.id',
+                    'records.mapname',
+                    'records.physics',
+                    'records.mode',
+                    'records.gametype',
+                    'records.time',
+                    'records.date_set',
+                    'records.rank',
+                    'maps.thumbnail as map_thumbnail',
+                    'maps.date_added as map_added',
+                ])
+                ->map(fn ($record) => [
                     'id' => $record->id,
                     'mapname' => $record->mapname,
                     'physics' => $record->physics,
@@ -48,6 +105,8 @@ class SelfReportController extends Controller
                     'time' => $record->time,
                     'date_set' => $record->date_set,
                     'rank' => $record->rank,
+                    'map_thumbnail' => $record->map_thumbnail,
+                    'map_added' => $record->map_added,
                 ]);
         }
 
@@ -55,7 +114,9 @@ class SelfReportController extends Controller
             'hasMddAccount' => (bool) $user->mdd_id,
             'records' => $records,
             'search' => $search,
-            'totalRecords' => $user->mdd_id ? Record::where('mdd_id', $user->mdd_id)->count() : 0,
+            'sort' => $sort,
+            'totalRecords' => $total,
+            'shown' => $records->count(),
             'reasons' => RecordFlagController::FLAG_TYPES,
             'mine' => PlayerSelfReport::where('user_id', $user->id)
                 ->orderByDesc('created_at')
@@ -63,57 +124,78 @@ class SelfReportController extends Controller
         ]);
     }
 
+    /**
+     * Withdraw one or more runs in a single go. Somebody cleaning up after an
+     * old habit is rarely cleaning up exactly one map, and making them repeat
+     * a confirmation forty times is how a good intention turns into "later".
+     */
     public function store(Request $request)
     {
         $user = $request->user();
 
+        if ($user->amnesty_blocked_at) {
+            return back()->withErrors([
+                'record_ids' => 'You no longer have access to the amnesty.',
+            ]);
+        }
+
         $data = $request->validate([
-            'record_id' => ['required', 'integer', 'exists:records,id'],
+            'record_ids' => ['required', 'array', 'min:1', 'max:100'],
+            'record_ids.*' => ['integer'],
             'reason' => ['required', 'string', 'in:' . implode(',', array_keys(RecordFlagController::FLAG_TYPES))],
             'note' => ['nullable', 'string', 'max:500'],
             'confirm' => ['accepted'],
         ], [
-            'confirm.accepted' => 'Tick the box - the time is deleted straight away and cannot be put back by us.',
+            'record_ids.required' => 'Pick at least one run.',
+            'confirm.accepted' => 'Tick the box - the times come off the leaderboard straight away.',
         ]);
 
-        $record = Record::find($data['record_id']);
-
         // Yours means yours. The MDD id is what ties a record to a person, so
-        // an account without one cannot withdraw anything, and an account with
-        // a different one is somebody else's run.
-        if (! $record || ! $user->mdd_id || (int) $record->mdd_id !== (int) $user->mdd_id) {
+        // an account without one cannot withdraw anything, and the ownership
+        // check is part of the QUERY rather than a loop over what was posted -
+        // anything not covered by it simply never comes back.
+        $records = $user->mdd_id
+            ? Record::whereIn('id', $data['record_ids'])->where('mdd_id', $user->mdd_id)->get()
+            : collect();
+
+        if ($records->isEmpty()) {
             return back()->withErrors([
-                'record_id' => 'That run is not yours.',
+                'record_ids' => 'Those runs are not yours.',
             ]);
         }
 
-        PlayerSelfReport::create([
+        foreach ($records as $record) {
+            PlayerSelfReport::create([
+                'user_id' => $user->id,
+                'mdd_id' => $record->mdd_id,
+                'player_name' => $record->name,
+                'record_id' => $record->id,
+                'mapname' => $record->mapname,
+                'physics' => $record->physics,
+                'mode' => $record->mode,
+                'gametype' => $record->gametype,
+                'time' => $record->time,
+                'reason' => $data['reason'],
+                'note' => $data['note'] ?? null,
+            ]);
+
+            // Soft delete: the model's own hooks detach uploaded demos and
+            // clear the profile and listing caches, which is exactly what has
+            // to happen and is what the admin-side deletions already do.
+            $record->delete();
+        }
+
+        Log::info('Self-reported records withdrawn', [
             'user_id' => $user->id,
-            'mdd_id' => $record->mdd_id,
-            'player_name' => $record->name,
-            'record_id' => $record->id,
-            'mapname' => $record->mapname,
-            'physics' => $record->physics,
-            'mode' => $record->mode,
-            'gametype' => $record->gametype,
-            'time' => $record->time,
+            'mdd_id' => $user->mdd_id,
+            'record_ids' => $records->pluck('id')->all(),
             'reason' => $data['reason'],
-            'note' => $data['note'] ?? null,
         ]);
 
-        // Soft delete: the model's own hooks detach uploaded demos and clear
-        // the profile and listing caches, which is exactly what has to happen
-        // and is already tested by the admin-side deletions.
-        $record->delete();
+        $count = $records->count();
 
-        Log::info('Self-reported record withdrawn', [
-            'user_id' => $user->id,
-            'mdd_id' => $record->mdd_id,
-            'record_id' => $record->id,
-            'mapname' => $record->mapname,
-            'reason' => $data['reason'],
-        ]);
-
-        return back()->with('success', 'Time withdrawn. It is off the leaderboard and listed in the public validation log.');
+        return back()->with('success', $count === 1
+            ? 'Time withdrawn. It is off the leaderboard, and nobody but the site admin is told about it.'
+            : $count . ' times withdrawn. They are off the leaderboard, and nobody but the site admin is told about it.');
     }
 }

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -61,13 +61,43 @@ class SelfReportController extends Controller
                 ],
                 'records' => ['data' => []],
                 'reasons' => RecordFlagController::FLAG_TYPES,
-                'mine' => [],
+                'mine' => ['data' => []],
+                'mineCounts' => [],
+                'mineState' => 'all',
             ]);
         }
 
         $search = trim((string) $request->input('search', ''));
         $sort = $request->input('sort');
         $sort = isset(self::SORTS[$sort]) ? $sort : 'date';
+
+        // Your own withdrawals, filtered and paged on their own. Somebody who
+        // cleans up an old habit sends dozens at once, and a list that loads
+        // all of them forever is a list nobody scrolls twice.
+        $mineState = $request->input('mine_state');
+        $mineState = in_array($mineState, ['waiting', 'queued', 'done', 'restored'], true) ? $mineState : 'all';
+
+        $mineBase = fn () => PlayerSelfReport::where('user_id', $user->id);
+
+        $applyState = fn ($query, string $state) => match ($state) {
+            'waiting' => $query->whereNull('processed_at')->where('handling', 'immediate'),
+            'queued' => $query->whereNull('processed_at')->where('handling', 'on_merge'),
+            'done' => $query->whereNotNull('processed_at')
+                ->where(fn ($q) => $q->whereNull('resolution')->orWhere('resolution', '!=', 'restored')),
+            'restored' => $query->where('resolution', 'restored'),
+            default => $query,
+        };
+
+        $mineCounts = collect(['all', 'waiting', 'queued', 'done', 'restored'])
+            ->mapWithKeys(fn (string $state) => [$state => $applyState($mineBase(), $state)->count()])
+            ->all();
+
+        $mine = $applyState($mineBase(), $mineState)
+            ->orderByDesc('created_at')
+            // Its own page parameter: the pickable records above have a
+            // paginator too, and one `page` for both would move both lists.
+            ->paginate(20, ['*'], 'mine_page')
+            ->withQueryString();
 
         $records = ['data' => []];
         $total = 0;
@@ -136,10 +166,10 @@ class SelfReportController extends Controller
             // months later "which runs did I take down" is a fair question and
             // the answer should not only exist in the admin panel.
             'handlingOptions' => PlayerSelfReport::HANDLING,
-            'mine' => PlayerSelfReport::where('user_id', $user->id)
-                ->orderByDesc('created_at')
-                ->get()
-                ->map(fn (PlayerSelfReport $report) => [
+            'mineState' => $mineState,
+            'mineCounts' => $mineCounts,
+            'mine' => $mine
+                ->through(fn (PlayerSelfReport $report) => [
                     'id' => $report->id,
                     'mapname' => $report->mapname,
                     'physics' => $report->physics,
@@ -150,6 +180,7 @@ class SelfReportController extends Controller
                     'note' => $report->note,
                     'processed' => $report->isProcessed(),
                     'beaten' => $report->wasBeaten(),
+                    'restored' => $report->wasRestored(),
                     'state' => $report->stateLabel(),
                     'created_at' => $report->created_at?->toIso8601String(),
                 ]),

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -178,7 +178,7 @@ class SelfReportController extends Controller
             'confirm' => ['accepted'],
         ], [
             'record_ids.required' => 'Pick at least one run.',
-            'confirm.accepted' => 'Tick the box to send it.',
+            'confirm.accepted' => 'Tick the declaration first - the reason has to be true for every run in the batch.',
         ]);
 
         // Yours means yours. The MDD id is what ties a record to a person, so

--- a/app/Http/Controllers/SelfReportController.php
+++ b/app/Http/Controllers/SelfReportController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PlayerSelfReport;
+use App\Models\Record;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+
+/**
+ * Taking your own invalid time down, with no consequence attached.
+ *
+ * The amnesty is the point. Somebody who set a time years ago with the wrong
+ * cvar has, right now, two options: say nothing and hope, or be reported and
+ * argued over. Neither ends with the leaderboard being correct. This is a
+ * third one, and it only works while it stays free: no validator, no verdict,
+ * no mark on the account. The time goes, and the log says who took it down
+ * and why.
+ *
+ * It deletes the record on the spot for the same reason. A queue would mean
+ * the honest answer still leaves the wrong time standing for a week, and the
+ * player has already told us it does not belong there - there is nothing left
+ * to establish.
+ */
+class SelfReportController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $search = trim((string) $request->input('search', ''));
+
+        $records = collect();
+
+        if ($user->mdd_id) {
+            $records = Record::query()
+                ->where('mdd_id', $user->mdd_id)
+                ->when($search !== '', fn ($query) => $query->where('mapname', 'like', '%' . $search . '%'))
+                ->orderByDesc('date_set')
+                ->limit(60)
+                ->get(['id', 'mapname', 'physics', 'mode', 'gametype', 'time', 'date_set', 'rank'])
+                ->map(fn (Record $record) => [
+                    'id' => $record->id,
+                    'mapname' => $record->mapname,
+                    'physics' => $record->physics,
+                    'mode' => $record->mode,
+                    'gametype' => $record->gametype,
+                    'time' => $record->time,
+                    'date_set' => $record->date_set,
+                    'rank' => $record->rank,
+                ]);
+        }
+
+        return Inertia::render('SelfReport', [
+            'hasMddAccount' => (bool) $user->mdd_id,
+            'records' => $records,
+            'search' => $search,
+            'totalRecords' => $user->mdd_id ? Record::where('mdd_id', $user->mdd_id)->count() : 0,
+            'reasons' => RecordFlagController::FLAG_TYPES,
+            'mine' => PlayerSelfReport::where('user_id', $user->id)
+                ->orderByDesc('created_at')
+                ->get(['id', 'mapname', 'physics', 'mode', 'time', 'reason', 'created_at']),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $user = $request->user();
+
+        $data = $request->validate([
+            'record_id' => ['required', 'integer', 'exists:records,id'],
+            'reason' => ['required', 'string', 'in:' . implode(',', array_keys(RecordFlagController::FLAG_TYPES))],
+            'note' => ['nullable', 'string', 'max:500'],
+            'confirm' => ['accepted'],
+        ], [
+            'confirm.accepted' => 'Tick the box - the time is deleted straight away and cannot be put back by us.',
+        ]);
+
+        $record = Record::find($data['record_id']);
+
+        // Yours means yours. The MDD id is what ties a record to a person, so
+        // an account without one cannot withdraw anything, and an account with
+        // a different one is somebody else's run.
+        if (! $record || ! $user->mdd_id || (int) $record->mdd_id !== (int) $user->mdd_id) {
+            return back()->withErrors([
+                'record_id' => 'That run is not yours.',
+            ]);
+        }
+
+        PlayerSelfReport::create([
+            'user_id' => $user->id,
+            'mdd_id' => $record->mdd_id,
+            'player_name' => $record->name,
+            'record_id' => $record->id,
+            'mapname' => $record->mapname,
+            'physics' => $record->physics,
+            'mode' => $record->mode,
+            'gametype' => $record->gametype,
+            'time' => $record->time,
+            'reason' => $data['reason'],
+            'note' => $data['note'] ?? null,
+        ]);
+
+        // Soft delete: the model's own hooks detach uploaded demos and clear
+        // the profile and listing caches, which is exactly what has to happen
+        // and is already tested by the admin-side deletions.
+        $record->delete();
+
+        Log::info('Self-reported record withdrawn', [
+            'user_id' => $user->id,
+            'mdd_id' => $record->mdd_id,
+            'record_id' => $record->id,
+            'mapname' => $record->mapname,
+            'reason' => $data['reason'],
+        ]);
+
+        return back()->with('success', 'Time withdrawn. It is off the leaderboard and listed in the public validation log.');
+    }
+}

--- a/app/Http/Controllers/ValidationLogController.php
+++ b/app/Http/Controllers/ValidationLogController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\PlayerSelfReport;
 use App\Models\RecordFlag;
 use App\Models\ServerdemoValidationCase;
 use Illuminate\Http\Request;
@@ -28,6 +27,12 @@ use Inertia\Inertia;
  * Who reported what is never public, at any stage. The reporters are the one
  * group with something to lose from transparency here, and a report is not
  * evidence - it is a request to go look.
+ *
+ * Withdrawn times are NOT in here. A player who takes their own run down has
+ * not been accused of anything and has not been judged by anybody, so there is
+ * no verdict to be transparent about - publishing it would just be a second
+ * punishment for the one response we actually want to encourage. Those stay
+ * with the admin alone, not even with the validators.
  */
 class ValidationLogController extends Controller
 {
@@ -51,7 +56,6 @@ class ValidationLogController extends Controller
             'stats' => $this->stats(),
             'closed' => $this->closed(),
             'open' => $this->open(),
-            'selfReports' => $this->selfReports(),
             'minReports' => (int) config('serverdemos.validation.min_reports', 2),
         ]);
     }
@@ -71,7 +75,6 @@ class ValidationLogController extends Controller
             'upheld' => ServerdemoValidationCase::where('validation_outcome', 'upheld')->count(),
             'dismissed' => ServerdemoValidationCase::where('validation_outcome', 'dismissed')->count(),
             'inconclusive' => ServerdemoValidationCase::where('validation_outcome', 'inconclusive')->count(),
-            'self_reports' => PlayerSelfReport::count(),
         ];
     }
 
@@ -119,31 +122,6 @@ class ValidationLogController extends Controller
                 'runs' => $case->flags_count,
                 'stage' => self::STAGE_LABELS[$case->validation_stage] ?? $case->validation_stage,
                 'opened_at' => $case->created_at?->toIso8601String(),
-            ]);
-    }
-
-    /**
-     * Times their own owners took down. Named, because the time itself was
-     * public and its disappearance from the map is public too - explaining
-     * where it went is the only version of this that is not a quiet edit.
-     */
-    private function selfReports()
-    {
-        return PlayerSelfReport::query()
-            ->with('user:id,name,plain_name,profile_photo_path,country')
-            ->orderByDesc('created_at')
-            ->limit(200)
-            ->get()
-            ->map(fn (PlayerSelfReport $report) => [
-                'id' => $report->id,
-                'player' => $report->player_name,
-                'user_id' => $report->user_id,
-                'mapname' => $report->mapname,
-                'physics' => trim(($report->physics ?? '') . ' ' . ($report->mode ?? '')),
-                'time' => $report->time,
-                'reason' => RecordFlagController::FLAG_TYPES[$report->reason] ?? $report->reason,
-                'note' => $report->note,
-                'created_at' => $report->created_at?->toIso8601String(),
             ]);
     }
 

--- a/app/Http/Controllers/ValidationLogController.php
+++ b/app/Http/Controllers/ValidationLogController.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PlayerSelfReport;
+use App\Models\RecordFlag;
+use App\Models\ServerdemoValidationCase;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+/**
+ * The public record of every report and what came of it.
+ *
+ * This page is the condition the whole enforcement rests on: nothing gets
+ * acted on before people can see what is being acted on. So it is written to
+ * be readable by somebody who does not trust us, which decides three things.
+ *
+ * A case is named once it is CLOSED, whichever way it went. Publishing only
+ * the guilty ones would turn the log into a list of convictions and hide
+ * every time the process cleared somebody - which is the half that shows the
+ * process works at all.
+ *
+ * A case in progress is NOT named. It is an accusation nobody has checked
+ * yet, and a name against an open accusation is a punishment handed out
+ * before the verdict. The count, the stage and the age are public, so nobody
+ * can quietly sit on a case either.
+ *
+ * Who reported what is never public, at any stage. The reporters are the one
+ * group with something to lose from transparency here, and a report is not
+ * evidence - it is a request to go look.
+ */
+class ValidationLogController extends Controller
+{
+    /** How the ladder reads to somebody who has not seen the admin panel. */
+    private const STAGE_LABELS = [
+        'assigned' => 'With a validator',
+        'second_opinion' => 'Second opinion',
+        'all_validators' => 'Open to all validators',
+        'admin' => 'With the admin',
+    ];
+
+    private const OUTCOME_LABELS = [
+        'upheld' => 'Upheld',
+        'dismissed' => 'Cleared',
+        'inconclusive' => 'Inconclusive',
+    ];
+
+    public function index(Request $request)
+    {
+        return Inertia::render('ValidationLog', [
+            'stats' => $this->stats(),
+            'closed' => $this->closed(),
+            'open' => $this->open(),
+            'selfReports' => $this->selfReports(),
+            'minReports' => (int) config('serverdemos.validation.min_reports', 2),
+        ]);
+    }
+
+    /**
+     * The numbers that say how much of this is happening at all. Reports are
+     * counted as reports, not as cases - several reports about one player are
+     * one case, and both figures are worth seeing.
+     */
+    private function stats(): array
+    {
+        return [
+            'reports' => RecordFlag::count(),
+            'awaiting_admin' => RecordFlag::awaitingClearance()->count(),
+            'in_validation' => ServerdemoValidationCase::whereNull('validation_closed_at')->count(),
+            'closed' => ServerdemoValidationCase::whereNotNull('validation_closed_at')->count(),
+            'upheld' => ServerdemoValidationCase::where('validation_outcome', 'upheld')->count(),
+            'dismissed' => ServerdemoValidationCase::where('validation_outcome', 'dismissed')->count(),
+            'inconclusive' => ServerdemoValidationCase::where('validation_outcome', 'inconclusive')->count(),
+            'self_reports' => PlayerSelfReport::count(),
+        ];
+    }
+
+    /** Decided cases, named, newest first. */
+    private function closed()
+    {
+        return ServerdemoValidationCase::query()
+            ->withCount('flags')
+            // Eager loaded because every row needs its report types below,
+            // and asking per row is 200 queries on a page anyone can open.
+            ->with('flags:id,validation_case_id,flag_type')
+            ->whereNotNull('validation_closed_at')
+            ->orderByDesc('validation_closed_at')
+            ->limit(200)
+            ->get()
+            ->map(fn (ServerdemoValidationCase $case) => [
+                'id' => $case->id,
+                'player' => $case->subjectLabel(),
+                'user_id' => $case->subject_user_id,
+                'kind' => $case->kind,
+                'runs' => $case->flags_count,
+                'outcome' => self::OUTCOME_LABELS[$case->validation_outcome] ?? 'Closed',
+                'outcome_key' => $case->validation_outcome,
+                'opened_at' => $case->created_at?->toIso8601String(),
+                'closed_at' => $case->validation_closed_at?->toIso8601String(),
+                'reasons' => $this->reasonsFor($case),
+            ]);
+    }
+
+    /**
+     * Cases still being looked at. Everything here is deliberately
+     * unidentifiable: no name, no map, no time - a run on a map IS a name to
+     * anyone who reads the leaderboard.
+     */
+    private function open()
+    {
+        return ServerdemoValidationCase::query()
+            ->withCount('flags')
+            ->whereNull('validation_closed_at')
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn (ServerdemoValidationCase $case) => [
+                'id' => $case->id,
+                'kind' => $case->kind,
+                'runs' => $case->flags_count,
+                'stage' => self::STAGE_LABELS[$case->validation_stage] ?? $case->validation_stage,
+                'opened_at' => $case->created_at?->toIso8601String(),
+            ]);
+    }
+
+    /**
+     * Times their own owners took down. Named, because the time itself was
+     * public and its disappearance from the map is public too - explaining
+     * where it went is the only version of this that is not a quiet edit.
+     */
+    private function selfReports()
+    {
+        return PlayerSelfReport::query()
+            ->with('user:id,name,plain_name,profile_photo_path,country')
+            ->orderByDesc('created_at')
+            ->limit(200)
+            ->get()
+            ->map(fn (PlayerSelfReport $report) => [
+                'id' => $report->id,
+                'player' => $report->player_name,
+                'user_id' => $report->user_id,
+                'mapname' => $report->mapname,
+                'physics' => trim(($report->physics ?? '') . ' ' . ($report->mode ?? '')),
+                'time' => $report->time,
+                'reason' => RecordFlagController::FLAG_TYPES[$report->reason] ?? $report->reason,
+                'note' => $report->note,
+                'created_at' => $report->created_at?->toIso8601String(),
+            ]);
+    }
+
+    /**
+     * What the case is about, as report types. The individual runs stay out
+     * of it: "sv_cheats, twice" is what a reader needs, and naming the maps
+     * would republish the accusation run by run even where it was dismissed.
+     */
+    private function reasonsFor(ServerdemoValidationCase $case): array
+    {
+        return $case->flags
+            ->groupBy('flag_type')
+            ->map(fn ($group, $type) => [
+                'label' => RecordFlagController::FLAG_TYPES[$type] ?? $type,
+                'count' => $group->count(),
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -82,6 +82,13 @@ class WishlistController extends Controller
             ]),
             'statuses' => Wish::STATUSES,
             'projects' => Wish::PROJECTS,
+            // Shown on the page, always. A budget people only discover by
+            // running out of it reads as the site being broken.
+            'budget' => $user ? [
+                'total' => Wish::voteBudget(),
+                'spent' => Wish::upvotesSpentBy($user->id),
+                'left' => Wish::upvotesLeftFor($user->id),
+            ] : null,
             'filter' => $filter,
             'projectFilter' => in_array($project, array_keys(Wish::PROJECTS), true) ? $project : null,
             // Counts per project so the filter row can say where the activity
@@ -128,6 +135,10 @@ class WishlistController extends Controller
      * One vote per person per wish. Clicking the side you already picked
      * takes the vote back, which is the only way to say "I no longer care"
      * without it counting as the opposite.
+     *
+     * Upvotes come out of a budget (see Wish::voteBudget). Taking a vote back
+     * or flipping it to a downvote refunds it, so nobody is ever stuck with a
+     * vote they no longer mean.
      */
     public function vote(Request $request, Wish $wish)
     {
@@ -141,9 +152,24 @@ class WishlistController extends Controller
             'value' => ['required', 'integer', 'in:1,-1'],
         ]);
 
+        $user = $request->user();
+
         $existing = WishVote::where('wish_id', $wish->id)
-            ->where('user_id', $request->user()->id)
+            ->where('user_id', $user->id)
             ->first();
+
+        // Charged only when this click actually adds an upvote to somebody
+        // else's wish: not when taking one back, not when flipping to a
+        // downvote, not on your own.
+        $spendsAVote = (int) $data['value'] === 1
+            && $wish->user_id !== $user->id
+            && (! $existing || $existing->value !== 1);
+
+        if ($spendsAVote && Wish::upvotesLeftFor($user->id) < 1) {
+            return back(303)->withErrors([
+                'vote' => 'You have used all your votes. Take one back from another wish to free it up.',
+            ]);
+        }
 
         if ($existing && $existing->value === (int) $data['value']) {
             $existing->delete();
@@ -152,7 +178,7 @@ class WishlistController extends Controller
         } else {
             WishVote::create([
                 'wish_id' => $wish->id,
-                'user_id' => $request->user()->id,
+                'user_id' => $user->id,
                 'value' => (int) $data['value'],
             ]);
         }

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Wish;
+use App\Models\WishVote;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+/**
+ * The wishlist. Anyone with an account writes down what they want built and
+ * everyone else says whether they want it too.
+ *
+ * Sorted by score, not by date. A suggestion box ordered by recency rewards
+ * whoever posted last; ordered by score it says what the site actually wants,
+ * which is the only reason to have one of these.
+ *
+ * Downvotes count and are shown. A wish nobody else wants is worth knowing
+ * about before it gets built, and hiding that behind an upvote-only counter
+ * just moves the argument into the comments of something already started.
+ */
+class WishlistController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $filter = $request->input('status');
+
+        $wishes = Wish::query()
+            ->with('user:id,name,plain_name,profile_photo_path,country')
+            ->when(in_array($filter, array_keys(Wish::STATUSES), true), fn ($q) => $q->where('status', $filter))
+            ->orderByDesc('score')
+            ->orderByDesc('created_at')
+            ->limit(300)
+            ->get();
+
+        $myVotes = $user
+            ? WishVote::where('user_id', $user->id)
+                ->whereIn('wish_id', $wishes->pluck('id'))
+                ->pluck('value', 'wish_id')
+            : collect();
+
+        return Inertia::render('Wishlist', [
+            'wishes' => $wishes->map(fn (Wish $wish) => [
+                'id' => $wish->id,
+                'title' => $wish->title,
+                'body' => $wish->body,
+                'status' => $wish->status,
+                'status_label' => Wish::STATUSES[$wish->status] ?? $wish->status,
+                'status_note' => $wish->status_note,
+                'upvotes' => $wish->upvotes,
+                'downvotes' => $wish->downvotes,
+                'score' => $wish->score,
+                'my_vote' => (int) ($myVotes[$wish->id] ?? 0),
+                'mine' => $user && $wish->user_id === $user->id,
+                'created_at' => $wish->created_at?->toIso8601String(),
+                'author' => $wish->user ? [
+                    'id' => $wish->user->id,
+                    'name' => $wish->user->plain_name ?: $wish->user->name,
+                    'profile_photo_path' => $wish->user->profile_photo_path,
+                    'country' => $wish->user->country,
+                ] : null,
+            ]),
+            'statuses' => Wish::STATUSES,
+            'filter' => $filter,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => ['required', 'string', 'min:6', 'max:120'],
+            'body' => ['required', 'string', 'min:20', 'max:2000'],
+        ], [
+            'body.min' => 'Say a bit more - at least 20 characters, so people know what they are voting on.',
+        ]);
+
+        $wish = Wish::create([
+            'user_id' => $request->user()->id,
+            'title' => $data['title'],
+            'body' => $data['body'],
+        ]);
+
+        // The author wants it, obviously. Saying so explicitly means a fresh
+        // wish starts at +1 instead of sitting at zero next to things people
+        // have actively turned down.
+        WishVote::create([
+            'wish_id' => $wish->id,
+            'user_id' => $request->user()->id,
+            'value' => 1,
+        ]);
+        $wish->recount();
+
+        return back()->with('success', 'Wish added.');
+    }
+
+    /**
+     * One vote per person per wish. Clicking the side you already picked
+     * takes the vote back, which is the only way to say "I no longer care"
+     * without it counting as the opposite.
+     */
+    public function vote(Request $request, Wish $wish)
+    {
+        $data = $request->validate([
+            'value' => ['required', 'integer', 'in:1,-1'],
+        ]);
+
+        $existing = WishVote::where('wish_id', $wish->id)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if ($existing && $existing->value === (int) $data['value']) {
+            $existing->delete();
+        } elseif ($existing) {
+            $existing->update(['value' => (int) $data['value']]);
+        } else {
+            WishVote::create([
+                'wish_id' => $wish->id,
+                'user_id' => $request->user()->id,
+                'value' => (int) $data['value'],
+            ]);
+        }
+
+        $wish->recount();
+
+        return back(303);
+    }
+
+    /** Authors can withdraw their own wish; anything else is the admin's. */
+    public function destroy(Request $request, Wish $wish)
+    {
+        if ($wish->user_id !== $request->user()->id && ! $request->user()->isAdmin()) {
+            abort(403);
+        }
+
+        $wish->delete();
+
+        return back()->with('success', 'Wish removed.');
+    }
+}

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -71,6 +71,7 @@ class WishlistController extends Controller
                 'my_vote' => (int) ($myVotes[$wish->id] ?? 0),
                 'mine' => $user && $wish->user_id === $user->id,
                 'pending' => ! $wish->isApproved(),
+                'removal_requested' => $wish->removal_requested_at !== null,
                 'created_at' => $wish->created_at?->toIso8601String(),
                 'author' => $wish->user ? [
                     'id' => $wish->user->id,
@@ -161,15 +162,26 @@ class WishlistController extends Controller
         return back(303);
     }
 
-    /** Authors can withdraw their own wish; anything else is the admin's. */
-    public function destroy(Request $request, Wish $wish)
+    /**
+     * Ask for your wish to be taken down. Only asking: once it is on the list
+     * other people have voted on it, and an author who could delete at will
+     * could withdraw an idea the moment it started collecting downvotes.
+     */
+    public function requestRemoval(Request $request, Wish $wish)
     {
-        if ($wish->user_id !== $request->user()->id && ! $request->user()->isAdmin()) {
+        if ($wish->user_id !== $request->user()->id) {
             abort(403);
         }
 
-        $wish->delete();
+        $data = $request->validate([
+            'reason' => ['nullable', 'string', 'max:255'],
+        ]);
 
-        return back()->with('success', 'Wish removed.');
+        $wish->update([
+            'removal_requested_at' => now(),
+            'removal_reason' => $data['reason'] ?? null,
+        ]);
+
+        return back()->with('success', 'Asked the admin to remove it. It stays on the list until they do.');
     }
 }

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -25,10 +25,12 @@ class WishlistController extends Controller
     {
         $user = $request->user();
         $filter = $request->input('status');
+        $project = $request->input('project');
 
         $wishes = Wish::query()
             ->with('user:id,name,plain_name,profile_photo_path,country')
             ->when(in_array($filter, array_keys(Wish::STATUSES), true), fn ($q) => $q->where('status', $filter))
+            ->when(in_array($project, array_keys(Wish::PROJECTS), true), fn ($q) => $q->where('project', $project))
             ->orderByDesc('score')
             ->orderByDesc('created_at')
             ->limit(300)
@@ -43,6 +45,8 @@ class WishlistController extends Controller
         return Inertia::render('Wishlist', [
             'wishes' => $wishes->map(fn (Wish $wish) => [
                 'id' => $wish->id,
+                'project' => $wish->project,
+                'project_label' => Wish::PROJECTS[$wish->project] ?? $wish->project,
                 'title' => $wish->title,
                 'body' => $wish->body,
                 'status' => $wish->status,
@@ -62,13 +66,21 @@ class WishlistController extends Controller
                 ] : null,
             ]),
             'statuses' => Wish::STATUSES,
+            'projects' => Wish::PROJECTS,
             'filter' => $filter,
+            'projectFilter' => in_array($project, array_keys(Wish::PROJECTS), true) ? $project : null,
+            // Counts per project so the filter row can say where the activity
+            // is, instead of sending people into empty lists to find out.
+            'projectCounts' => Wish::selectRaw('project, count(*) as total')
+                ->groupBy('project')
+                ->pluck('total', 'project'),
         ]);
     }
 
     public function store(Request $request)
     {
         $data = $request->validate([
+            'project' => ['required', 'string', 'in:' . implode(',', array_keys(Wish::PROJECTS))],
             'title' => ['required', 'string', 'min:6', 'max:120'],
             'body' => ['required', 'string', 'min:20', 'max:2000'],
         ], [
@@ -77,6 +89,7 @@ class WishlistController extends Controller
 
         $wish = Wish::create([
             'user_id' => $request->user()->id,
+            'project' => $data['project'],
             'title' => $data['title'],
             'body' => $data['body'],
         ]);

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -29,8 +29,21 @@ class WishlistController extends Controller
 
         $wishes = Wish::query()
             ->with('user:id,name,plain_name,profile_photo_path,country')
+            // Approved only, plus your own while it waits. Hiding somebody's
+            // wish from themselves reads as it having been deleted, and they
+            // post it again.
+            ->where(function ($query) use ($user) {
+                $query->approved();
+
+                if ($user) {
+                    $query->orWhere('user_id', $user->id);
+                }
+            })
             ->when(in_array($filter, array_keys(Wish::STATUSES), true), fn ($q) => $q->where('status', $filter))
             ->when(in_array($project, array_keys(Wish::PROJECTS), true), fn ($q) => $q->where('project', $project))
+            // Anything still waiting sits at the top for its author, who has
+            // just posted it and is looking for it.
+            ->orderByRaw('approved_at is null desc')
             ->orderByDesc('score')
             ->orderByDesc('created_at')
             ->limit(300)
@@ -57,6 +70,7 @@ class WishlistController extends Controller
                 'score' => $wish->score,
                 'my_vote' => (int) ($myVotes[$wish->id] ?? 0),
                 'mine' => $user && $wish->user_id === $user->id,
+                'pending' => ! $wish->isApproved(),
                 'created_at' => $wish->created_at?->toIso8601String(),
                 'author' => $wish->user ? [
                     'id' => $wish->user->id,
@@ -71,7 +85,8 @@ class WishlistController extends Controller
             'projectFilter' => in_array($project, array_keys(Wish::PROJECTS), true) ? $project : null,
             // Counts per project so the filter row can say where the activity
             // is, instead of sending people into empty lists to find out.
-            'projectCounts' => Wish::selectRaw('project, count(*) as total')
+            'projectCounts' => Wish::approved()
+                ->selectRaw('project, count(*) as total')
                 ->groupBy('project')
                 ->pluck('total', 'project'),
         ]);
@@ -87,6 +102,7 @@ class WishlistController extends Controller
             'body.min' => 'Say a bit more - at least 20 characters, so people know what they are voting on.',
         ]);
 
+        // Not approved: it goes nowhere public until an admin lets it through.
         $wish = Wish::create([
             'user_id' => $request->user()->id,
             'project' => $data['project'],
@@ -104,7 +120,7 @@ class WishlistController extends Controller
         ]);
         $wish->recount();
 
-        return back()->with('success', 'Wish added.');
+        return back()->with('success', 'Wish submitted. It goes on the list once an admin has looked at it.');
     }
 
     /**
@@ -114,6 +130,12 @@ class WishlistController extends Controller
      */
     public function vote(Request $request, Wish $wish)
     {
+        // Its own author can see it while it waits, so the guard has to be
+        // here too rather than relying on the list not showing it.
+        if (! $wish->isApproved()) {
+            return back(303);
+        }
+
         $data = $request->validate([
             'value' => ['required', 'integer', 'in:1,-1'],
         ]);

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -25,10 +25,12 @@ class PlayerSelfReport extends Model
         'processed_at',
         'processed_by',
         'resolution',
+        'detached',
     ];
 
     protected $casts = [
         'processed_at' => 'datetime',
+        'detached' => 'array',
     ];
 
     /**
@@ -75,6 +77,67 @@ class PlayerSelfReport extends Model
         return $this->handling === 'immediate'
             ? 'Waiting for an admin'
             : 'Queued for the MDD merge';
+    }
+
+    /**
+     * Hide the run, remembering what that pulled off it.
+     *
+     * Record::deleting detaches uploaded demos and nothing puts them back, so
+     * without this snapshot a restore would silently cost the record its demo,
+     * the YouTube render hanging off that demo, and its time history entry.
+     */
+    public function hideRun(?int $adminId): bool
+    {
+        $run = Record::find($this->record_id);
+
+        if (! $run) {
+            return false;
+        }
+
+        $demos = UploadedDemo::where('record_id', $run->id)
+            ->whereIn('status', ['assigned', 'fallback-assigned'])
+            ->get(['id', 'status'])
+            ->map(fn ($demo) => ['id' => $demo->id, 'status' => $demo->status])
+            ->all();
+
+        $run->delete();
+
+        $this->update([
+            'processed_at' => now(),
+            'processed_by' => $adminId,
+            'detached' => $demos ?: null,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Put the run back, demos and all.
+     *
+     * A demo is only re-attached if it is still loose: demos:rematch-all may
+     * have given it to somebody else in the meantime, and taking it back off
+     * them would trade one wrong answer for another.
+     */
+    public function restoreRun(): bool
+    {
+        $run = Record::onlyTrashed()->whereKey($this->record_id)->first();
+
+        if (! $run) {
+            return false;
+        }
+
+        $run->restore();
+
+        foreach ($this->detached ?? [] as $demo) {
+            UploadedDemo::whereKey($demo['id'] ?? null)
+                ->whereNull('record_id')
+                ->update([
+                    'record_id' => $run->id,
+                    'status' => $demo['status'] ?? 'assigned',
+                ]);
+        }
+
+        return true;
     }
 
     /**

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -77,6 +77,86 @@ class PlayerSelfReport extends Model
             : 'Queued for the MDD merge';
     }
 
+    /**
+     * The serverdemo of this run, if it was set on one of our servers.
+     *
+     * Matched from the snapshot rather than through the record: hiding the run
+     * soft-deletes it, and the withdrawal has to stay reviewable afterwards.
+     * Same key the validation queue uses - map, player, time, physics, mode.
+     */
+    public function serverDemo(): ?ServerDemo
+    {
+        return $this->memo('serverDemo', fn () => ServerDemo::query()
+            ->where('map_name', $this->mapname)
+            ->where('mdd_id', $this->mdd_id)
+            ->where('time_ms', $this->time)
+            ->when($this->physics, fn ($q, $p) => $q->where('physics', strtolower($p)))
+            ->when($this->mode, fn ($q, $m) => $q->where('mode', strtolower($m)))
+            ->first());
+    }
+
+    /**
+     * The demo the player uploaded here, if any.
+     *
+     * Tried by record first, then by the run itself, because deleting a record
+     * detaches its uploaded demos (Record::deleting) - so after the run is
+     * hidden the link is gone and only the map, time and player are left.
+     */
+    public function uploadedDemo(): ?UploadedDemo
+    {
+        return $this->memo('uploadedDemo', function () {
+            if ($this->record_id) {
+                $byRecord = UploadedDemo::where('record_id', $this->record_id)->first();
+
+                if ($byRecord) {
+                    return $byRecord;
+                }
+            }
+
+            return UploadedDemo::query()
+                ->where('map_name', $this->mapname)
+                ->where('time_ms', $this->time)
+                ->where(function ($q) {
+                    $q->where('user_id', $this->user_id)
+                        ->orWhere('player_name', $this->player_name);
+                })
+                ->first();
+        });
+    }
+
+    /** A published YouTube render of this run, if one exists. */
+    public function video(): ?RenderedVideo
+    {
+        return $this->memo('video', fn () => RenderedVideo::query()
+            ->whereNotNull('youtube_url')
+            ->where('status', 'completed')
+            ->where(function ($q) {
+                $q->where('record_id', $this->record_id)
+                    ->orWhere(fn ($inner) => $inner
+                        ->where('map_name', $this->mapname)
+                        ->where('time_ms', $this->time)
+                        ->where('player_name', $this->player_name));
+            })
+            ->first());
+    }
+
+    /**
+     * Each lookup runs once per row. The admin table asks the same question in
+     * the badge column and again in the download action.
+     */
+    private function memo(string $key, \Closure $resolve)
+    {
+        static $cache = [];
+
+        $id = $key . ':' . $this->getKey();
+
+        if (! array_key_exists($id, $cache)) {
+            $cache[$id] = $resolve();
+        }
+
+        return $cache[$id];
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -21,7 +21,34 @@ class PlayerSelfReport extends Model
         'time',
         'reason',
         'note',
+        'handling',
+        'processed_at',
+        'processed_by',
     ];
+
+    protected $casts = [
+        'processed_at' => 'datetime',
+    ];
+
+    /**
+     * When the player wants it handled. `mode` was already taken by the game
+     * mode of the run, so the column is `handling` - naming it `mode` twice
+     * would have been a bug waiting for whoever reads this next.
+     */
+    public const HANDLING = [
+        'immediate' => 'Hide it here as soon as an admin approves',
+        'on_merge' => 'Wait for the MDD merge and do both at once',
+    ];
+
+    public function scopePending($query)
+    {
+        return $query->whereNull('processed_at');
+    }
+
+    public function isProcessed(): bool
+    {
+        return $this->processed_at !== null;
+    }
 
     public function user()
     {

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A time its own owner withdrew. See the migration for why it is a snapshot.
+ */
+class PlayerSelfReport extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'mdd_id',
+        'player_name',
+        'record_id',
+        'mapname',
+        'physics',
+        'mode',
+        'gametype',
+        'time',
+        'reason',
+        'note',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function map()
+    {
+        return $this->belongsTo(Map::class, 'mapname', 'name');
+    }
+}

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -24,6 +24,7 @@ class PlayerSelfReport extends Model
         'handling',
         'processed_at',
         'processed_by',
+        'resolution',
     ];
 
     protected $casts = [
@@ -40,6 +41,11 @@ class PlayerSelfReport extends Model
         'on_merge' => 'Wait for the MDD merge and do both at once',
     ];
 
+    public const RESOLUTIONS = [
+        'hidden' => 'Hidden by an admin',
+        'beaten' => 'Beaten by a new run',
+    ];
+
     public function scopePending($query)
     {
         return $query->whereNull('processed_at');
@@ -48,6 +54,27 @@ class PlayerSelfReport extends Model
     public function isProcessed(): bool
     {
         return $this->processed_at !== null;
+    }
+
+    public function wasBeaten(): bool
+    {
+        return $this->resolution === 'beaten';
+    }
+
+    /** What the player sees as the state of their request. */
+    public function stateLabel(): string
+    {
+        if ($this->wasBeaten()) {
+            return 'Beaten - resolved';
+        }
+
+        if ($this->isProcessed()) {
+            return 'Off the board';
+        }
+
+        return $this->handling === 'immediate'
+            ? 'Waiting for an admin'
+            : 'Queued for the MDD merge';
     }
 
     public function user()

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -70,6 +70,17 @@ class PlayerSelfReport extends Model
         return $this->resolution === 'restored';
     }
 
+    /**
+     * Did this request take the run off the board, and is it still off?
+     *
+     * "Beaten" never hid anything - the player replaced the time themselves -
+     * and "restored" already put it back, so neither is undoable.
+     */
+    public function hidRun(): bool
+    {
+        return $this->isProcessed() && ! $this->wasBeaten() && ! $this->wasRestored();
+    }
+
     public function stateLabel(): string
     {
         if ($this->wasBeaten()) {
@@ -131,6 +142,13 @@ class PlayerSelfReport extends Model
      */
     public function restoreRun(?int $adminId = null): bool
     {
+        // Only what THIS request took down. A record can be gone because some
+        // other admin removed it for some other reason, and the amnesty is not
+        // allowed to undo that just because the run happens to be missing.
+        if (! $this->hidRun()) {
+            return false;
+        }
+
         $run = Record::onlyTrashed()->whereKey($this->record_id)->first();
 
         if (! $run) {
@@ -159,6 +177,29 @@ class PlayerSelfReport extends Model
         ]);
 
         return true;
+    }
+
+    /**
+     * Demos the amnesty is currently holding down.
+     *
+     * Hiding a run detaches its demos, and `demos:rematch-all` picks up loose
+     * demos every Monday, fuzzy-matches the nickname and files them as offline
+     * records - which would put the withdrawn run back in front of everybody a
+     * week after the player was told it was gone. These are off limits to it
+     * until the request is restored, which clears the list by itself.
+     */
+    public static function withheldDemoIds(): array
+    {
+        return static::query()
+            ->whereNotNull('processed_at')
+            ->whereNotNull('detached')
+            ->where(fn ($q) => $q->whereNull('resolution')->orWhereNotIn('resolution', ['beaten', 'restored']))
+            ->pluck('detached')
+            ->flatMap(fn ($demos) => collect($demos)->pluck('id'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
     }
 
     /**
@@ -226,19 +267,22 @@ class PlayerSelfReport extends Model
 
     /**
      * Each lookup runs once per row. The admin table asks the same question in
-     * the badge column and again in the download action.
+     * the badge column and again in every download action.
+     *
+     * On the instance, NOT in a static: under Octane a static outlives the
+     * request and the whole worker keeps answering from it. It did - the panel
+     * went on offering a serverdemo that had been deleted three requests
+     * earlier. This dies with the row that owns it.
      */
+    private array $lookups = [];
+
     private function memo(string $key, \Closure $resolve)
     {
-        static $cache = [];
-
-        $id = $key . ':' . $this->getKey();
-
-        if (! array_key_exists($id, $cache)) {
-            $cache[$id] = $resolve();
+        if (! array_key_exists($key, $this->lookups)) {
+            $this->lookups[$key] = $resolve();
         }
 
-        return $cache[$id];
+        return $this->lookups[$key];
     }
 
     public function user()

--- a/app/Models/PlayerSelfReport.php
+++ b/app/Models/PlayerSelfReport.php
@@ -46,6 +46,7 @@ class PlayerSelfReport extends Model
     public const RESOLUTIONS = [
         'hidden' => 'Hidden by an admin',
         'beaten' => 'Beaten by a new run',
+        'restored' => 'Put back by an admin',
     ];
 
     public function scopePending($query)
@@ -64,10 +65,19 @@ class PlayerSelfReport extends Model
     }
 
     /** What the player sees as the state of their request. */
+    public function wasRestored(): bool
+    {
+        return $this->resolution === 'restored';
+    }
+
     public function stateLabel(): string
     {
         if ($this->wasBeaten()) {
             return 'Beaten - resolved';
+        }
+
+        if ($this->wasRestored()) {
+            return 'Put back on the board';
         }
 
         if ($this->isProcessed()) {
@@ -105,6 +115,7 @@ class PlayerSelfReport extends Model
         $this->update([
             'processed_at' => now(),
             'processed_by' => $adminId,
+            'resolution' => 'hidden',
             'detached' => $demos ?: null,
         ]);
 
@@ -118,7 +129,7 @@ class PlayerSelfReport extends Model
      * have given it to somebody else in the meantime, and taking it back off
      * them would trade one wrong answer for another.
      */
-    public function restoreRun(): bool
+    public function restoreRun(?int $adminId = null): bool
     {
         $run = Record::onlyTrashed()->whereKey($this->record_id)->first();
 
@@ -136,6 +147,16 @@ class PlayerSelfReport extends Model
                     'status' => $demo['status'] ?? 'assigned',
                 ]);
         }
+
+        // The row stays. Deleting it would leave the panel unable to answer
+        // "what happened to that request" - and a run that was taken down and
+        // put back is exactly the case somebody asks about later.
+        $this->update([
+            'processed_at' => $this->processed_at ?? now(),
+            'processed_by' => $adminId ?? $this->processed_by,
+            'resolution' => 'restored',
+            'detached' => null,
+        ]);
 
         return true;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -116,6 +116,7 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
     protected $casts = [
         'email_verified_at' => 'datetime',
         'last_login_at' => 'datetime',
+        'amnesty_blocked_at' => 'datetime',
         'preview_system' => 'array',
         'nsfw_confirmed' => 'boolean',
         'default_show_oldtop' => 'boolean',

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Wish extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'body',
+        'status',
+        'status_note',
+        'upvotes',
+        'downvotes',
+        'score',
+    ];
+
+    public const STATUSES = [
+        'considering' => 'Considering',
+        'planned' => 'Planned',
+        'done' => 'Done',
+        'rejected' => 'Not happening',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function votes()
+    {
+        return $this->hasMany(WishVote::class);
+    }
+
+    /**
+     * Recount from the votes and store the result.
+     *
+     * Counted rather than incremented on purpose: a vote can be added,
+     * flipped or taken back, and three separate delta paths is three chances
+     * for the cached number to drift away from the rows that justify it.
+     */
+    public function recount(): void
+    {
+        $this->upvotes = $this->votes()->where('value', 1)->count();
+        $this->downvotes = $this->votes()->where('value', -1)->count();
+        $this->score = $this->upvotes - $this->downvotes;
+        $this->save();
+    }
+}

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -35,13 +35,13 @@ class Wish extends Model
      */
     public const PROJECTS = [
         'web' => 'defrag.racing',
-        'launcher' => 'Launcher',
+        'launcher' => 'Defrag Launcher',
         'defraglive' => 'DefragLive',
         'defraglive_extension' => 'DefragLive extension',
         'demome' => 'Demome',
         'defraglegends' => 'DefragLegends',
         'odfe' => 'oDFe engine',
-        'server_bundle' => 'Server bundle',
+        'server_bundle' => 'Server bundle Linux',
         'server_bundle_windows' => 'Server bundle (Windows)',
         'other' => 'Something else',
     ];

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -11,6 +11,7 @@ class Wish extends Model
 
     protected $fillable = [
         'user_id',
+        'project',
         'title',
         'body',
         'status',
@@ -25,6 +26,24 @@ class Wish extends Model
         'planned' => 'Planned',
         'done' => 'Done',
         'rejected' => 'Not happening',
+    ];
+
+    /**
+     * Everything a wish can be about: the public repositories in the org, plus
+     * the two things that are ours but are not repositories, plus a catch-all.
+     * Without the catch-all people file website wishes about the engine.
+     */
+    public const PROJECTS = [
+        'web' => 'defrag.racing',
+        'launcher' => 'Launcher',
+        'defraglive' => 'DefragLive',
+        'defraglive_extension' => 'DefragLive extension',
+        'demome' => 'Demome',
+        'defraglegends' => 'DefragLegends',
+        'odfe' => 'oDFe engine',
+        'server_bundle' => 'Server bundle',
+        'server_bundle_windows' => 'Server bundle (Windows)',
+        'other' => 'Something else',
     ];
 
     public function user()

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -16,9 +16,15 @@ class Wish extends Model
         'body',
         'status',
         'status_note',
+        'approved_at',
+        'approved_by',
         'upvotes',
         'downvotes',
         'score',
+    ];
+
+    protected $casts = [
+        'approved_at' => 'datetime',
     ];
 
     public const STATUSES = [
@@ -54,6 +60,17 @@ class Wish extends Model
     public function votes()
     {
         return $this->hasMany(WishVote::class);
+    }
+
+    /** Live on the public list. */
+    public function scopeApproved($query)
+    {
+        return $query->whereNotNull('approved_at');
+    }
+
+    public function isApproved(): bool
+    {
+        return $this->approved_at !== null;
     }
 
     /**

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -55,6 +55,47 @@ class Wish extends Model
         'other' => 'Something else',
     ];
 
+    /**
+     * How many upvotes one person gets to spend, in total, across the board.
+     *
+     * It grows with the board so the rule never becomes absurd: five while the
+     * list is short, a third of it once it is long. A fixed number ages badly -
+     * five votes over two hundred wishes is not a priority, it is a lottery
+     * ticket.
+     *
+     * Downvotes are deliberately outside the budget. The budget exists to make
+     * people choose what they want most; saying "this is a bad idea" is not a
+     * want and rationing it would just silence the objections.
+     */
+    public static function voteBudget(): int
+    {
+        return max(5, (int) ceil(static::approved()->count() / 3));
+    }
+
+    /**
+     * Upvotes this person has already spent. Your own wish does not count:
+     * the upvote on it is placed automatically when you post, so charging for
+     * it would mean writing wishes costs you the right to support other
+     * people's.
+     */
+    public static function upvotesSpentBy(int $userId): int
+    {
+        return WishVote::query()
+            ->join('wishes', 'wishes.id', '=', 'wish_votes.wish_id')
+            ->where('wish_votes.user_id', $userId)
+            ->where('wish_votes.value', 1)
+            ->whereNull('wishes.deleted_at')
+            ->whereNotNull('wishes.approved_at')
+            ->where('wishes.user_id', '!=', $userId)
+            ->count();
+    }
+
+    /** Votes left, never negative - the budget can shrink when wishes go. */
+    public static function upvotesLeftFor(int $userId): int
+    {
+        return max(0, static::voteBudget() - static::upvotesSpentBy($userId));
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -18,6 +18,8 @@ class Wish extends Model
         'status_note',
         'approved_at',
         'approved_by',
+        'removal_requested_at',
+        'removal_reason',
         'upvotes',
         'downvotes',
         'score',
@@ -25,6 +27,7 @@ class Wish extends Model
 
     protected $casts = [
         'approved_at' => 'datetime',
+        'removal_requested_at' => 'datetime',
     ];
 
     public const STATUSES = [

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -58,10 +58,16 @@ class Wish extends Model
     /**
      * How many upvotes one person gets to spend, in total, across the board.
      *
-     * It grows with the board so the rule never becomes absurd: five while the
-     * list is short, a third of it once it is long. A fixed number ages badly -
-     * five votes over two hundred wishes is not a priority, it is a lottery
-     * ticket.
+     * Three rules stacked, in this order:
+     *
+     * - never more votes than there are wishes. One wish on the board is one
+     *   vote, not five - a budget that offers more than there is to spend is
+     *   not a budget, and it makes the counter read as broken.
+     * - five while the list is short, so an early board is not a fight over
+     *   two votes.
+     * - a third of the board once it is long, because a fixed number ages
+     *   badly: five votes over two hundred wishes is a lottery ticket, not a
+     *   priority.
      *
      * Downvotes are deliberately outside the budget. The budget exists to make
      * people choose what they want most; saying "this is a bad idea" is not a
@@ -69,7 +75,9 @@ class Wish extends Model
      */
     public static function voteBudget(): int
     {
-        return max(5, (int) ceil(static::approved()->count() / 3));
+        $wishes = static::approved()->count();
+
+        return min($wishes, max(5, (int) ceil($wishes / 3)));
     }
 
     /**

--- a/app/Models/WishVote.php
+++ b/app/Models/WishVote.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WishVote extends Model
+{
+    protected $fillable = [
+        'wish_id',
+        'user_id',
+        'value',
+    ];
+
+    protected $casts = [
+        'value' => 'integer',
+    ];
+
+    public function wish()
+    {
+        return $this->belongsTo(Wish::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/CommunityScoreService.php
+++ b/app/Services/CommunityScoreService.php
@@ -415,6 +415,10 @@ class CommunityScoreService
         // Records link to users via mdd_id, not user_id
         $counts = DB::table('records')
             ->join('users', 'users.mdd_id', '=', 'records.mdd_id')
+            // Deleted records are not contributions. Without this a withdrawn
+            // or removed run keeps paying its owner, which is the one thing
+            // the amnesty must never do.
+            ->whereNull('records.deleted_at')
             ->whereNotNull('records.mdd_id')
             ->whereNotNull('users.mdd_id')
             ->groupBy('users.id')

--- a/database/migrations/2026_08_06_000100_create_player_self_reports_table.php
+++ b/database/migrations/2026_08_06_000100_create_player_self_reports_table.php
@@ -7,14 +7,19 @@ use Illuminate\Support\Facades\Schema;
 /**
  * A player taking their own invalid time down, before anyone reports it.
  *
- * The row is a SNAPSHOT rather than a pointer, because the record it
- * describes is deleted in the same breath. The public log has to be able to
- * say "this time, on this map, was withdrawn" long after the record row is
- * gone, and a join to a deleted record cannot do that.
+ * ADMIN EYES ONLY. Nothing in this table is shown to validators or to the
+ * public, and no count derived from it is either - on a leaderboard anyone can
+ * diff, "three runs were withdrawn this week" is most of a name. The amnesty
+ * only works if using it is invisible.
  *
- * There is no status and no reviewer. The whole point of the amnesty is that
- * admitting it costs nothing and needs nobody's approval - the moment it
- * needs a verdict, people stop using it and report each other instead.
+ * The row is a SNAPSHOT rather than a pointer, because the record it describes
+ * is soft-deleted in the same breath: the admin view has to still say which
+ * time on which map this was, and it has to survive the record row being
+ * cleaned up later.
+ *
+ * There is no status and no reviewer. The whole point is that admitting it
+ * costs nothing and needs nobody's approval - the moment it needs a verdict,
+ * people stop using it and let themselves be reported instead.
  */
 return new class extends Migration
 {

--- a/database/migrations/2026_08_06_000100_create_player_self_reports_table.php
+++ b/database/migrations/2026_08_06_000100_create_player_self_reports_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A player taking their own invalid time down, before anyone reports it.
+ *
+ * The row is a SNAPSHOT rather than a pointer, because the record it
+ * describes is deleted in the same breath. The public log has to be able to
+ * say "this time, on this map, was withdrawn" long after the record row is
+ * gone, and a join to a deleted record cannot do that.
+ *
+ * There is no status and no reviewer. The whole point of the amnesty is that
+ * admitting it costs nothing and needs nobody's approval - the moment it
+ * needs a verdict, people stop using it and report each other instead.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('player_self_reports', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->unsignedBigInteger('mdd_id')->nullable()->index();
+            $table->string('player_name')->nullable();
+
+            // Kept for forensics only - the record itself is soft-deleted, so
+            // nothing may be looked up through this in the public log.
+            $table->unsignedBigInteger('record_id')->nullable()->index();
+
+            $table->string('mapname')->nullable()->index();
+            $table->string('physics')->nullable();
+            $table->string('mode')->nullable();
+            $table->string('gametype')->nullable();
+            $table->unsignedBigInteger('time')->nullable();
+
+            // One of RecordFlagController::FLAG_TYPES, so a self-report reads
+            // the same as a report somebody else would have filed.
+            $table->string('reason');
+            $table->text('note')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('player_self_reports');
+    }
+};

--- a/database/migrations/2026_08_06_000200_create_wishes_tables.php
+++ b/database/migrations/2026_08_06_000200_create_wishes_tables.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The wishlist: anyone with an account writes down what they want built, and
+ * everyone else says whether they want it too.
+ *
+ * The score is stored on the wish rather than counted from the votes on every
+ * page load. The list is sorted by it, and sorting on a subquery over a table
+ * that grows with every click is the one thing that would make this page slow.
+ * `wish_votes` stays the source of truth; the two counters are rebuilt from it
+ * whenever a vote changes.
+ *
+ * One row per (wish, voter) with a +1/-1 value, so changing your mind updates
+ * a row instead of adding one, and nobody can vote twice.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wishes', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->string('title');
+            $table->text('body');
+
+            // considering | planned | done | rejected - the admin's answer.
+            $table->string('status')->default('considering')->index();
+            $table->text('status_note')->nullable();
+
+            $table->integer('upvotes')->default(0);
+            $table->integer('downvotes')->default(0);
+            $table->integer('score')->default(0)->index();
+
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+
+        Schema::create('wish_votes', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('wish_id');
+            $table->unsignedBigInteger('user_id');
+            $table->tinyInteger('value'); // +1 or -1
+
+            $table->timestamps();
+
+            $table->foreign('wish_id')->references('id')->on('wishes')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+
+            $table->unique(['wish_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wish_votes');
+        Schema::dropIfExists('wishes');
+    }
+};

--- a/database/migrations/2026_08_06_000300_add_amnesty_block_to_users_table.php
+++ b/database/migrations/2026_08_06_000300_add_amnesty_block_to_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Losing the right to withdraw your own runs.
+ *
+ * The amnesty is unconditional by design, which is exactly what makes it worth
+ * abusing: withdraw a clean run to bury the pattern around it, or use it as a
+ * laundry for whatever the next report would have found. The answer is not to
+ * start reviewing withdrawals - that would kill the thing for everyone honest -
+ * but to take the door away from the one person who was proven to be gaming it.
+ *
+ * A timestamp rather than a boolean, because "since when" is the first thing
+ * anybody asks afterwards, and the reason is stored so it can be quoted back.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('amnesty_blocked_at')->nullable();
+            $table->string('amnesty_blocked_reason')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['amnesty_blocked_at', 'amnesty_blocked_reason']);
+        });
+    }
+};

--- a/database/migrations/2026_08_06_000400_add_project_to_wishes_table.php
+++ b/database/migrations/2026_08_06_000400_add_project_to_wishes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Which of our things a wish is about.
+ *
+ * Without it the list is one pile: somebody who only cares about the launcher
+ * has to read forty website wishes to find the three that are theirs, and the
+ * score stops meaning anything because it is comparing a map filter against an
+ * engine change.
+ *
+ * Stored as a key rather than a repo name, because two of the entries are not
+ * repositories at all (the YouTube channel, "something else") and a repo can be
+ * renamed without the wishes losing their meaning.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->string('project')->default('web')->index()->after('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->dropColumn('project');
+        });
+    }
+};

--- a/database/migrations/2026_08_06_000500_add_approval_to_wishes_table.php
+++ b/database/migrations/2026_08_06_000500_add_approval_to_wishes_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Nothing appears on the wishlist until an admin lets it through.
+ *
+ * The list is a public page with a voting widget on it, which is the shape of
+ * thing that attracts spam, abuse aimed at a person, and the same wish filed
+ * five times. Deleting those afterwards means they were still on the site while
+ * somebody read them, and a wish that got votes before it was removed took the
+ * ordering with it.
+ *
+ * Separate from `status`: status is the ANSWER to a wish (considering, planned,
+ * done, not happening) and only means anything once the wish is real. This is
+ * whether it is a wish at all.
+ *
+ * Existing rows are approved on the way in - they were posted when there was no
+ * gate, and retroactively hiding them would be a bug rather than a policy.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->timestamp('approved_at')->nullable()->index()->after('status_note');
+            $table->unsignedBigInteger('approved_by')->nullable()->after('approved_at');
+
+            $table->foreign('approved_by')->references('id')->on('users')->nullOnDelete();
+        });
+
+        DB::table('wishes')->whereNull('approved_at')->update(['approved_at' => now()]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->dropForeign(['approved_by']);
+            $table->dropColumn(['approved_at', 'approved_by']);
+        });
+    }
+};

--- a/database/migrations/2026_08_06_000600_add_removal_request_to_wishes_table.php
+++ b/database/migrations/2026_08_06_000600_add_removal_request_to_wishes_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Asking for a wish to be taken down, instead of taking it down.
+ *
+ * Once a wish is on the list it is not only its author's any more: other people
+ * voted on it, and some of them voted because of it rather than for it. An
+ * author who can delete at will can withdraw an idea the moment it collects
+ * downvotes, which quietly edits the record everyone else was reading.
+ *
+ * So the author asks and the admin decides. The request is a timestamp on the
+ * wish rather than a table of its own - there is only ever one open request per
+ * wish, and clearing it is the whole of "no".
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->timestamp('removal_requested_at')->nullable()->index()->after('approved_by');
+            $table->string('removal_reason')->nullable()->after('removal_requested_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->dropColumn(['removal_requested_at', 'removal_reason']);
+        });
+    }
+};

--- a/database/migrations/2026_08_06_000700_add_handling_to_player_self_reports.php
+++ b/database/migrations/2026_08_06_000700_add_handling_to_player_self_reports.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A withdrawal is a REQUEST now, not the act itself.
+ *
+ * Two things forced this. Our leaderboard is not the only place the run exists:
+ * until the MDD databases are merged, hiding a time here leaves it standing on
+ * q3df.org, and somebody who was told "it is gone" and then sees it there
+ * concludes we lied. And a run leaving the board is worth an admin looking at
+ * it, if only to catch the wrong run being sent.
+ *
+ * So the player says WHEN they want it handled - now, accepting that it stays
+ * visible elsewhere until the merge, or at the merge, both databases at once -
+ * and an admin approves the hide. `processed_at` is the moment the record was
+ * actually taken off the board, which is also the answer to "why is my run
+ * still there".
+ *
+ * Rows that predate this were withdrawn under the old immediate behaviour, so
+ * they are marked as already processed rather than reappearing as a queue.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('player_self_reports', function (Blueprint $table) {
+            // immediate | on_merge. Called `handling` because `mode` on this
+            // table is already the game mode of the run.
+            $table->string('handling')->default('on_merge')->index()->after('reason');
+
+            $table->timestamp('processed_at')->nullable()->index()->after('note');
+            $table->unsignedBigInteger('processed_by')->nullable()->after('processed_at');
+
+            $table->foreign('processed_by')->references('id')->on('users')->nullOnDelete();
+        });
+
+        DB::table('player_self_reports')
+            ->whereNull('processed_at')
+            ->update(['handling' => 'immediate', 'processed_at' => now()]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_self_reports', function (Blueprint $table) {
+            $table->dropForeign(['processed_by']);
+            $table->dropColumn(['handling', 'processed_at', 'processed_by']);
+        });
+    }
+};

--- a/database/migrations/2026_08_06_000800_add_resolution_to_player_self_reports.php
+++ b/database/migrations/2026_08_06_000800_add_resolution_to_player_self_reports.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * How a withdrawal request ended: hidden, or beaten.
+ *
+ * A player who goes back and beats the time they asked us to remove has
+ * settled it themselves. MDD only ever reports personal bests, so the new run
+ * replaces the old record on its own and the bad time is already off the
+ * board - leaving the request in the queue would be asking an admin to hide
+ * something that is not there.
+ *
+ * The row stays either way. After the MDD merge we get the full time history,
+ * and knowing which of those old times their own owner disowned is exactly
+ * what makes that history cleanable.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('player_self_reports', function (Blueprint $table) {
+            // hidden | beaten
+            $table->string('resolution')->nullable()->index()->after('processed_by');
+        });
+
+        DB::table('player_self_reports')
+            ->whereNotNull('processed_at')
+            ->update(['resolution' => 'hidden']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_self_reports', function (Blueprint $table) {
+            $table->dropColumn('resolution');
+        });
+    }
+};

--- a/database/migrations/2026_08_07_000100_add_detached_to_player_self_reports.php
+++ b/database/migrations/2026_08_07_000100_add_detached_to_player_self_reports.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * What hiding a run pulled off it, so putting it back can put that back too.
+ *
+ * Deleting a record detaches its uploaded demos (Record::deleting) and nothing
+ * puts them back, which quietly costs the record its demo, the YouTube render
+ * that hangs off that demo, and its place in the time history. Restoring is
+ * offered as an undo, so it has to be one.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('player_self_reports', function (Blueprint $table) {
+            $table->json('detached')->nullable()->after('resolution');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_self_reports', function (Blueprint $table) {
+            $table->dropColumn('detached');
+        });
+    }
+};

--- a/resources/js/Components/AmnestyBanner.vue
+++ b/resources/js/Components/AmnestyBanner.vue
@@ -1,46 +1,19 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
-import { ref } from 'vue';
 
-// Where people look at times - the rankings and the record feed - is where
-// somebody remembers the one of theirs that should not be there. The amnesty
-// is useless if it is only findable from a submenu, so it comes to them.
-//
-// Dismissable and remembered, because a permanent strip above a page you visit
-// daily stops being a message and becomes furniture.
-const STORAGE_KEY = 'amnesty_banner_dismissed';
-
-const dismissed = ref(localStorage.getItem(STORAGE_KEY) === '1');
-
-const dismiss = () => {
-    dismissed.value = true;
-    localStorage.setItem(STORAGE_KEY, '1');
-};
+// Sits in the header row of the pages that show times, next to the heading,
+// the way Servers carries its launcher and rules links. Permanent and small:
+// the point is that somebody looking at a leaderboard always has the way out
+// in view, not that they are told about it once in a strip they close.
 </script>
 
 <template>
-    <div v-if="!dismissed" class="relative z-20 border-y border-emerald-400/25 bg-emerald-500/[0.08]">
-        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-2.5 flex items-center gap-3">
-            <svg class="w-5 h-5 shrink-0 text-emerald-300" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
-            </svg>
-
-            <p class="text-sm text-gray-200 min-w-0 flex-1">
-                <span class="font-bold text-emerald-200">Standing on a time that should not count?</span>
-                Take it down yourself. It is private, nobody is told, and nothing happens to your account.
-            </p>
-
-            <Link href="/amnesty"
-                class="shrink-0 px-3 py-1.5 rounded-lg bg-emerald-500/80 hover:bg-emerald-500 text-white text-sm font-bold transition-colors">
-                Amnesty
-            </Link>
-
-            <button type="button" @click="dismiss" title="Dismiss"
-                class="shrink-0 p-1.5 rounded-lg text-gray-500 hover:text-white hover:bg-white/10 transition-colors">
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
-        </div>
-    </div>
+    <Link href="/amnesty"
+        class="flex items-center gap-2 bg-gradient-to-r from-emerald-600/30 to-emerald-500/15 hover:from-emerald-600/40 hover:to-emerald-500/25 backdrop-blur-sm px-3 py-2 rounded-lg border border-emerald-400/40 hover:border-emerald-300/60 transition-colors text-sm">
+        <svg class="w-5 h-5 text-emerald-300 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+        </svg>
+        <span class="font-bold text-white whitespace-nowrap">Amnesty</span>
+        <span class="hidden sm:inline text-emerald-200/80 font-semibold text-xs">take your own invalid times down, privately</span>
+    </Link>
 </template>

--- a/resources/js/Components/AmnestyBanner.vue
+++ b/resources/js/Components/AmnestyBanner.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { Link } from '@inertiajs/vue3';
+import { ref } from 'vue';
+
+// Where people look at times - the rankings and the record feed - is where
+// somebody remembers the one of theirs that should not be there. The amnesty
+// is useless if it is only findable from a submenu, so it comes to them.
+//
+// Dismissable and remembered, because a permanent strip above a page you visit
+// daily stops being a message and becomes furniture.
+const STORAGE_KEY = 'amnesty_banner_dismissed';
+
+const dismissed = ref(localStorage.getItem(STORAGE_KEY) === '1');
+
+const dismiss = () => {
+    dismissed.value = true;
+    localStorage.setItem(STORAGE_KEY, '1');
+};
+</script>
+
+<template>
+    <div v-if="!dismissed" class="relative z-20 border-y border-emerald-400/25 bg-emerald-500/[0.08]">
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-2.5 flex items-center gap-3">
+            <svg class="w-5 h-5 shrink-0 text-emerald-300" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+            </svg>
+
+            <p class="text-sm text-gray-200 min-w-0 flex-1">
+                <span class="font-bold text-emerald-200">Standing on a time that should not count?</span>
+                Take it down yourself. It is private, nobody is told, and nothing happens to your account.
+            </p>
+
+            <Link href="/amnesty"
+                class="shrink-0 px-3 py-1.5 rounded-lg bg-emerald-500/80 hover:bg-emerald-500 text-white text-sm font-bold transition-colors">
+                Amnesty
+            </Link>
+
+            <button type="button" @click="dismiss" title="Dismiss"
+                class="shrink-0 p-1.5 rounded-lg text-gray-500 hover:text-white hover:bg-white/10 transition-colors">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/DemoFlagModal.vue
+++ b/resources/js/Components/DemoFlagModal.vue
@@ -99,6 +99,11 @@ const FLAG_TYPES = {
     'pmove_fixed': 'pmove',
     'pmove_msec': 'msec',
     'df_mp_interferenceoff': 'interference',
+    'left_right': '+left/+right',
+    'scripts': 'scripts',
+    'upmove': 'upmove',
+    'replay_cheat': 'replay',
+    'engine_cheat': 'engine',
     'other': 'other',
 };
 

--- a/resources/js/Components/Footer.vue
+++ b/resources/js/Components/Footer.vue
@@ -61,12 +61,17 @@
                     </Link>
                 </div>
             </div>
-            <div v-if="footerPages" class="flex space-x-4 flex-grow sm:flex-grow-0 mx-auto mt-3">
+            <div class="flex space-x-4 flex-grow sm:flex-grow-0 mx-auto mt-3">
                 <!-- Footer Navigation Menu-->
                 <div class="max-w-8xl mx-auto mt-2">
-                    <!-- Navigation Links -->
+                    <!-- Navigation Links. The validation log is here rather
+                         than behind a login because its whole purpose is to be
+                         checkable by anyone, including somebody who does not
+                         have an account and does not trust us. -->
                     <div class="space-x-8 md:-my-px md:flex pb-1">
-                        <FooterLink v-for="page in footerPages" :key="page.slug" :href="'/' + page.slug" :active="false" :text="page.title" />
+                        <FooterLink :href="route('validation-log')" :active="false" text="Validation log" />
+                        <FooterLink :href="route('wishlist.index')" :active="false" text="Wishlist" />
+                        <FooterLink v-for="page in footerPages || []" :key="page.slug" :href="'/' + page.slug" :active="false" :text="page.title" />
                     </div>
                 </div>
             </div>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -308,6 +308,11 @@
         'pmove_fixed': { short: 'pmove', desc: 'Non-standard pmove_fixed - flagged by community' },
         'pmove_msec': { short: 'msec', desc: 'Non-standard pmove_msec - flagged by community' },
         'df_mp_interferenceoff': { short: 'interf', desc: 'Interference setting modified - flagged by community' },
+        'left_right': { short: '+left/+right', desc: '+left / +right turn binds - flagged by community' },
+        'scripts': { short: 'scripts', desc: 'Scripted movement - flagged by community' },
+        'upmove': { short: 'upmove', desc: 'Upmove script - flagged by community' },
+        'replay_cheat': { short: 'replay', desc: 'Replay cheat - flagged by community' },
+        'engine_cheat': { short: 'engine', desc: 'Modified engine - flagged by community' },
         'other': { short: 'flagged', desc: 'Flagged by community for validity issue' },
     };
 

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -38,6 +38,7 @@
         return {
             home: route().current('home'),
             servers: route().current('servers'),
+            wishlist: route().current('wishlist.*'),
             players: route().current('records') || route().current('clans.*'),
             rankings: route().current('ranking') || route().current('community'),
             mapsmodels: route().current('maps') || route().current('maps.stats') || route().current('models.*'),
@@ -763,7 +764,14 @@
                             Servers
                         </NavLink>
 
-                        <!-- 2. Players - visible from md -->
+                        <!-- 2. Wishlist - always visible. Third on purpose:
+                             a suggestion box nobody walks past is a suggestion
+                             box nobody writes in. -->
+                        <NavLink :href="route('wishlist.index')" :active="navActive.wishlist">
+                            Wishlist
+                        </NavLink>
+
+                        <!-- 3. Players - visible from md -->
                         <div class="hidden md:block">
                             <Dropdown align="left" width="48" :hoverable="true">
                                 <template #trigger="{ open }">
@@ -780,7 +788,7 @@
                             </Dropdown>
                         </div>
 
-                        <!-- 3. Rankings - visible from lg -->
+                        <!-- 4. Rankings - visible from lg -->
                         <div class="hidden lg:block">
                             <Dropdown align="left" width="56" :hoverable="true">
                                 <template #trigger="{ open }">
@@ -797,7 +805,7 @@
                             </Dropdown>
                         </div>
 
-                        <!-- 4. Maps & Models - visible from md -->
+                        <!-- 5. Maps & Models - visible from md -->
                         <div class="hidden md:block">
                             <Dropdown align="left" width="48" :hoverable="true">
                                 <template #trigger="{ open }">
@@ -822,7 +830,7 @@
                             Maplists
                         </Link>
 
-                        <!-- 5. Demos - visible from md -->
+                        <!-- 6. Demos - visible from md -->
                         <div class="hidden md:block">
                             <Dropdown align="left" width="48" :hoverable="true">
                                 <template #trigger="{ open }">
@@ -839,7 +847,7 @@
                             </Dropdown>
                         </div>
 
-                        <!-- 6. Challenges - visible from lg -->
+                        <!-- 7. Challenges - visible from lg -->
                         <div class="hidden lg:block">
                             <Dropdown align="left" width="48" :hoverable="true">
                                 <template #trigger="{ open }">
@@ -858,28 +866,28 @@
                             </Dropdown>
                         </div>
 
-                        <!-- 7. Tournaments - visible from xl -->
+                        <!-- 8. Tournaments - visible from xl -->
                         <div class="hidden xl:inline-flex">
                             <NavLink :href="route('tournaments.index')" :active="navActive.tournaments">
                                 Tournaments
                             </NavLink>
                         </div>
 
-                        <!-- 8. Wiki - visible from xl -->
+                        <!-- 9. Wiki - visible from xl -->
                         <div class="hidden xl:inline-flex">
                             <NavLink :href="route('wiki.index')" :active="navActive.wiki">
                                 Wiki
                             </NavLink>
                         </div>
 
-                        <!-- 9. Downloads - visible from xl -->
+                        <!-- 10. Downloads - visible from xl -->
                         <div class="hidden xl:inline-flex">
                             <NavLink :href="route('downloads')" :active="navActive.bundles">
                                 Downloads
                             </NavLink>
                         </div>
 
-                        <!-- 9. Beta - visible from xl -->
+                        <!-- 11. Beta - visible from xl -->
                         <div class="hidden xl:inline-flex">
                             <NavLink href="/test-map-viewer.html?map=pornstar-cpmrun">
                                 Beta

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -720,7 +720,7 @@
                                             <Link :href="route('settings.show') + '?tab=security'" class="block text-sm text-gray-400 hover:text-red-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Security</Link>
                                             <Link :href="route('server-hosting.index')" class="block text-sm text-gray-400 hover:text-emerald-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Server hosting</Link>
                                             <Link :href="route('serverdemo-validators.index')" class="block text-sm text-gray-400 hover:text-blue-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Serverdemo validators</Link>
-                                            <Link :href="route('self-report.index')" class="block text-sm text-gray-400 hover:text-amber-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Withdraw your own time</Link>
+                                            <Link :href="route('amnesty.index')" class="block text-sm text-gray-400 hover:text-amber-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Amnesty - self report</Link>
                                         </div>
                                         <a v-if="$page.props.auth.user.admin || $page.props.auth.user.is_moderator" href="/defraghq" target="_blank" class="block w-full px-4 py-2 text-sm leading-5 text-emerald-400 hover:bg-white/5 transition-all font-semibold">
                                             Admin Panel

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -719,6 +719,7 @@
                                             <Link :href="route('settings.show') + '?tab=security'" class="block text-sm text-gray-400 hover:text-red-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Security</Link>
                                             <Link :href="route('server-hosting.index')" class="block text-sm text-gray-400 hover:text-emerald-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Server hosting</Link>
                                             <Link :href="route('serverdemo-validators.index')" class="block text-sm text-gray-400 hover:text-blue-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Serverdemo validators</Link>
+                                            <Link :href="route('self-report.index')" class="block text-sm text-gray-400 hover:text-amber-400 py-1 px-2 rounded hover:bg-white/5 transition-all">Withdraw your own time</Link>
                                         </div>
                                         <a v-if="$page.props.auth.user.admin || $page.props.auth.user.is_moderator" href="/defraghq" target="_blank" class="block w-full px-4 py-2 text-sm leading-5 text-emerald-400 hover:bg-white/5 transition-all font-semibold">
                                             Admin Panel

--- a/resources/js/Pages/RankingView.vue
+++ b/resources/js/Pages/RankingView.vue
@@ -187,8 +187,6 @@
     <div class="">
         <Head title="Ranking" />
 
-        <AmnestyBanner />
-
         <!-- WIP Banner -->
         <div class="relative z-20 bg-red-600 border-b-4 border-red-800 px-4 py-4 text-center">
             <div class="max-w-4xl mx-auto">
@@ -241,6 +239,10 @@
                                     <p>Rankings are recalculated instantly every time a new record is submitted. A full recalculation across all maps also runs once daily.</p>
                                 </div>
                             </div>
+                        </div>
+
+                        <div class="mt-3">
+                            <AmnestyBanner />
                         </div>
                     </div>
 

--- a/resources/js/Pages/RankingView.vue
+++ b/resources/js/Pages/RankingView.vue
@@ -1,6 +1,7 @@
 <script setup>
     import { Head, router, Link, usePage } from '@inertiajs/vue3';
     import Rating from '@/Components/Rating.vue';
+    import AmnestyBanner from '@/Components/AmnestyBanner.vue';
     import Pagination from '@/Components/Basic/Pagination.vue';
     import { watchEffect, ref, computed, onMounted, onUnmounted } from 'vue';
 
@@ -185,6 +186,8 @@
 <template>
     <div class="">
         <Head title="Ranking" />
+
+        <AmnestyBanner />
 
         <!-- WIP Banner -->
         <div class="relative z-20 bg-red-600 border-b-4 border-red-800 px-4 py-4 text-center">

--- a/resources/js/Pages/RecordsView.vue
+++ b/resources/js/Pages/RecordsView.vue
@@ -104,8 +104,6 @@
     <div class="pb-4">
         <Head title="Records" />
 
-        <AmnestyBanner />
-
         <!-- Resolution Debug Indicator -->
         <div class="fixed bottom-2 right-2 z-[99999] bg-black/80 border border-white/20 rounded-lg px-3 py-1.5 text-xs font-mono text-green-400 pointer-events-none">
             {{ breakpointLabel }}
@@ -125,6 +123,8 @@
                             <span class="text-sm font-semibold">{{ (vq3Records?.total || 0) + (cpmRecords?.total || 0) }} total records</span>
                         </div>
                     </div>
+
+                    <AmnestyBanner />
 
                     <!-- Gamemode Filter -->
                     <div class="flex flex-wrap items-center gap-2 bg-black/40 backdrop-blur-sm rounded-xl p-2.5">

--- a/resources/js/Pages/RecordsView.vue
+++ b/resources/js/Pages/RecordsView.vue
@@ -1,6 +1,7 @@
 <script setup>
     import { Head, router, Link, usePage } from '@inertiajs/vue3';
     import Record from '@/Components/Record.vue';
+    import AmnestyBanner from '@/Components/AmnestyBanner.vue';
     import Pagination from '@/Components/Basic/Pagination.vue';
     import Dropdown from '@/Components/Laravel/Dropdown.vue';
     import { watchEffect, ref, computed, onMounted } from 'vue';
@@ -102,6 +103,8 @@
 <template>
     <div class="pb-4">
         <Head title="Records" />
+
+        <AmnestyBanner />
 
         <!-- Resolution Debug Indicator -->
         <div class="fixed bottom-2 right-2 z-[99999] bg-black/80 border border-white/20 rounded-lg px-3 py-1.5 text-xs font-mono text-green-400 pointer-events-none">

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -8,13 +8,16 @@ export default {
 
 <script setup>
 import { Head, Link, router, useForm } from '@inertiajs/vue3';
-import { getCurrentInstance, ref, watch } from 'vue';
+import { computed, getCurrentInstance, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps({
     hasMddAccount: { type: Boolean, default: false },
+    blocked: { type: Object, default: null },
     records: { type: Array, default: () => [] },
     search: { type: String, default: '' },
+    sort: { type: String, default: 'date' },
     totalRecords: { type: Number, default: 0 },
+    shown: { type: Number, default: 0 },
     reasons: { type: Object, default: () => ({}) },
     mine: { type: Array, default: () => [] },
 });
@@ -22,187 +25,285 @@ const props = defineProps({
 const { proxy } = getCurrentInstance();
 const formatTime = proxy.formatTime;
 
+const SORTS = {
+    date: 'Date of run',
+    rank: 'Rank',
+    name: 'Map name',
+    map_added: 'Map release date',
+};
+
 const search = ref(props.search);
+const sort = ref(props.sort);
 
-// Searching is a GET reload rather than client-side filtering: only the 60
-// most recent runs are sent, so filtering what arrived would silently hide
-// everything older than that.
+// Both filters are a server round trip rather than client-side work: only the
+// first 120 rows are sent, so sorting or filtering what arrived would quietly
+// reorder a slice instead of the whole list.
+const reload = () => {
+    router.get('/self-report', { search: search.value, sort: sort.value }, {
+        preserveState: true,
+        preserveScroll: true,
+        replace: true,
+        only: ['records', 'search', 'sort', 'shown'],
+    });
+};
+
 let searchTimer = null;
-watch(search, (value) => {
+watch(search, () => {
     clearTimeout(searchTimer);
-    searchTimer = setTimeout(() => {
-        router.get('/self-report', { search: value }, {
-            preserveState: true,
-            preserveScroll: true,
-            replace: true,
-        });
-    }, 350);
+    searchTimer = setTimeout(reload, 350);
 });
+watch(sort, reload);
 
-const selected = ref(null);
+// Selection survives searching and re-sorting, so a player can collect runs
+// from several searches before withdrawing them in one go.
+const picked = ref(new Set());
+const pickedCount = computed(() => picked.value.size);
+
+const toggle = (id) => {
+    const next = new Set(picked.value);
+    next.has(id) ? next.delete(id) : next.add(id);
+    picked.value = next;
+};
+
+const allShownPicked = computed(() => props.records.length > 0
+    && props.records.every((record) => picked.value.has(record.id)));
+
+const toggleAllShown = () => {
+    const next = new Set(picked.value);
+    if (allShownPicked.value) {
+        props.records.forEach((record) => next.delete(record.id));
+    } else {
+        props.records.forEach((record) => next.add(record.id));
+    }
+    picked.value = next;
+};
+
+const clearPicked = () => { picked.value = new Set(); };
 
 const form = useForm({
-    record_id: null,
+    record_ids: [],
     reason: 'other',
     note: '',
     confirm: false,
 });
 
-const pick = (record) => {
-    selected.value = record;
-    form.record_id = record.id;
-    form.reason = 'other';
-    form.note = '';
-    form.confirm = false;
-    form.clearErrors();
-};
-
 const submit = () => {
+    form.record_ids = [...picked.value];
     form.post('/self-report', {
         preserveScroll: true,
         onSuccess: () => {
-            selected.value = null;
+            clearPicked();
             form.reset();
         },
     });
 };
 
+// A native <select> draws its option list with the operating system, which
+// ignores every colour on this page - white rows and a blue highlight in the
+// middle of a dark panel. So the list is ours, and it can hold labels as long
+// as "No proper finish (client_finish=false)" without the browser cutting them.
+const reasonOpen = ref(false);
+const reasonBox = ref(null);
+
+const closeReason = (event) => {
+    if (reasonBox.value && !reasonBox.value.contains(event.target)) {
+        reasonOpen.value = false;
+    }
+};
+
+const closeReasonOnEscape = (event) => {
+    if (event.key === 'Escape') {
+        reasonOpen.value = false;
+    }
+};
+
+onMounted(() => {
+    document.addEventListener('mousedown', closeReason);
+    document.addEventListener('keydown', closeReasonOnEscape);
+});
+
+onUnmounted(() => {
+    document.removeEventListener('mousedown', closeReason);
+    document.removeEventListener('keydown', closeReasonOnEscape);
+});
+
+const pickReason = (key) => {
+    form.reason = key;
+    reasonOpen.value = false;
+};
+
 const fmtDate = (value) => value ? new Date(value).toLocaleDateString() : '';
+const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
 </script>
 
 <template>
     <Head title="Withdraw your own time" />
 
-    <div class="min-h-screen py-10">
+    <!-- Bottom padding leaves room for the action bar, which is fixed and
+         would otherwise cover the last rows of the list. -->
+    <div class="min-h-screen py-10" :class="pickedCount ? 'pb-56' : ''">
         <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
 
-            <div class="mb-8">
-                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/15 border border-blue-400/30 text-blue-300 text-xs font-bold uppercase tracking-wider mb-4">
+            <div class="mb-6">
+                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-500/15 border border-emerald-400/30 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-4">
                     Amnesty
                 </div>
-                <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Withdraw your own time</h1>
+                <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Withdraw your own times</h1>
                 <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
-                    If one of your times should not be standing - wrong cvar, a run that was never
-                    legitimate, anything - take it down yourself. It costs you nothing: no validator, no
-                    verdict, no mark on your account. The time goes and the
-                    <Link href="/validation-log" class="text-purple-300 hover:underline">validation log</Link>
-                    says you took it down.
+                    If a time of yours should not be standing - wrong cvar, a run that was never
+                    legitimate, anything - take it down yourself. Tick as many as you like and withdraw
+                    them in one go.
                 </p>
             </div>
 
-            <div class="grid gap-6 lg:grid-cols-3 mb-6">
-                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
-                    <h2 class="text-white font-bold mb-2">It is immediate and final</h2>
-                    <p class="text-gray-400 text-sm leading-relaxed">
-                        The record is deleted the moment you confirm. We cannot put it back, so pick the
-                        right run.
-                    </p>
-                </div>
-                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
-                    <h2 class="text-white font-bold mb-2">Nothing else happens to you</h2>
-                    <p class="text-gray-400 text-sm leading-relaxed">
-                        A withdrawn time is not a case and is not reviewed. Doing this is treated as
-                        putting the leaderboard right, because that is what it is.
-                    </p>
-                </div>
-                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
-                    <h2 class="text-white font-bold mb-2">Your name is in the log</h2>
-                    <p class="text-gray-400 text-sm leading-relaxed">
-                        The time was public and its disappearance is public, so the log says where it
-                        went. Hiding that would be the quiet edit this is meant to replace.
+            <!-- Said once, loudly, before anything else. The single reason
+                 somebody would not use this is the fear that using it is itself
+                 an admission everyone gets to see. -->
+            <div class="rounded-2xl border border-emerald-400/40 bg-emerald-500/[0.09] p-5 flex gap-4 mb-4">
+                <svg class="w-8 h-8 shrink-0 text-emerald-300" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+                </svg>
+                <div>
+                    <h2 class="text-emerald-200 font-black text-lg mb-1">This is private, and it is your right</h2>
+                    <p class="text-gray-200 leading-relaxed">
+                        Nobody is told that you withdrew a run, and nobody is told why. Not the validators,
+                        not the public, not the log, nowhere on the site - only the site admin can see it.
+                        Anyone can use this, at any time, on any of their own runs. You need no permission,
+                        you owe nobody an explanation, and nothing about it is ever held against you.
+                        That is what an amnesty means.
                     </p>
                 </div>
             </div>
 
-            <div v-if="!hasMddAccount" class="bg-black/40 border border-yellow-400/30 rounded-2xl p-6 text-yellow-200">
+            <!-- Three facts people ask before clicking, and the one reason to
+                 do it now rather than later. -->
+            <div class="grid gap-3 md:grid-cols-3 mb-8">
+                <div class="rounded-xl border border-white/10 bg-black/40 p-4">
+                    <div class="text-white font-bold text-sm mb-1">It happens immediately</div>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        The times come off the leaderboard when you confirm. Nothing is wiped from the
+                        database, so an admin can put a run back if you pick the wrong one.
+                    </p>
+                </div>
+                <div class="rounded-xl border border-white/10 bg-black/40 p-4">
+                    <div class="text-white font-bold text-sm mb-1">No case, no review</div>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        A withdrawn run is not reported and not judged by anybody. It is treated as
+                        putting the leaderboard right, because that is what it is.
+                    </p>
+                </div>
+                <div class="rounded-xl border border-red-400/25 bg-red-500/[0.07] p-4">
+                    <div class="text-red-300 font-bold text-sm mb-1">Only while you are ahead of it</div>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        Once somebody else reports the run it becomes a case, and when validators decide
+                        it, the outcome is published with your name on it.
+                    </p>
+                </div>
+            </div>
+
+            <!-- The one condition on an otherwise unconditional promise. It is
+                 stated as plainly as the promise itself, because a rule people
+                 only meet when it is used on them reads as an excuse. -->
+            <div class="rounded-xl border border-amber-400/30 bg-amber-500/[0.07] p-4 mb-8">
+                <span class="text-amber-300 font-bold">Abusing this loses you the amnesty.</span>
+                <span class="text-gray-300">
+                    It is here to put the leaderboard right, not to launder anything. If it is shown that
+                    somebody used it to game the system, that player loses access to the amnesty programme
+                    and from then on their runs go through reports and validators like anybody else's.
+                </span>
+            </div>
+
+            <div v-if="blocked" class="bg-black/40 border border-red-400/40 rounded-2xl p-6 mb-8">
+                <h2 class="text-red-300 font-black text-lg mb-1">You no longer have access to the amnesty</h2>
+                <p class="text-gray-300 leading-relaxed">
+                    Withdrawn on {{ fmtDate(blocked.since) }}<span v-if="blocked.reason">: {{ blocked.reason }}</span>.
+                    Your runs are handled through the normal reporting and validation process from here on.
+                    Take it up with the admin if you think this is wrong.
+                </p>
+            </div>
+
+            <div v-if="!blocked && !hasMddAccount" class="bg-black/40 border border-yellow-400/30 rounded-2xl p-6 text-yellow-200">
                 Your account is not linked to an MDD profile, so there are no records tied to it here.
                 Link it in your settings first.
             </div>
 
-            <template v-else>
-                <div class="grid gap-6 lg:grid-cols-2">
+            <template v-else-if="!blocked">
+                <!-- The list -->
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                    <div class="p-4 border-b border-white/5 flex flex-wrap items-center gap-3">
+                        <input v-model="search" type="text" placeholder="Search your maps..."
+                            class="flex-1 min-w-[12rem] bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-emerald-400/50" />
 
-                    <!-- Your runs -->
-                    <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
-                        <div class="p-4 border-b border-white/5 flex items-center gap-3">
-                            <input v-model="search" type="text" placeholder="Search your maps..."
-                                class="flex-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50" />
-                            <span class="text-xs text-gray-500 whitespace-nowrap">{{ totalRecords }} total</span>
-                        </div>
-
-                        <div v-if="!records.length" class="p-8 text-center text-gray-500">
-                            No runs found.
-                        </div>
-                        <div v-else class="divide-y divide-white/5 max-h-[32rem] overflow-y-auto">
-                            <button v-for="record in records" :key="record.id" type="button" @click="pick(record)"
-                                class="w-full text-left p-4 flex items-center gap-3 hover:bg-white/5 transition-colors"
-                                :class="selected && selected.id === record.id ? 'bg-purple-500/10' : ''">
-                                <div class="min-w-0 flex-1">
-                                    <div class="font-semibold text-white truncate">{{ record.mapname }}</div>
-                                    <div class="text-xs text-gray-500 mt-0.5">
-                                        {{ record.physics }} {{ record.mode }} · {{ fmtDate(record.date_set) }}
-                                    </div>
-                                </div>
-                                <div class="font-mono text-sm text-gray-300 whitespace-nowrap">{{ formatTime(record.time) }}</div>
+                        <!-- Buttons rather than a <select> for the same reason
+                             the reason picker is hand-built: four options are
+                             worth four buttons, and the browser cannot repaint
+                             these in system colours. -->
+                        <div class="flex items-center gap-1 p-1 rounded-lg bg-black/40 border border-white/10">
+                            <span class="text-xs uppercase tracking-wide text-gray-500 px-2">Sort</span>
+                            <button v-for="(label, key) in SORTS" :key="key" type="button" @click="sort = key"
+                                class="px-3 py-1.5 rounded-md text-sm font-semibold transition-colors"
+                                :class="sort === key ? 'bg-emerald-500/20 text-emerald-200' : 'text-gray-400 hover:text-white hover:bg-white/10'">
+                                {{ label }}
                             </button>
                         </div>
+
+                        <button type="button" @click="toggleAllShown" :disabled="!records.length"
+                            class="px-3 py-2 rounded-lg text-sm font-bold bg-white/5 hover:bg-white/10 text-gray-200 transition-colors disabled:opacity-40">
+                            {{ allShownPicked ? 'Unselect these' : 'Select these' }}
+                        </button>
+
+                        <span class="text-xs text-gray-500 whitespace-nowrap">
+                            {{ shown }} of {{ totalRecords }}
+                        </span>
                     </div>
 
-                    <!-- The confirmation -->
-                    <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
-                        <div v-if="!selected" class="text-gray-500 py-12 text-center">
-                            Pick one of your runs on the left.
-                        </div>
+                    <div v-if="!records.length" class="p-10 text-center text-gray-500">
+                        No runs found.
+                    </div>
 
-                        <form v-else @submit.prevent="submit" class="space-y-4">
-                            <div>
-                                <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Withdrawing</div>
-                                <div class="text-xl font-black text-white">{{ selected.mapname }}</div>
-                                <div class="text-sm text-gray-400 mt-0.5">
-                                    {{ selected.physics }} {{ selected.mode }} · <span class="font-mono">{{ formatTime(selected.time) }}</span>
+                    <div v-else class="divide-y divide-white/5">
+                        <label v-for="record in records" :key="record.id"
+                            class="flex items-center gap-4 p-3 cursor-pointer transition-colors"
+                            :class="picked.has(record.id) ? 'bg-emerald-500/10' : 'hover:bg-white/[0.04]'">
+
+                            <input type="checkbox" :checked="picked.has(record.id)" @change="toggle(record.id)"
+                                class="w-5 h-5 shrink-0 rounded bg-black/50 border-white/20 text-emerald-500 focus:ring-emerald-500/40" />
+
+                            <img :src="thumb(record.map_thumbnail)" alt=""
+                                onerror="this.onerror=null;this.src='/images/unknown.jpg'"
+                                class="w-24 h-14 shrink-0 rounded-lg object-cover bg-gray-900" />
+
+                            <div class="min-w-0 flex-1">
+                                <div class="font-semibold text-white truncate">{{ record.mapname }}</div>
+                                <div class="text-xs text-gray-500 mt-0.5 flex flex-wrap gap-x-3">
+                                    <span class="uppercase">{{ record.physics }} {{ record.mode }}</span>
+                                    <span>run {{ fmtDate(record.date_set) }}</span>
+                                    <span v-if="record.map_added">map {{ fmtDate(record.map_added) }}</span>
                                 </div>
                             </div>
 
-                            <div>
-                                <label class="block text-sm text-gray-300 mb-1">What was wrong with it</label>
-                                <select v-model="form.reason"
-                                    class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-purple-400/50">
-                                    <option v-for="(label, key) in reasons" :key="key" :value="key">{{ label }}</option>
-                                </select>
-                                <div v-if="form.errors.reason" class="text-red-400 text-sm mt-1">{{ form.errors.reason }}</div>
+                            <div v-if="record.rank" class="text-center shrink-0 w-14">
+                                <div class="text-[10px] uppercase tracking-wide text-gray-600">Rank</div>
+                                <div class="font-black" :class="record.rank === 1 ? 'text-yellow-400' : record.rank <= 3 ? 'text-gray-300' : 'text-gray-400'">
+                                    {{ record.rank }}
+                                </div>
                             </div>
 
-                            <div>
-                                <label class="block text-sm text-gray-300 mb-1">Anything to add (optional, public)</label>
-                                <textarea v-model="form.note" rows="3" maxlength="500"
-                                    class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50"
-                                    placeholder="Shown in the validation log next to the withdrawn time."></textarea>
-                                <div v-if="form.errors.note" class="text-red-400 text-sm mt-1">{{ form.errors.note }}</div>
-                            </div>
+                            <div class="font-mono text-gray-200 whitespace-nowrap w-24 text-right">{{ formatTime(record.time) }}</div>
+                        </label>
+                    </div>
 
-                            <label class="flex items-start gap-3 text-sm text-gray-300">
-                                <input type="checkbox" v-model="form.confirm" class="mt-1 rounded bg-black/50 border-white/20" />
-                                <span>I understand this deletes the time immediately and it cannot be restored.</span>
-                            </label>
-                            <div v-if="form.errors.confirm" class="text-red-400 text-sm">{{ form.errors.confirm }}</div>
-                            <div v-if="form.errors.record_id" class="text-red-400 text-sm">{{ form.errors.record_id }}</div>
-
-                            <div class="flex gap-3">
-                                <button type="submit" :disabled="form.processing"
-                                    class="px-5 py-2.5 rounded-lg bg-red-500/80 hover:bg-red-500 text-white font-bold transition-colors disabled:opacity-50">
-                                    Withdraw this time
-                                </button>
-                                <button type="button" @click="selected = null"
-                                    class="px-5 py-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-gray-300 font-bold transition-colors">
-                                    Cancel
-                                </button>
-                            </div>
-                        </form>
+                    <div v-if="shown < totalRecords" class="p-3 text-center text-xs text-gray-500 border-t border-white/5">
+                        Showing the first {{ shown }}. Search or re-sort to reach the rest - anything you have
+                        already ticked stays ticked.
                     </div>
                 </div>
 
                 <div v-if="mine.length" class="mt-6 bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
-                    <div class="p-4 border-b border-white/5 text-white font-bold">Times you have withdrawn</div>
+                    <div class="p-4 border-b border-white/5 text-white font-bold">
+                        Times you have withdrawn
+                        <span class="font-normal text-gray-500 text-sm">- visible to you and the admin only</span>
+                    </div>
                     <div class="divide-y divide-white/5">
                         <div v-for="row in mine" :key="row.id" class="p-4 flex flex-wrap items-center gap-x-4 gap-y-1">
                             <div class="min-w-0 flex-1 font-semibold text-white">{{ row.mapname }}</div>
@@ -211,6 +312,77 @@ const fmtDate = (value) => value ? new Date(value).toLocaleDateString() : '';
                             <div class="text-sm text-gray-500">{{ fmtDate(row.created_at) }}</div>
                         </div>
                     </div>
+                </div>
+
+                <!-- Action bar. Fixed rather than sitting under the list: with
+                     120 rows the confirmation would otherwise be a scroll away
+                     from whatever was just ticked. -->
+                <div v-if="pickedCount"
+                    class="fixed bottom-0 inset-x-0 z-40 border-t border-emerald-400/30 bg-gray-950/95 backdrop-blur-xl shadow-[0_-8px_40px_rgba(0,0,0,0.6)]">
+                    <form @submit.prevent="submit" class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-4 flex flex-wrap items-end gap-4">
+
+                        <div class="shrink-0">
+                            <div class="text-2xl font-black text-emerald-300 leading-none">{{ pickedCount }}</div>
+                            <button type="button" @click="clearPicked" class="text-xs text-gray-500 hover:text-white">
+                                run<span v-if="pickedCount !== 1">s</span> picked - clear
+                            </button>
+                        </div>
+
+                        <div ref="reasonBox" class="relative min-w-[16rem] flex-1">
+                            <label class="block text-xs text-gray-400 mb-1">What was wrong with them</label>
+                            <button type="button" @click="reasonOpen = !reasonOpen"
+                                class="w-full flex items-center justify-between gap-2 bg-black/50 border rounded-lg px-3 py-2 text-left text-white transition-colors"
+                                :class="reasonOpen ? 'border-emerald-400/60' : 'border-white/10 hover:border-white/25'">
+                                <span>{{ reasons[form.reason] }}</span>
+                                <svg class="w-4 h-4 opacity-60 transition-transform duration-200 shrink-0"
+                                    :class="reasonOpen ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="2" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                                </svg>
+                            </button>
+
+                            <!-- Opens upward: the bar is already at the bottom
+                                 of the window. -->
+                            <div v-if="reasonOpen"
+                                class="absolute z-50 bottom-full left-0 right-0 mb-2 p-1.5 rounded-xl border border-white/15 bg-gray-900/95 backdrop-blur-xl shadow-[0_8px_40px_rgba(0,0,0,0.6)] max-h-72 overflow-y-auto">
+                                <button v-for="(label, key) in reasons" :key="key" type="button" @click="pickReason(key)"
+                                    class="w-full flex items-center gap-2 text-left px-3 py-2 rounded-lg text-sm transition-colors"
+                                    :class="form.reason === key
+                                        ? 'bg-emerald-500/20 text-emerald-100'
+                                        : 'text-gray-300 hover:bg-white/10 hover:text-white'">
+                                    <svg class="w-4 h-4 shrink-0" :class="form.reason === key ? 'opacity-100' : 'opacity-0'"
+                                        fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                                    </svg>
+                                    <span>{{ label }}</span>
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="min-w-[14rem] flex-1">
+                            <label class="block text-xs text-gray-400 mb-1">Note (optional, admin only)</label>
+                            <input v-model="form.note" type="text" maxlength="500"
+                                class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-emerald-400/50"
+                                placeholder="Only the site admin reads this." />
+                        </div>
+
+                        <div class="flex items-center gap-4">
+                            <label class="flex items-center gap-2 text-sm text-gray-300 max-w-xs">
+                                <input type="checkbox" v-model="form.confirm" class="w-5 h-5 rounded bg-black/50 border-white/20 text-emerald-500" />
+                                <span>I understand only an admin can put them back.</span>
+                            </label>
+
+                            <button type="submit" :disabled="form.processing"
+                                class="px-5 py-2.5 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white font-bold transition-colors disabled:opacity-50 whitespace-nowrap">
+                                Withdraw {{ pickedCount }} run<span v-if="pickedCount !== 1">s</span>
+                            </button>
+                        </div>
+
+                        <div v-if="form.errors.confirm || form.errors.record_ids || form.errors.reason"
+                            class="w-full text-red-400 text-sm">
+                            {{ form.errors.confirm || form.errors.record_ids || form.errors.reason }}
+                        </div>
+                    </form>
                 </div>
             </template>
 

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -171,8 +171,9 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
 
                 <p class="text-gray-400 mt-2 max-w-3xl">
                     You cheated, and you have worked out which of your times should not be standing.
-                    This is where you put it right, privately. Tick as many runs as you like and send
-                    them in one go.
+                    This is where you put it right, privately. Send them one at a time or all at once,
+                    but the reason you give has to be true for every run in the batch - anything you did
+                    differently goes in a batch of its own.
                 </p>
             </div>
         </div>
@@ -389,7 +390,11 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                         </div>
 
                         <div ref="reasonBox" class="relative min-w-[16rem] flex-1">
-                            <label class="block text-xs text-gray-400 mb-1">What was wrong with them</label>
+                            <label class="block text-xs text-gray-400 mb-1">
+                                What you did in
+                                <span v-if="pickedCount === 1">this run</span>
+                                <span v-else>all {{ pickedCount }} of these runs</span>
+                            </label>
                             <button type="button" @click="reasonOpen = !reasonOpen"
                                 class="w-full flex items-center justify-between gap-2 bg-black/50 border rounded-lg px-3 py-2 text-left text-white transition-colors"
                                 :class="reasonOpen ? 'border-emerald-400/60' : 'border-white/10 hover:border-white/25'">
@@ -445,9 +450,12 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                         </div>
 
                         <div class="flex items-center gap-4">
-                            <label class="flex items-center gap-2 text-sm text-gray-300 max-w-xs">
-                                <input type="checkbox" v-model="form.confirm" class="w-5 h-5 rounded bg-black/50 border-white/20 text-emerald-500" />
-                                <span>I understand this cannot be taken back.</span>
+                            <label class="flex items-start gap-2 text-sm text-gray-300 max-w-sm">
+                                <input type="checkbox" v-model="form.confirm" class="mt-0.5 w-5 h-5 shrink-0 rounded bg-black/50 border-white/20 text-emerald-500" />
+                                <span>
+                                    To the best of my knowledge and conscience, what I have said about
+                                    these runs is true.
+                                </span>
                             </label>
 
                             <button type="submit" :disabled="form.processing"
@@ -478,6 +486,15 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                             You are sending <span class="font-bold text-white">{{ pickedCount }}</span> of your
                             own run<span v-if="pickedCount !== 1">s</span> to be taken off the board. This step
                             is irreversible - once they are handled you cannot bring them back.
+                        </p>
+
+                        <p class="text-gray-300 leading-relaxed mb-3">
+                            You are declaring, to the best of your knowledge and conscience, that
+                            <span class="font-semibold text-white">{{ reasons[form.reason] }}</span> is what
+                            happened in
+                            <span v-if="pickedCount === 1">this run</span>
+                            <span v-else>every one of these {{ pickedCount }} runs</span>. If it is not
+                            true of all of them, go back and send them in separate batches.
                         </p>
 
                         <p class="text-gray-300 leading-relaxed mb-5">

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -19,6 +19,7 @@ const props = defineProps({
     sort: { type: String, default: 'date' },
     totalRecords: { type: Number, default: 0 },
     reasons: { type: Object, default: () => ({}) },
+    handlingOptions: { type: Object, default: () => ({}) },
     mine: { type: Array, default: () => [] },
 });
 
@@ -88,15 +89,29 @@ const clearPicked = () => { picked.value = new Set(); };
 const form = useForm({
     record_ids: [],
     reason: 'other',
+    handling: 'on_merge',
     note: '',
     confirm: false,
 });
+
+// Nothing is sent from the bar itself. The last thing between a player and a
+// list of their own runs disappearing is a sentence they have to read.
+const confirming = ref(false);
+
+const askConfirm = () => {
+    if (!form.confirm) {
+        form.setError('confirm', 'Tick the box first.');
+        return;
+    }
+    confirming.value = true;
+};
 
 const submit = () => {
     form.record_ids = [...picked.value];
     form.post('/amnesty', {
         preserveScroll: true,
         onSuccess: () => {
+            confirming.value = false;
             clearPicked();
             form.reset();
         },
@@ -155,9 +170,9 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                 </div>
 
                 <p class="text-gray-400 mt-2 max-w-3xl">
-                    If a time of yours should not be standing - wrong cvar, a run that was never
-                    legitimate, anything - take it down yourself. Tick as many as you like and withdraw
-                    them in one go.
+                    You cheated, or you broke a rule without knowing it, and you have worked out which of
+                    your times should not be standing. This is where you put it right, privately. Tick as
+                    many runs as you like and send them in one go.
                 </p>
             </div>
         </div>
@@ -186,14 +201,29 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                 </div>
             </div>
 
+            <!-- Set the expectation before anything else, because the first
+                 complaint would otherwise be "I sent it and my run is still
+                 there, on q3df too". -->
+            <div class="rounded-2xl border border-amber-400/35 bg-amber-500/[0.08] p-5 mb-4">
+                <h2 class="text-amber-200 font-black text-lg mb-1">Nothing disappears the moment you send it</h2>
+                <p class="text-gray-200 leading-relaxed">
+                    These requests are handled when the MDD databases are merged. That merge is planned
+                    but not done, and until it happens a run taken off this site still stands on
+                    q3df.org - we cannot reach that database yet. So you choose which you want: have it
+                    hidden here as soon as an admin approves it and accept that q3df still shows it for
+                    now, or leave it queued and have both handled together at the merge. Either way an
+                    admin approves the hide, and your run stays on the board until they do.
+                </p>
+            </div>
+
             <!-- Three facts people ask before clicking, and the one reason to
                  do it now rather than later. -->
             <div class="grid gap-3 md:grid-cols-3 mb-8">
                 <div class="rounded-xl border border-white/10 bg-black/40 p-4">
-                    <div class="text-white font-bold text-sm mb-1">It happens immediately</div>
+                    <div class="text-white font-bold text-sm mb-1">You cannot take it back</div>
                     <p class="text-gray-400 text-sm leading-relaxed">
-                        The times come off the leaderboard the moment you confirm, and you cannot take
-                        that back. Check what you have ticked before you do it.
+                        Once a run is handled it is off the board, and undoing that is not yours to do.
+                        Check what you have ticked before you send it.
                     </p>
                 </div>
                 <div class="rounded-xl border border-white/10 bg-black/40 p-4">
@@ -204,7 +234,7 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                     </p>
                 </div>
                 <div class="rounded-xl border border-red-400/25 bg-red-500/[0.07] p-4">
-                    <div class="text-red-300 font-bold text-sm mb-1">Only while you are ahead of it</div>
+                    <div class="text-red-300 font-bold text-sm mb-1">Only while you are ahead of a report</div>
                     <p class="text-gray-400 text-sm leading-relaxed">
                         Once somebody else reports the run it becomes a case, and when validators decide
                         it, the outcome is published with your name on it.
@@ -317,14 +347,22 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
 
                 <div v-if="mine.length" class="mt-6 bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
                     <div class="p-4 border-b border-white/5 flex flex-wrap items-baseline gap-x-3">
-                        <span class="text-white font-bold">Runs you have withdrawn</span>
+                        <span class="text-white font-bold">Runs you have sent</span>
                         <span class="text-gray-500 text-sm">{{ mine.length }} in total, and why</span>
                         <span class="ml-auto text-xs text-gray-600">Visible to you and the site admin. Nobody else.</span>
                     </div>
                     <div class="divide-y divide-white/5">
                         <div v-for="row in mine" :key="row.id" class="p-4 flex flex-wrap items-center gap-x-4 gap-y-1">
                             <div class="min-w-0 flex-1">
-                                <div class="font-semibold text-white">{{ row.mapname }}</div>
+                                <div class="flex items-center gap-2 flex-wrap">
+                                    <span class="font-semibold text-white">{{ row.mapname }}</span>
+                                    <span class="text-[11px] px-2 py-0.5 rounded border font-bold"
+                                        :class="row.processed
+                                            ? 'border-green-400/30 bg-green-500/15 text-green-300'
+                                            : 'border-amber-400/40 bg-amber-500/15 text-amber-200'">
+                                        {{ row.processed ? 'Off the board' : (row.handling === 'immediate' ? 'Waiting for an admin' : 'Queued for the MDD merge') }}
+                                    </span>
+                                </div>
                                 <div class="text-sm text-gray-400 mt-0.5">
                                     {{ row.reason }}<span v-if="row.note" class="text-gray-500"> - {{ row.note }}</span>
                                 </div>
@@ -341,7 +379,7 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                      from whatever was just ticked. -->
                 <div v-if="pickedCount"
                     class="fixed bottom-0 inset-x-0 z-40 border-t border-emerald-400/30 bg-gray-950/95 backdrop-blur-xl shadow-[0_-8px_40px_rgba(0,0,0,0.6)]">
-                    <form @submit.prevent="submit" class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-4 flex flex-wrap items-end gap-4">
+                    <form @submit.prevent="askConfirm" class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 py-4 flex flex-wrap items-end gap-4">
 
                         <div class="shrink-0">
                             <div class="text-2xl font-black text-emerald-300 leading-none">{{ pickedCount }}</div>
@@ -388,6 +426,24 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                                 placeholder="Only the site admin reads this." />
                         </div>
 
+                        <div class="min-w-[18rem] flex-1">
+                            <label class="block text-xs text-gray-400 mb-1">When</label>
+                            <div class="flex flex-col gap-1">
+                                <button v-for="(label, key) in handlingOptions" :key="key" type="button"
+                                    @click="form.handling = key"
+                                    class="flex items-start gap-2 text-left px-3 py-1.5 rounded-lg text-sm transition-colors"
+                                    :class="form.handling === key
+                                        ? 'bg-emerald-500/20 text-emerald-100'
+                                        : 'text-gray-400 hover:bg-white/10 hover:text-white'">
+                                    <svg class="w-4 h-4 shrink-0 mt-0.5" :class="form.handling === key ? 'opacity-100' : 'opacity-0'"
+                                        fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                                    </svg>
+                                    <span>{{ label }}</span>
+                                </button>
+                            </div>
+                        </div>
+
                         <div class="flex items-center gap-4">
                             <label class="flex items-center gap-2 text-sm text-gray-300 max-w-xs">
                                 <input type="checkbox" v-model="form.confirm" class="w-5 h-5 rounded bg-black/50 border-white/20 text-emerald-500" />
@@ -400,11 +456,61 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                             </button>
                         </div>
 
-                        <div v-if="form.errors.confirm || form.errors.record_ids || form.errors.reason"
+                        <div v-if="form.errors.confirm || form.errors.record_ids || form.errors.reason || form.errors.handling"
                             class="w-full text-red-400 text-sm">
-                            {{ form.errors.confirm || form.errors.record_ids || form.errors.reason }}
+                            {{ form.errors.confirm || form.errors.record_ids || form.errors.reason || form.errors.handling }}
                         </div>
                     </form>
+                </div>
+
+                <!-- The last thing between a player and their own runs coming
+                     off the board. Deliberately blunt, and deliberately not a
+                     browser confirm() - this one has to be read. -->
+                <div v-if="confirming" class="fixed inset-0 z-[60] flex items-center justify-center p-4">
+                    <div class="absolute inset-0 bg-black/80 backdrop-blur-sm" @click="confirming = false"></div>
+
+                    <div class="relative w-full max-w-lg rounded-2xl border border-red-400/40 bg-gray-950 p-6 shadow-[0_20px_80px_rgba(0,0,0,0.8)]">
+                        <h2 class="text-xl md:text-2xl font-black text-red-300 mb-3">
+                            Are you sure you want to do this?
+                        </h2>
+
+                        <p class="text-gray-200 leading-relaxed mb-3">
+                            You are sending <span class="font-bold text-white">{{ pickedCount }}</span> of your
+                            own run<span v-if="pickedCount !== 1">s</span> to be taken off the board. This step
+                            is irreversible - once they are handled you cannot bring them back.
+                        </p>
+
+                        <p class="text-gray-300 leading-relaxed mb-5">
+                            This exists for runs that should never have counted. Abusing it to delete times
+                            you are simply not happy with costs you access to this section permanently.
+                        </p>
+
+                        <div class="rounded-xl border border-white/10 bg-black/40 p-3 mb-5 text-sm">
+                            <div class="flex justify-between gap-3 py-0.5">
+                                <span class="text-gray-500">Runs</span>
+                                <span class="text-white font-semibold">{{ pickedCount }}</span>
+                            </div>
+                            <div class="flex justify-between gap-3 py-0.5">
+                                <span class="text-gray-500">Reason</span>
+                                <span class="text-white font-semibold text-right">{{ reasons[form.reason] }}</span>
+                            </div>
+                            <div class="flex justify-between gap-3 py-0.5">
+                                <span class="text-gray-500">When</span>
+                                <span class="text-white font-semibold text-right">{{ handlingOptions[form.handling] }}</span>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap gap-3 justify-end">
+                            <button type="button" @click="confirming = false"
+                                class="px-5 py-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-gray-200 font-bold transition-colors">
+                                No, take me back
+                            </button>
+                            <button type="button" @click="submit" :disabled="form.processing"
+                                class="px-5 py-2.5 rounded-lg bg-red-500 hover:bg-red-600 text-white font-bold transition-colors disabled:opacity-50">
+                                Yes, send {{ pickedCount }} run<span v-if="pickedCount !== 1">s</span>
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </template>
 

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -39,7 +39,7 @@ const sort = ref(props.sort);
 // first 120 rows are sent, so sorting or filtering what arrived would quietly
 // reorder a slice instead of the whole list.
 const reload = () => {
-    router.get('/self-report', { search: search.value, sort: sort.value }, {
+    router.get('/amnesty', { search: search.value, sort: sort.value }, {
         preserveState: true,
         preserveScroll: true,
         replace: true,
@@ -89,7 +89,7 @@ const form = useForm({
 
 const submit = () => {
     form.record_ids = [...picked.value];
-    form.post('/self-report', {
+    form.post('/amnesty', {
         preserveScroll: true,
         onSuccess: () => {
             clearPicked();
@@ -137,7 +137,7 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
 </script>
 
 <template>
-    <Head title="Withdraw your own time" />
+    <Head title="Amnesty - self report" />
 
     <!-- Bottom padding leaves room for the action bar, which is fixed and
          would otherwise cover the last rows of the list. -->

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -170,9 +170,9 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                 </div>
 
                 <p class="text-gray-400 mt-2 max-w-3xl">
-                    You cheated, or you broke a rule without knowing it, and you have worked out which of
-                    your times should not be standing. This is where you put it right, privately. Tick as
-                    many runs as you like and send them in one go.
+                    You cheated, and you have worked out which of your times should not be standing.
+                    This is where you put it right, privately. Tick as many runs as you like and send
+                    them in one go.
                 </p>
             </div>
         </div>

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -9,18 +9,22 @@ export default {
 <script setup>
 import { Head, Link, router, useForm } from '@inertiajs/vue3';
 import { computed, getCurrentInstance, onMounted, onUnmounted, ref, watch } from 'vue';
+import Pagination from '@/Components/Basic/Pagination.vue';
 
 const props = defineProps({
     hasMddAccount: { type: Boolean, default: false },
     blocked: { type: Object, default: null },
-    records: { type: Array, default: () => [] },
+    records: { type: Object, default: () => ({ data: [] }) },
     search: { type: String, default: '' },
     sort: { type: String, default: 'date' },
     totalRecords: { type: Number, default: 0 },
-    shown: { type: Number, default: 0 },
     reasons: { type: Object, default: () => ({}) },
     mine: { type: Array, default: () => [] },
 });
+
+// The rows of the page being looked at. Everything else on this page talks
+// about the whole collection, so the two are kept apart by name.
+const rows = computed(() => props.records?.data ?? []);
 
 const { proxy } = getCurrentInstance();
 const formatTime = proxy.formatTime;
@@ -35,15 +39,16 @@ const SORTS = {
 const search = ref(props.search);
 const sort = ref(props.sort);
 
-// Both filters are a server round trip rather than client-side work: only the
-// first 120 rows are sent, so sorting or filtering what arrived would quietly
-// reorder a slice instead of the whole list.
+// Both filters are a server round trip rather than client-side work: one page
+// of rows is in the browser, so sorting or filtering what arrived would quietly
+// reorder a slice instead of the whole list. No page parameter, so changing
+// either goes back to the first page rather than to page 9 of a new search.
 const reload = () => {
     router.get('/amnesty', { search: search.value, sort: sort.value }, {
         preserveState: true,
         preserveScroll: true,
         replace: true,
-        only: ['records', 'search', 'sort', 'shown'],
+        only: ['records', 'search', 'sort'],
     });
 };
 
@@ -65,15 +70,15 @@ const toggle = (id) => {
     picked.value = next;
 };
 
-const allShownPicked = computed(() => props.records.length > 0
-    && props.records.every((record) => picked.value.has(record.id)));
+const allShownPicked = computed(() => rows.value.length > 0
+    && rows.value.every((record) => picked.value.has(record.id)));
 
 const toggleAllShown = () => {
     const next = new Set(picked.value);
     if (allShownPicked.value) {
-        props.records.forEach((record) => next.delete(record.id));
+        rows.value.forEach((record) => next.delete(record.id));
     } else {
-        props.records.forEach((record) => next.add(record.id));
+        rows.value.forEach((record) => next.add(record.id));
     }
     picked.value = next;
 };
@@ -253,22 +258,24 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                             </button>
                         </div>
 
-                        <button type="button" @click="toggleAllShown" :disabled="!records.length"
+                        <button type="button" @click="toggleAllShown" :disabled="!rows.length"
                             class="px-3 py-2 rounded-lg text-sm font-bold bg-white/5 hover:bg-white/10 text-gray-200 transition-colors disabled:opacity-40">
-                            {{ allShownPicked ? 'Unselect these' : 'Select these' }}
+                            {{ allShownPicked ? 'Unselect this page' : 'Select this page' }}
                         </button>
 
                         <span class="text-xs text-gray-500 whitespace-nowrap">
-                            {{ shown }} of {{ totalRecords }}
+                            {{ records.total ?? rows.length }} run<span v-if="(records.total ?? rows.length) !== 1">s</span>
+                            <span v-if="search"> found</span>
+                            <span v-else> in total</span>
                         </span>
                     </div>
 
-                    <div v-if="!records.length" class="p-10 text-center text-gray-500">
+                    <div v-if="!rows.length" class="p-10 text-center text-gray-500">
                         No runs found.
                     </div>
 
                     <div v-else class="divide-y divide-white/5">
-                        <label v-for="record in records" :key="record.id"
+                        <label v-for="record in rows" :key="record.id"
                             class="flex items-center gap-4 p-3 cursor-pointer transition-colors"
                             :class="picked.has(record.id) ? 'bg-emerald-500/10' : 'hover:bg-white/[0.04]'">
 
@@ -299,9 +306,12 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                         </label>
                     </div>
 
-                    <div v-if="shown < totalRecords" class="p-3 text-center text-xs text-gray-500 border-t border-white/5">
-                        Showing the first {{ shown }}. Search or re-sort to reach the rest - anything you have
-                        already ticked stays ticked.
+                    <!-- Anything ticked stays ticked across pages, searches and
+                         re-sorts: the selection is held in the browser, and the
+                         page changes are partial reloads. -->
+                    <div v-if="records.last_page > 1" class="p-3 border-t border-white/5">
+                        <Pagination :last_page="records.last_page" :current_page="records.current_page"
+                            :link="records.first_page_url" :only="['records']" />
                     </div>
                 </div>
 

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -20,12 +20,35 @@ const props = defineProps({
     totalRecords: { type: Number, default: 0 },
     reasons: { type: Object, default: () => ({}) },
     handlingOptions: { type: Object, default: () => ({}) },
-    mine: { type: Array, default: () => [] },
+    mine: { type: Object, default: () => ({ data: [] }) },
+    mineCounts: { type: Object, default: () => ({}) },
+    mineState: { type: String, default: 'all' },
 });
 
 // The rows of the page being looked at. Everything else on this page talks
 // about the whole collection, so the two are kept apart by name.
 const rows = computed(() => props.records?.data ?? []);
+
+// Your own withdrawals: same states the admin sees, in the words a player
+// would use for them.
+const MINE_STATES = {
+    all: 'All',
+    waiting: 'Waiting',
+    queued: 'Queued for the merge',
+    done: 'Off the board',
+    restored: 'Put back',
+};
+
+const mineRows = computed(() => props.mine?.data ?? []);
+
+const setMineState = (state) => {
+    router.get('/amnesty', { mine_state: state === 'all' ? undefined : state }, {
+        preserveState: true,
+        preserveScroll: true,
+        replace: true,
+        only: ['mine', 'mineState', 'mineCounts'],
+    });
+};
 
 const { proxy } = getCurrentInstance();
 const formatTime = proxy.formatTime;
@@ -354,23 +377,44 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                     </div>
                 </div>
 
-                <div v-if="mine.length" class="mt-6 bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                <div v-if="mineCounts.all" class="mt-6 bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
                     <div class="p-4 border-b border-white/5 flex flex-wrap items-baseline gap-x-3">
                         <span class="text-white font-bold">Runs you have sent</span>
-                        <span class="text-gray-500 text-sm">{{ mine.length }} in total, and why</span>
+                        <span class="text-gray-500 text-sm">{{ mineCounts.all }} in total, and why</span>
                         <span class="ml-auto text-xs text-gray-600">Visible to you and the site admin. Nobody else.</span>
                     </div>
-                    <div class="divide-y divide-white/5">
-                        <div v-for="row in mine" :key="row.id" class="p-4 flex flex-wrap items-center gap-x-4 gap-y-1">
+
+                    <!-- Same split the admin panel uses, so what you are told
+                         here and what happens there are the same thing. -->
+                    <div class="px-4 pt-3 flex flex-wrap gap-2">
+                        <button v-for="(label, key) in MINE_STATES" :key="key" type="button"
+                            v-show="key === 'all' || mineCounts[key]"
+                            @click="setMineState(key)"
+                            class="px-3 py-1.5 rounded-lg text-sm font-semibold border transition-colors"
+                            :class="mineState === key
+                                ? 'bg-emerald-500/20 border-emerald-400/50 text-emerald-200'
+                                : 'bg-black/40 border-white/10 text-gray-400 hover:text-white hover:border-white/25'">
+                            {{ label }}
+                            <span class="ml-1 opacity-60">{{ mineCounts[key] ?? 0 }}</span>
+                        </button>
+                    </div>
+
+                    <div class="divide-y divide-white/5 mt-3">
+                        <div v-if="!mineRows.length" class="p-6 text-center text-gray-500 text-sm">
+                            Nothing in this one.
+                        </div>
+                        <div v-for="row in mineRows" :key="row.id" class="p-4 flex flex-wrap items-center gap-x-4 gap-y-1">
                             <div class="min-w-0 flex-1">
                                 <div class="flex items-center gap-2 flex-wrap">
                                     <span class="font-semibold text-white">{{ row.mapname }}</span>
                                     <span class="text-[11px] px-2 py-0.5 rounded border font-bold"
                                         :class="row.beaten
                                             ? 'border-blue-400/30 bg-blue-500/15 text-blue-200'
-                                            : row.processed
-                                                ? 'border-green-400/30 bg-green-500/15 text-green-300'
-                                                : 'border-amber-400/40 bg-amber-500/15 text-amber-200'">
+                                            : row.restored
+                                                ? 'border-red-400/30 bg-red-500/15 text-red-200'
+                                                : row.processed
+                                                    ? 'border-green-400/30 bg-green-500/15 text-green-300'
+                                                    : 'border-amber-400/40 bg-amber-500/15 text-amber-200'">
                                         {{ row.state }}
                                     </span>
                                 </div>
@@ -382,6 +426,14 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                             <div class="font-mono text-sm text-gray-300 whitespace-nowrap">{{ formatTime(row.time) }}</div>
                             <div class="text-sm text-gray-500 whitespace-nowrap">{{ fmtDate(row.created_at) }}</div>
                         </div>
+                    </div>
+
+                    <div v-if="mine.last_page > 1" class="p-4 border-t border-white/5">
+                        <!-- Its own page parameter, or paging this list would
+                             page the records above it as well. -->
+                        <Pagination :last_page="mine.last_page" :current_page="mine.current_page"
+                            :link="mine.first_page_url" page-name="mine_page"
+                            :only="['mine', 'mineState', 'mineCounts']" />
                     </div>
                 </div>
 

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -145,10 +145,14 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
         <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
 
             <div class="mb-6">
-                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-500/15 border border-emerald-400/30 text-emerald-300 text-xs font-bold uppercase tracking-wider mb-4">
-                    Amnesty
+                <!-- Label beside the heading, not above it: on its own line it
+                     cost a whole row of the fold to say one word. -->
+                <div class="flex items-center gap-3 flex-wrap mb-3">
+                    <h1 class="text-2xl md:text-3xl font-black text-white">Withdraw your own times</h1>
+                    <span class="px-3 py-1 rounded-full bg-emerald-500/15 border border-emerald-400/30 text-emerald-300 text-xs font-bold uppercase tracking-wider">
+                        Amnesty
+                    </span>
                 </div>
-                <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Withdraw your own times</h1>
                 <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
                     If a time of yours should not be standing - wrong cvar, a run that was never
                     legitimate, anything - take it down yourself. Tick as many as you like and withdraw

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -219,7 +219,7 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
 
             <!-- Three facts people ask before clicking, and the one reason to
                  do it now rather than later. -->
-            <div class="grid gap-3 md:grid-cols-3 mb-8">
+            <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-4 mb-8">
                 <div class="rounded-xl border border-white/10 bg-black/40 p-4">
                     <div class="text-white font-bold text-sm mb-1">You cannot take it back</div>
                     <p class="text-gray-400 text-sm leading-relaxed">
@@ -234,6 +234,14 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                         putting the leaderboard right, because that is what it is.
                     </p>
                 </div>
+                <div class="rounded-xl border border-white/10 bg-black/40 p-4">
+                    <div class="text-white font-bold text-sm mb-1">Beating it settles it</div>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        Go back and run the map properly, and the new time replaces the old one on its
+                        own. Your request closes itself as beaten - no admin, no waiting.
+                    </p>
+                </div>
+
                 <div class="rounded-xl border border-red-400/25 bg-red-500/[0.07] p-4">
                     <div class="text-red-300 font-bold text-sm mb-1">Only while you are ahead of a report</div>
                     <p class="text-gray-400 text-sm leading-relaxed">
@@ -358,10 +366,12 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                                 <div class="flex items-center gap-2 flex-wrap">
                                     <span class="font-semibold text-white">{{ row.mapname }}</span>
                                     <span class="text-[11px] px-2 py-0.5 rounded border font-bold"
-                                        :class="row.processed
-                                            ? 'border-green-400/30 bg-green-500/15 text-green-300'
-                                            : 'border-amber-400/40 bg-amber-500/15 text-amber-200'">
-                                        {{ row.processed ? 'Off the board' : (row.handling === 'immediate' ? 'Waiting for an admin' : 'Queued for the MDD merge') }}
+                                        :class="row.beaten
+                                            ? 'border-blue-400/30 bg-blue-500/15 text-blue-200'
+                                            : row.processed
+                                                ? 'border-green-400/30 bg-green-500/15 text-green-300'
+                                                : 'border-amber-400/40 bg-amber-500/15 text-amber-200'">
+                                        {{ row.state }}
                                     </span>
                                 </div>
                                 <div class="text-sm text-gray-400 mt-0.5">

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -181,8 +181,8 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                 <div class="rounded-xl border border-white/10 bg-black/40 p-4">
                     <div class="text-white font-bold text-sm mb-1">It happens immediately</div>
                     <p class="text-gray-400 text-sm leading-relaxed">
-                        The times come off the leaderboard when you confirm. Nothing is wiped from the
-                        database, so an admin can put a run back if you pick the wrong one.
+                        The times come off the leaderboard the moment you confirm, and you cannot take
+                        that back. Check what you have ticked before you do it.
                     </p>
                 </div>
                 <div class="rounded-xl border border-white/10 bg-black/40 p-4">
@@ -300,16 +300,22 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                 </div>
 
                 <div v-if="mine.length" class="mt-6 bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
-                    <div class="p-4 border-b border-white/5 text-white font-bold">
-                        Times you have withdrawn
-                        <span class="font-normal text-gray-500 text-sm">- visible to you and the admin only</span>
+                    <div class="p-4 border-b border-white/5 flex flex-wrap items-baseline gap-x-3">
+                        <span class="text-white font-bold">Runs you have withdrawn</span>
+                        <span class="text-gray-500 text-sm">{{ mine.length }} in total, and why</span>
+                        <span class="ml-auto text-xs text-gray-600">Visible to you and the site admin. Nobody else.</span>
                     </div>
                     <div class="divide-y divide-white/5">
                         <div v-for="row in mine" :key="row.id" class="p-4 flex flex-wrap items-center gap-x-4 gap-y-1">
-                            <div class="min-w-0 flex-1 font-semibold text-white">{{ row.mapname }}</div>
-                            <div class="text-sm text-gray-400 uppercase">{{ row.physics }} {{ row.mode }}</div>
-                            <div class="font-mono text-sm text-gray-300">{{ formatTime(row.time) }}</div>
-                            <div class="text-sm text-gray-500">{{ fmtDate(row.created_at) }}</div>
+                            <div class="min-w-0 flex-1">
+                                <div class="font-semibold text-white">{{ row.mapname }}</div>
+                                <div class="text-sm text-gray-400 mt-0.5">
+                                    {{ row.reason }}<span v-if="row.note" class="text-gray-500"> - {{ row.note }}</span>
+                                </div>
+                            </div>
+                            <div class="text-sm text-gray-400 uppercase whitespace-nowrap">{{ row.physics }} {{ row.mode }}</div>
+                            <div class="font-mono text-sm text-gray-300 whitespace-nowrap">{{ formatTime(row.time) }}</div>
+                            <div class="text-sm text-gray-500 whitespace-nowrap">{{ fmtDate(row.created_at) }}</div>
                         </div>
                     </div>
                 </div>
@@ -369,7 +375,7 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
                         <div class="flex items-center gap-4">
                             <label class="flex items-center gap-2 text-sm text-gray-300 max-w-xs">
                                 <input type="checkbox" v-model="form.confirm" class="w-5 h-5 rounded bg-black/50 border-white/20 text-emerald-500" />
-                                <span>I understand only an admin can put them back.</span>
+                                <span>I understand this cannot be taken back.</span>
                             </label>
 
                             <button type="submit" :disabled="form.processing"

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -139,26 +139,28 @@ const thumb = (path) => path ? `/storage/${path}` : '/images/unknown.jpg';
 <template>
     <Head title="Amnesty - self report" />
 
-    <!-- Bottom padding leaves room for the action bar, which is fixed and
-         would otherwise cover the last rows of the list. -->
-    <div class="min-h-screen py-10" :class="pickedCount ? 'pb-56' : ''">
-        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
-
-            <div class="mb-6">
-                <!-- Label beside the heading, not above it: on its own line it
-                     cost a whole row of the fold to say one word. -->
-                <div class="flex items-center gap-3 flex-wrap mb-3">
-                    <h1 class="text-2xl md:text-3xl font-black text-white">Withdraw your own times</h1>
-                    <span class="px-3 py-1 rounded-full bg-emerald-500/15 border border-emerald-400/30 text-emerald-300 text-xs font-bold uppercase tracking-wider">
+    <div class="">
+        <!-- Header Section - same shape as Servers, Records and Ranking. -->
+        <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
+            <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">
+                <div class="flex justify-between items-center flex-wrap gap-4">
+                    <h1 class="text-2xl md:text-3xl font-black text-gray-300/90">
                         Amnesty
-                    </span>
+                    </h1>
                 </div>
-                <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
+
+                <p class="text-gray-400 mt-2 max-w-3xl">
                     If a time of yours should not be standing - wrong cvar, a run that was never
                     legitimate, anything - take it down yourself. Tick as many as you like and withdraw
                     them in one go.
                 </p>
             </div>
+        </div>
+
+        <!-- Bottom padding leaves room for the action bar, which is fixed and
+             would otherwise cover the last rows of the list. -->
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12" :class="pickedCount ? 'pb-56' : ''"
+            style="margin-top: -22rem;">
 
             <!-- Said once, loudly, before anything else. The single reason
                  somebody would not use this is the fear that using it is itself

--- a/resources/js/Pages/SelfReport.vue
+++ b/resources/js/Pages/SelfReport.vue
@@ -1,0 +1,219 @@
+<script>
+import MainLayout from '@/Layouts/MainLayout.vue';
+
+export default {
+    layout: MainLayout,
+};
+</script>
+
+<script setup>
+import { Head, Link, router, useForm } from '@inertiajs/vue3';
+import { getCurrentInstance, ref, watch } from 'vue';
+
+const props = defineProps({
+    hasMddAccount: { type: Boolean, default: false },
+    records: { type: Array, default: () => [] },
+    search: { type: String, default: '' },
+    totalRecords: { type: Number, default: 0 },
+    reasons: { type: Object, default: () => ({}) },
+    mine: { type: Array, default: () => [] },
+});
+
+const { proxy } = getCurrentInstance();
+const formatTime = proxy.formatTime;
+
+const search = ref(props.search);
+
+// Searching is a GET reload rather than client-side filtering: only the 60
+// most recent runs are sent, so filtering what arrived would silently hide
+// everything older than that.
+let searchTimer = null;
+watch(search, (value) => {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+        router.get('/self-report', { search: value }, {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        });
+    }, 350);
+});
+
+const selected = ref(null);
+
+const form = useForm({
+    record_id: null,
+    reason: 'other',
+    note: '',
+    confirm: false,
+});
+
+const pick = (record) => {
+    selected.value = record;
+    form.record_id = record.id;
+    form.reason = 'other';
+    form.note = '';
+    form.confirm = false;
+    form.clearErrors();
+};
+
+const submit = () => {
+    form.post('/self-report', {
+        preserveScroll: true,
+        onSuccess: () => {
+            selected.value = null;
+            form.reset();
+        },
+    });
+};
+
+const fmtDate = (value) => value ? new Date(value).toLocaleDateString() : '';
+</script>
+
+<template>
+    <Head title="Withdraw your own time" />
+
+    <div class="min-h-screen py-10">
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
+
+            <div class="mb-8">
+                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/15 border border-blue-400/30 text-blue-300 text-xs font-bold uppercase tracking-wider mb-4">
+                    Amnesty
+                </div>
+                <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Withdraw your own time</h1>
+                <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
+                    If one of your times should not be standing - wrong cvar, a run that was never
+                    legitimate, anything - take it down yourself. It costs you nothing: no validator, no
+                    verdict, no mark on your account. The time goes and the
+                    <Link href="/validation-log" class="text-purple-300 hover:underline">validation log</Link>
+                    says you took it down.
+                </p>
+            </div>
+
+            <div class="grid gap-6 lg:grid-cols-3 mb-6">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                    <h2 class="text-white font-bold mb-2">It is immediate and final</h2>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        The record is deleted the moment you confirm. We cannot put it back, so pick the
+                        right run.
+                    </p>
+                </div>
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                    <h2 class="text-white font-bold mb-2">Nothing else happens to you</h2>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        A withdrawn time is not a case and is not reviewed. Doing this is treated as
+                        putting the leaderboard right, because that is what it is.
+                    </p>
+                </div>
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                    <h2 class="text-white font-bold mb-2">Your name is in the log</h2>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        The time was public and its disappearance is public, so the log says where it
+                        went. Hiding that would be the quiet edit this is meant to replace.
+                    </p>
+                </div>
+            </div>
+
+            <div v-if="!hasMddAccount" class="bg-black/40 border border-yellow-400/30 rounded-2xl p-6 text-yellow-200">
+                Your account is not linked to an MDD profile, so there are no records tied to it here.
+                Link it in your settings first.
+            </div>
+
+            <template v-else>
+                <div class="grid gap-6 lg:grid-cols-2">
+
+                    <!-- Your runs -->
+                    <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                        <div class="p-4 border-b border-white/5 flex items-center gap-3">
+                            <input v-model="search" type="text" placeholder="Search your maps..."
+                                class="flex-1 bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50" />
+                            <span class="text-xs text-gray-500 whitespace-nowrap">{{ totalRecords }} total</span>
+                        </div>
+
+                        <div v-if="!records.length" class="p-8 text-center text-gray-500">
+                            No runs found.
+                        </div>
+                        <div v-else class="divide-y divide-white/5 max-h-[32rem] overflow-y-auto">
+                            <button v-for="record in records" :key="record.id" type="button" @click="pick(record)"
+                                class="w-full text-left p-4 flex items-center gap-3 hover:bg-white/5 transition-colors"
+                                :class="selected && selected.id === record.id ? 'bg-purple-500/10' : ''">
+                                <div class="min-w-0 flex-1">
+                                    <div class="font-semibold text-white truncate">{{ record.mapname }}</div>
+                                    <div class="text-xs text-gray-500 mt-0.5">
+                                        {{ record.physics }} {{ record.mode }} · {{ fmtDate(record.date_set) }}
+                                    </div>
+                                </div>
+                                <div class="font-mono text-sm text-gray-300 whitespace-nowrap">{{ formatTime(record.time) }}</div>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- The confirmation -->
+                    <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                        <div v-if="!selected" class="text-gray-500 py-12 text-center">
+                            Pick one of your runs on the left.
+                        </div>
+
+                        <form v-else @submit.prevent="submit" class="space-y-4">
+                            <div>
+                                <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Withdrawing</div>
+                                <div class="text-xl font-black text-white">{{ selected.mapname }}</div>
+                                <div class="text-sm text-gray-400 mt-0.5">
+                                    {{ selected.physics }} {{ selected.mode }} · <span class="font-mono">{{ formatTime(selected.time) }}</span>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label class="block text-sm text-gray-300 mb-1">What was wrong with it</label>
+                                <select v-model="form.reason"
+                                    class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-purple-400/50">
+                                    <option v-for="(label, key) in reasons" :key="key" :value="key">{{ label }}</option>
+                                </select>
+                                <div v-if="form.errors.reason" class="text-red-400 text-sm mt-1">{{ form.errors.reason }}</div>
+                            </div>
+
+                            <div>
+                                <label class="block text-sm text-gray-300 mb-1">Anything to add (optional, public)</label>
+                                <textarea v-model="form.note" rows="3" maxlength="500"
+                                    class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50"
+                                    placeholder="Shown in the validation log next to the withdrawn time."></textarea>
+                                <div v-if="form.errors.note" class="text-red-400 text-sm mt-1">{{ form.errors.note }}</div>
+                            </div>
+
+                            <label class="flex items-start gap-3 text-sm text-gray-300">
+                                <input type="checkbox" v-model="form.confirm" class="mt-1 rounded bg-black/50 border-white/20" />
+                                <span>I understand this deletes the time immediately and it cannot be restored.</span>
+                            </label>
+                            <div v-if="form.errors.confirm" class="text-red-400 text-sm">{{ form.errors.confirm }}</div>
+                            <div v-if="form.errors.record_id" class="text-red-400 text-sm">{{ form.errors.record_id }}</div>
+
+                            <div class="flex gap-3">
+                                <button type="submit" :disabled="form.processing"
+                                    class="px-5 py-2.5 rounded-lg bg-red-500/80 hover:bg-red-500 text-white font-bold transition-colors disabled:opacity-50">
+                                    Withdraw this time
+                                </button>
+                                <button type="button" @click="selected = null"
+                                    class="px-5 py-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-gray-300 font-bold transition-colors">
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div v-if="mine.length" class="mt-6 bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                    <div class="p-4 border-b border-white/5 text-white font-bold">Times you have withdrawn</div>
+                    <div class="divide-y divide-white/5">
+                        <div v-for="row in mine" :key="row.id" class="p-4 flex flex-wrap items-center gap-x-4 gap-y-1">
+                            <div class="min-w-0 flex-1 font-semibold text-white">{{ row.mapname }}</div>
+                            <div class="text-sm text-gray-400 uppercase">{{ row.physics }} {{ row.mode }}</div>
+                            <div class="font-mono text-sm text-gray-300">{{ formatTime(row.time) }}</div>
+                            <div class="text-sm text-gray-500">{{ fmtDate(row.created_at) }}</div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/ValidationLog.vue
+++ b/resources/js/Pages/ValidationLog.vue
@@ -14,13 +14,11 @@ const props = defineProps({
     stats: { type: Object, default: () => ({}) },
     closed: { type: Array, default: () => [] },
     open: { type: Array, default: () => [] },
-    selfReports: { type: Array, default: () => [] },
     minReports: { type: Number, default: 2 },
 });
 
 const { proxy } = getCurrentInstance();
 const q3tohtml = proxy.q3tohtml;
-const formatTime = proxy.formatTime;
 
 const tab = ref('closed');
 
@@ -49,7 +47,6 @@ const kindLabel = (kind) => kind === 'public_demo' ? 'Uploaded demo' : 'Serverde
 const tabs = computed(() => [
     { key: 'closed', label: 'Decided', count: props.closed.length },
     { key: 'open', label: 'In progress', count: props.open.length },
-    { key: 'self', label: 'Withdrawn by the player', count: props.selfReports.length },
 ]);
 </script>
 
@@ -105,7 +102,7 @@ const tabs = computed(() => [
                     { label: 'Being validated', value: stats.in_validation },
                     { label: 'Upheld', value: stats.upheld, tone: 'text-red-300' },
                     { label: 'Cleared', value: stats.dismissed, tone: 'text-green-300' },
-                    { label: 'Withdrawn by the player', value: stats.self_reports, tone: 'text-blue-300' },
+                    { label: 'Inconclusive', value: stats.inconclusive },
                 ]" :key="cell.label" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-4">
                     <div class="text-2xl font-black" :class="cell.tone || 'text-white'">{{ cell.value ?? 0 }}</div>
                     <div class="text-[11px] uppercase tracking-wide text-gray-500 mt-1">{{ cell.label }}</div>
@@ -160,7 +157,7 @@ const tabs = computed(() => [
             </div>
 
             <!-- Open cases, anonymous -->
-            <div v-else-if="tab === 'open'" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+            <div v-else class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
                 <div v-if="!open.length" class="p-8 text-center text-gray-500">
                     Nothing is being validated right now.
                 </div>
@@ -186,32 +183,22 @@ const tabs = computed(() => [
                 </div>
             </div>
 
-            <!-- Self-reports -->
-            <div v-else class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
-                <div class="p-4 md:p-5 border-b border-white/5 text-sm text-gray-400">
-                    Times their own owners took down. No validation, no verdict, no mark on the account -
-                    <Link href="/self-report" class="text-purple-300 hover:underline">withdraw one of yours</Link>.
-                </div>
-                <div v-if="!selfReports.length" class="p-8 text-center text-gray-500">
-                    Nobody has withdrawn a time yet.
-                </div>
-                <div v-else class="divide-y divide-white/5">
-                    <div v-for="row in selfReports" :key="row.id" class="p-4 md:p-5 flex flex-wrap items-center gap-x-4 gap-y-2">
-                        <div class="min-w-0 flex-1">
-                            <div class="flex items-center gap-2 flex-wrap">
-                                <Link v-if="row.user_id" :href="`/profile/${row.user_id}`"
-                                    class="font-bold hover:underline" v-html="q3tohtml(row.player)" />
-                                <span v-else class="font-bold text-white" v-html="q3tohtml(row.player)"></span>
-                                <span class="text-gray-500">on</span>
-                                <Link :href="`/maps/${row.mapname}`" class="text-white font-semibold hover:underline">{{ row.mapname }}</Link>
-                            </div>
-                            <div class="text-sm text-gray-400 mt-1">{{ row.reason }}<span v-if="row.note"> - {{ row.note }}</span></div>
-                        </div>
-                        <div class="text-sm text-gray-400 uppercase whitespace-nowrap">{{ row.physics }}</div>
-                        <div class="font-mono text-white whitespace-nowrap">{{ formatTime(row.time) }}</div>
-                        <div class="text-sm text-gray-500 whitespace-nowrap">{{ fmtDate(row.created_at) }}</div>
-                    </div>
-                </div>
+            <!-- The way out, on the page somebody reads when they are worried.
+                 No numbers and no list: what gets withdrawn is private, and
+                 saying "3 people did this" against a leaderboard anyone can
+                 diff would not be. -->
+            <div class="mt-6 rounded-2xl border border-blue-400/25 bg-blue-500/[0.07] p-5">
+                <h2 class="text-white font-bold mb-2">Standing on a time that should not count?</h2>
+                <p class="text-gray-300 text-sm leading-relaxed max-w-3xl">
+                    Take it down yourself and none of this happens to you. No case, no validators, no
+                    entry on this page - it is between you and the admin, and nothing goes on your
+                    account. Once somebody else reports it, that choice is gone: it becomes a case, and
+                    when the case is decided it is published here with your name on it.
+                </p>
+                <Link href="/self-report"
+                    class="inline-flex mt-3 px-4 py-2 rounded-lg bg-blue-500/80 hover:bg-blue-500 text-white text-sm font-bold transition-colors">
+                    Withdraw one of your times
+                </Link>
             </div>
 
         </div>

--- a/resources/js/Pages/ValidationLog.vue
+++ b/resources/js/Pages/ValidationLog.vue
@@ -53,23 +53,24 @@ const tabs = computed(() => [
 <template>
     <Head title="Validation log" />
 
-    <div class="min-h-screen py-10">
-        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
-
-            <div class="mb-8">
-                <!-- Label beside the heading, not above it: on its own line it
-                     cost a whole row of the fold to say two words. -->
-                <div class="flex items-center gap-3 flex-wrap mb-3">
-                    <h1 class="text-2xl md:text-3xl font-black text-white">Validation log</h1>
-                    <span class="px-3 py-1 rounded-full bg-purple-500/15 border border-purple-400/30 text-purple-300 text-xs font-bold uppercase tracking-wider">
-                        Public record
-                    </span>
+    <div class="">
+        <!-- Header Section - same shape as Servers, Records and Ranking. -->
+        <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
+            <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">
+                <div class="flex justify-between items-center flex-wrap gap-4">
+                    <h1 class="text-2xl md:text-3xl font-black text-gray-300/90">
+                        Validation log
+                    </h1>
                 </div>
-                <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
+
+                <p class="text-gray-400 mt-2 max-w-3xl">
                     Every report filed on this site, and what came of it. Nothing is enforced against anyone
                     before it can be read here.
                 </p>
             </div>
+        </div>
+
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12" style="margin-top: -22rem;">
 
             <!-- The rules of the log itself, stated on the log. Somebody who
                  arrives here because they were reported should not have to ask

--- a/resources/js/Pages/ValidationLog.vue
+++ b/resources/js/Pages/ValidationLog.vue
@@ -57,10 +57,14 @@ const tabs = computed(() => [
         <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
 
             <div class="mb-8">
-                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-500/15 border border-purple-400/30 text-purple-300 text-xs font-bold uppercase tracking-wider mb-4">
-                    Public record
+                <!-- Label beside the heading, not above it: on its own line it
+                     cost a whole row of the fold to say two words. -->
+                <div class="flex items-center gap-3 flex-wrap mb-3">
+                    <h1 class="text-2xl md:text-3xl font-black text-white">Validation log</h1>
+                    <span class="px-3 py-1 rounded-full bg-purple-500/15 border border-purple-400/30 text-purple-300 text-xs font-bold uppercase tracking-wider">
+                        Public record
+                    </span>
                 </div>
-                <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Validation log</h1>
                 <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
                     Every report filed on this site, and what came of it. Nothing is enforced against anyone
                     before it can be read here.

--- a/resources/js/Pages/ValidationLog.vue
+++ b/resources/js/Pages/ValidationLog.vue
@@ -199,7 +199,7 @@ const tabs = computed(() => [
                     account. Once somebody else reports it, that choice is gone: it becomes a case, and
                     when the case is decided it is published here with your name on it.
                 </p>
-                <Link href="/self-report"
+                <Link href="/amnesty"
                     class="inline-flex mt-3 px-4 py-2 rounded-lg bg-blue-500/80 hover:bg-blue-500 text-white text-sm font-bold transition-colors">
                     Withdraw one of your times
                 </Link>

--- a/resources/js/Pages/ValidationLog.vue
+++ b/resources/js/Pages/ValidationLog.vue
@@ -1,0 +1,219 @@
+<script>
+import MainLayout from '@/Layouts/MainLayout.vue';
+
+export default {
+    layout: MainLayout,
+};
+</script>
+
+<script setup>
+import { Head, Link } from '@inertiajs/vue3';
+import { computed, getCurrentInstance, ref } from 'vue';
+
+const props = defineProps({
+    stats: { type: Object, default: () => ({}) },
+    closed: { type: Array, default: () => [] },
+    open: { type: Array, default: () => [] },
+    selfReports: { type: Array, default: () => [] },
+    minReports: { type: Number, default: 2 },
+});
+
+const { proxy } = getCurrentInstance();
+const q3tohtml = proxy.q3tohtml;
+const formatTime = proxy.formatTime;
+
+const tab = ref('closed');
+
+const fmtDate = (iso) => {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+};
+
+// How long an open case has been sitting there. The point of publishing this
+// is that nobody can quietly leave one alone, so it is stated in days rather
+// than as a date somebody has to subtract in their head.
+const daysOpen = (iso) => {
+    if (!iso) return 0;
+    return Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 86400000));
+};
+
+const outcomeClass = (key) => ({
+    upheld: 'bg-red-500/15 border-red-400/30 text-red-300',
+    dismissed: 'bg-green-500/15 border-green-400/30 text-green-300',
+    inconclusive: 'bg-white/5 border-white/15 text-gray-300',
+}[key] || 'bg-white/5 border-white/15 text-gray-300');
+
+const kindLabel = (kind) => kind === 'public_demo' ? 'Uploaded demo' : 'Serverdemo';
+
+const tabs = computed(() => [
+    { key: 'closed', label: 'Decided', count: props.closed.length },
+    { key: 'open', label: 'In progress', count: props.open.length },
+    { key: 'self', label: 'Withdrawn by the player', count: props.selfReports.length },
+]);
+</script>
+
+<template>
+    <Head title="Validation log" />
+
+    <div class="min-h-screen py-10">
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
+
+            <div class="mb-8">
+                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-500/15 border border-purple-400/30 text-purple-300 text-xs font-bold uppercase tracking-wider mb-4">
+                    Public record
+                </div>
+                <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Validation log</h1>
+                <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
+                    Every report filed on this site, and what came of it. Nothing is enforced against anyone
+                    before it can be read here.
+                </p>
+            </div>
+
+            <!-- The rules of the log itself, stated on the log. Somebody who
+                 arrives here because they were reported should not have to ask
+                 what will and will not be published about them. -->
+            <div class="grid gap-4 mb-8 lg:grid-cols-3">
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                    <h2 class="text-white font-bold mb-2">Names appear when a case is decided</h2>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        Whichever way it went. Publishing only the upheld ones would hide every time the
+                        process cleared somebody, and that is the half that shows it works.
+                    </p>
+                </div>
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                    <h2 class="text-white font-bold mb-2">Open cases stay anonymous</h2>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        An unchecked accusation is not a verdict. You can see how many there are, what
+                        stage they are at and how long they have been waiting, but not who they are about.
+                    </p>
+                </div>
+                <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5">
+                    <h2 class="text-white font-bold mb-2">Reporters are never named</h2>
+                    <p class="text-gray-400 text-sm leading-relaxed">
+                        At any stage. A report is not evidence, it is a request to go and look, and it
+                        takes at least {{ minReports }} different people before it becomes a case at all.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Numbers first: the shape of the whole thing before the rows. -->
+            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
+                <div v-for="cell in [
+                    { label: 'Reports filed', value: stats.reports },
+                    { label: 'Waiting on the admin', value: stats.awaiting_admin },
+                    { label: 'Being validated', value: stats.in_validation },
+                    { label: 'Upheld', value: stats.upheld, tone: 'text-red-300' },
+                    { label: 'Cleared', value: stats.dismissed, tone: 'text-green-300' },
+                    { label: 'Withdrawn by the player', value: stats.self_reports, tone: 'text-blue-300' },
+                ]" :key="cell.label" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-xl p-4">
+                    <div class="text-2xl font-black" :class="cell.tone || 'text-white'">{{ cell.value ?? 0 }}</div>
+                    <div class="text-[11px] uppercase tracking-wide text-gray-500 mt-1">{{ cell.label }}</div>
+                </div>
+            </div>
+
+            <div class="flex flex-wrap gap-2 mb-4">
+                <button v-for="t in tabs" :key="t.key" @click="tab = t.key"
+                    class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
+                    :class="tab === t.key
+                        ? 'bg-purple-500/20 border-purple-400/40 text-purple-200'
+                        : 'bg-black/30 border-white/10 text-gray-400 hover:text-white hover:border-white/25'">
+                    {{ t.label }}
+                    <span class="ml-1.5 text-xs opacity-70">{{ t.count }}</span>
+                </button>
+            </div>
+
+            <!-- Decided cases -->
+            <div v-if="tab === 'closed'" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                <div v-if="!closed.length" class="p-8 text-center text-gray-500">
+                    Nothing has been decided yet.
+                </div>
+                <div v-else class="divide-y divide-white/5">
+                    <div v-for="row in closed" :key="row.id" class="p-4 md:p-5 flex flex-wrap items-center gap-x-4 gap-y-2">
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center gap-2 flex-wrap">
+                                <Link v-if="row.user_id" :href="`/profile/${row.user_id}`"
+                                    class="font-bold hover:underline" v-html="q3tohtml(row.player)" />
+                                <span v-else class="font-bold text-white" v-html="q3tohtml(row.player)"></span>
+                                <span class="text-[11px] px-2 py-0.5 rounded border border-white/10 bg-white/5 text-gray-400">
+                                    {{ kindLabel(row.kind) }}
+                                </span>
+                            </div>
+                            <div class="text-sm text-gray-400 mt-1">
+                                <span v-for="(reason, i) in row.reasons" :key="reason.label">
+                                    <span v-if="i">, </span>{{ reason.label }}<span v-if="reason.count > 1"> ×{{ reason.count }}</span>
+                                </span>
+                                <span v-if="!row.reasons.length">Reported runs: {{ row.runs }}</span>
+                            </div>
+                        </div>
+                        <div class="text-sm text-gray-500 whitespace-nowrap">
+                            {{ row.runs }} run<span v-if="row.runs !== 1">s</span>
+                        </div>
+                        <div class="text-sm text-gray-500 whitespace-nowrap">
+                            {{ fmtDate(row.opened_at) }} → {{ fmtDate(row.closed_at) }}
+                        </div>
+                        <div class="px-3 py-1 rounded-lg border text-xs font-bold whitespace-nowrap" :class="outcomeClass(row.outcome_key)">
+                            {{ row.outcome }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Open cases, anonymous -->
+            <div v-else-if="tab === 'open'" class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                <div v-if="!open.length" class="p-8 text-center text-gray-500">
+                    Nothing is being validated right now.
+                </div>
+                <div v-else class="divide-y divide-white/5">
+                    <div v-for="row in open" :key="row.id" class="p-4 md:p-5 flex flex-wrap items-center gap-x-4 gap-y-2">
+                        <div class="min-w-0 flex-1">
+                            <div class="font-bold text-gray-300">Case #{{ row.id }}</div>
+                            <div class="text-sm text-gray-500 mt-1">
+                                Name withheld until it is decided.
+                            </div>
+                        </div>
+                        <span class="text-[11px] px-2 py-0.5 rounded border border-white/10 bg-white/5 text-gray-400 whitespace-nowrap">
+                            {{ kindLabel(row.kind) }}
+                        </span>
+                        <div class="text-sm text-gray-500 whitespace-nowrap">
+                            {{ row.runs }} run<span v-if="row.runs !== 1">s</span>
+                        </div>
+                        <div class="text-sm text-gray-400 whitespace-nowrap">{{ row.stage }}</div>
+                        <div class="text-sm text-gray-500 whitespace-nowrap">
+                            open {{ daysOpen(row.opened_at) }}d
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Self-reports -->
+            <div v-else class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden">
+                <div class="p-4 md:p-5 border-b border-white/5 text-sm text-gray-400">
+                    Times their own owners took down. No validation, no verdict, no mark on the account -
+                    <Link href="/self-report" class="text-purple-300 hover:underline">withdraw one of yours</Link>.
+                </div>
+                <div v-if="!selfReports.length" class="p-8 text-center text-gray-500">
+                    Nobody has withdrawn a time yet.
+                </div>
+                <div v-else class="divide-y divide-white/5">
+                    <div v-for="row in selfReports" :key="row.id" class="p-4 md:p-5 flex flex-wrap items-center gap-x-4 gap-y-2">
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center gap-2 flex-wrap">
+                                <Link v-if="row.user_id" :href="`/profile/${row.user_id}`"
+                                    class="font-bold hover:underline" v-html="q3tohtml(row.player)" />
+                                <span v-else class="font-bold text-white" v-html="q3tohtml(row.player)"></span>
+                                <span class="text-gray-500">on</span>
+                                <Link :href="`/maps/${row.mapname}`" class="text-white font-semibold hover:underline">{{ row.mapname }}</Link>
+                            </div>
+                            <div class="text-sm text-gray-400 mt-1">{{ row.reason }}<span v-if="row.note"> - {{ row.note }}</span></div>
+                        </div>
+                        <div class="text-sm text-gray-400 uppercase whitespace-nowrap">{{ row.physics }}</div>
+                        <div class="font-mono text-white whitespace-nowrap">{{ formatTime(row.time) }}</div>
+                        <div class="text-sm text-gray-500 whitespace-nowrap">{{ fmtDate(row.created_at) }}</div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -48,9 +48,13 @@ const vote = (wish, value) => {
     router.post(`/wishlist/${wish.id}/vote`, { value }, { preserveScroll: true, preserveState: true });
 };
 
-const remove = (wish) => {
-    if (!confirm('Remove this wish?')) return;
-    router.delete(`/wishlist/${wish.id}`, { preserveScroll: true });
+// Asking, not deleting. Other people have voted on this by now, so taking it
+// down is the admin's call and the wish stays up meanwhile.
+const askRemoval = (wish) => {
+    const reason = prompt('Ask an admin to remove this wish. Why? (optional)');
+    if (reason === null) return;
+
+    router.post(`/wishlist/${wish.id}/request-removal`, { reason }, { preserveScroll: true });
 };
 
 // Both filters go through the same call so picking one never silently drops
@@ -66,6 +70,9 @@ const applyFilters = (status, project) => {
 const setFilter = (status) => applyFilters(status, props.projectFilter);
 const setProject = (project) => applyFilters(props.filter, project);
 
+const totalWishes = computed(() => Object.values(props.projectCounts || {})
+    .reduce((sum, count) => sum + Number(count || 0), 0));
+
 const statusClass = (status) => ({
     considering: 'bg-white/5 border-white/15 text-gray-300',
     planned: 'bg-blue-500/15 border-blue-400/30 text-blue-300',
@@ -79,34 +86,39 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
 <template>
     <Head title="Wishlist" />
 
-    <div class="min-h-screen py-10">
-        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
+    <div class="">
+        <!-- Header Section - same shape as Servers, Records and Ranking: the
+             gradient block holds the heading, the content is pulled up under
+             it. A page of ours that starts differently reads as a page from
+             somewhere else. -->
+        <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">
+            <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pointer-events-auto">
+                <div class="flex justify-between items-center flex-wrap gap-4">
+                    <h1 class="text-2xl md:text-3xl font-black text-gray-300/90">
+                        Wishlist
+                    </h1>
 
-            <div class="mb-8 flex flex-wrap items-end justify-between gap-4">
-                <div>
-                    <!-- Label beside the heading, not above it: on its own line
-                         it cost a whole row of the fold to say one word. -->
-                    <div class="flex items-center gap-3 flex-wrap mb-3">
-                        <h1 class="text-2xl md:text-3xl font-black text-white">Wishlist</h1>
-                        <span class="px-3 py-1 rounded-full bg-amber-500/15 border border-amber-400/30 text-amber-300 text-xs font-bold uppercase tracking-wider">
-                            Book of wishes
-                        </span>
-                    </div>
-                    <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
-                        What do you want built here? Write it down, and vote on what everyone else wants.
-                        The list is ordered by score, so what the community actually wants sits at the top.
-                    </p>
+                    <button v-if="user" @click="showForm = !showForm"
+                        class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors">
+                        {{ showForm ? 'Close' : 'Add a wish' }}
+                    </button>
+                    <Link v-else href="/login"
+                        class="px-5 py-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-gray-200 font-bold transition-colors">
+                        Log in to add or vote
+                    </Link>
                 </div>
 
-                <button v-if="user" @click="showForm = !showForm"
-                    class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors">
-                    {{ showForm ? 'Close' : 'Add a wish' }}
-                </button>
-                <Link v-else href="/login"
-                    class="px-5 py-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-gray-200 font-bold transition-colors">
-                    Log in to add or vote
-                </Link>
+                <p class="text-gray-400 mt-2 max-w-3xl">
+                    Ask for something to be added or changed, and vote on what other people asked for.
+                    The more votes a request has, the sooner it gets done.
+                </p>
+                <p class="text-gray-500 text-sm italic mt-1">
+                    Yours truly, <Link href="/profile/8" class="not-italic font-semibold hover:text-gray-300 transition-colors">neyo</Link>
+                </p>
             </div>
+        </div>
+
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pb-12" style="margin-top: -22rem;">
 
             <form v-if="showForm && user" @submit.prevent="submit"
                 class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5 mb-6 space-y-4">
@@ -149,34 +161,53 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                 </div>
             </form>
 
-            <!-- Project first, status second: which of our things you care
-                 about narrows the list far harder than what state it is in. -->
-            <div class="flex flex-wrap gap-2 mb-3">
-                <button @click="setProject(null)"
-                    class="px-3 py-1.5 rounded-lg text-sm font-bold border transition-colors"
-                    :class="!projectFilter ? 'bg-blue-500/20 border-blue-400/40 text-blue-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
-                    All projects
-                </button>
-                <button v-for="(label, key) in projects" :key="key" @click="setProject(key)"
-                    class="px-3 py-1.5 rounded-lg text-sm font-bold border transition-colors"
-                    :class="projectFilter === key ? 'bg-blue-500/20 border-blue-400/40 text-blue-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
-                    {{ label }}
-                    <span class="ml-1 text-xs opacity-60">{{ projectCounts[key] || 0 }}</span>
-                </button>
-            </div>
+            <!-- Two questions, two shapes. The projects are a standing menu
+                 down the side; the status is a switch over the list. As two
+                 rows of pills they were one control wearing two hats. -->
+            <div class="lg:grid lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-5">
 
-            <div class="flex flex-wrap gap-2 mb-4">
-                <button @click="setFilter(null)"
-                    class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
-                    :class="!filter ? 'bg-purple-500/20 border-purple-400/40 text-purple-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
-                    Any status
-                </button>
-                <button v-for="(label, key) in statuses" :key="key" @click="setFilter(key)"
-                    class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
-                    :class="filter === key ? 'bg-purple-500/20 border-purple-400/40 text-purple-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
-                    {{ label }}
-                </button>
-            </div>
+                <aside class="mb-4 lg:mb-0">
+                    <div class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-2 lg:sticky lg:top-4">
+                        <div class="px-2 py-1.5 text-[11px] font-bold text-gray-500 uppercase tracking-wider">Projects</div>
+
+                        <!-- Horizontal scroll on small screens, a list on wide
+                             ones: the same buttons either way. -->
+                        <div class="flex lg:block gap-1 overflow-x-auto lg:overflow-visible pb-1 lg:pb-0">
+                            <button @click="setProject(null)"
+                                class="shrink-0 lg:w-full flex items-center justify-between gap-3 px-3 py-2 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap"
+                                :class="!projectFilter ? 'bg-blue-500/20 text-blue-100' : 'text-gray-400 hover:text-white hover:bg-white/10'">
+                                <span>All projects</span>
+                                <span class="text-xs opacity-50">{{ totalWishes }}</span>
+                            </button>
+                            <button v-for="(label, key) in projects" :key="key" @click="setProject(key)"
+                                class="shrink-0 lg:w-full flex items-center justify-between gap-3 px-3 py-2 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap"
+                                :class="projectFilter === key ? 'bg-blue-500/20 text-blue-100' : 'text-gray-400 hover:text-white hover:bg-white/10'">
+                                <span>{{ label }}</span>
+                                <span class="text-xs opacity-50">{{ projectCounts[key] || 0 }}</span>
+                            </button>
+                        </div>
+                    </div>
+                </aside>
+
+                <div class="min-w-0">
+                    <div class="flex flex-wrap items-center gap-3 mb-4">
+                        <div class="flex items-center gap-1 p-1 rounded-xl bg-black/40 border border-white/10">
+                            <button @click="setFilter(null)"
+                                class="px-3 py-1.5 rounded-lg text-sm font-semibold transition-colors"
+                                :class="!filter ? 'bg-purple-500/25 text-purple-100' : 'text-gray-400 hover:text-white hover:bg-white/10'">
+                                Any status
+                            </button>
+                            <button v-for="(label, key) in statuses" :key="key" @click="setFilter(key)"
+                                class="px-3 py-1.5 rounded-lg text-sm font-semibold transition-colors"
+                                :class="filter === key ? 'bg-purple-500/25 text-purple-100' : 'text-gray-400 hover:text-white hover:bg-white/10'">
+                                {{ label }}
+                            </button>
+                        </div>
+
+                        <div class="ml-auto text-xs text-gray-500">
+                            {{ wishes.length }} request<span v-if="wishes.length !== 1">s</span>
+                        </div>
+                    </div>
 
             <div v-if="!wishes.length" class="bg-black/40 border border-white/10 rounded-2xl p-10 text-center text-gray-500">
                 Nothing here yet. Be the first.
@@ -233,9 +264,17 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                             </Link>
                             <span v-else>deleted account</span>
                             <span>{{ fmtDate(wish.created_at) }}</span>
-                            <button v-if="wish.mine" @click="remove(wish)" class="text-red-400 hover:underline">Remove</button>
+                            <span v-if="wish.mine && wish.removal_requested" class="text-amber-300">
+                                Removal requested - waiting for an admin
+                            </span>
+                            <button v-else-if="wish.mine" @click="askRemoval(wish)" class="text-red-400 hover:underline">
+                                Ask an admin to remove it
+                            </button>
                         </div>
                     </div>
+                </div>
+            </div>
+
                 </div>
             </div>
 

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -17,10 +17,22 @@ const props = defineProps({
     projectCounts: { type: Object, default: () => ({}) },
     filter: { type: String, default: null },
     projectFilter: { type: String, default: null },
+    budget: { type: Object, default: null },
 });
 
 const page = usePage();
 const user = computed(() => page.props.auth?.user);
+
+// The vote budget, always on screen. Running out is a rule people should have
+// seen coming, not a button that suddenly refuses.
+const votesLeft = computed(() => props.budget?.left ?? 0);
+const voteError = computed(() => page.props.errors?.vote);
+
+// Taking your own vote back is always allowed, and your own wish is free -
+// only a fresh upvote on somebody else's costs anything.
+const canUpvote = (wish) => !!user.value
+    && !wish.pending
+    && (wish.my_vote === 1 || wish.mine || votesLeft.value > 0);
 
 const showForm = ref(false);
 
@@ -45,6 +57,7 @@ const submit = () => {
 // agrees is a number people stop trusting.
 const vote = (wish, value) => {
     if (!user.value || wish.pending) return;
+    if (value === 1 && !canUpvote(wish)) return;
     router.post(`/wishlist/${wish.id}/vote`, { value }, { preserveScroll: true, preserveState: true });
 };
 
@@ -204,9 +217,33 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                             </button>
                         </div>
 
+                        <!-- Your votes. Sits next to the list rather than in a
+                             help page, because the number changes as you use
+                             it and that is the whole point of showing it. -->
+                        <div v-if="budget"
+                            class="flex items-center gap-2 px-3 py-1.5 rounded-xl bg-black/40 border"
+                            :class="votesLeft ? 'border-white/10' : 'border-amber-400/40'">
+                            <span class="text-sm font-bold" :class="votesLeft ? 'text-green-300' : 'text-amber-300'">
+                                {{ votesLeft }}
+                            </span>
+                            <span class="text-xs text-gray-500">
+                                of {{ budget.total }} votes left
+                            </span>
+                        </div>
+
                         <div class="ml-auto text-xs text-gray-500">
                             {{ wishes.length }} request<span v-if="wishes.length !== 1">s</span>
                         </div>
+                    </div>
+
+                    <div v-if="budget && !votesLeft" class="mb-4 text-xs text-gray-500">
+                        You have spent all your votes. Take one back from a wish you care less about to
+                        free it up - downvotes and your own wishes never cost you anything.
+                    </div>
+
+                    <div v-if="voteError"
+                        class="mb-4 px-4 py-3 rounded-xl border border-amber-400/40 bg-amber-500/10 text-sm text-amber-200">
+                        {{ voteError }}
                     </div>
 
             <div v-if="!wishes.length" class="bg-black/40 border border-white/10 rounded-2xl p-10 text-center text-gray-500">
@@ -221,8 +258,9 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                          is what the list is sorted by; the split sits under it
                          so a contested wish does not read like an ignored one. -->
                     <div class="flex flex-col items-center gap-1 w-16 shrink-0" :class="wish.pending ? 'opacity-40' : ''">
-                        <button @click="vote(wish, 1)" :disabled="!user || wish.pending"
-                            class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors disabled:opacity-40"
+                        <button @click="vote(wish, 1)" :disabled="!canUpvote(wish)"
+                            :title="user && !canUpvote(wish) ? 'No votes left - take one back from another wish' : ''"
+                            class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                             :class="wish.my_vote === 1 ? 'bg-green-500/25 text-green-300' : 'bg-white/5 text-gray-400 hover:bg-white/10'">
                             <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 4l8 10h-6v6h-4v-6H4z"/></svg>
                         </button>

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -44,7 +44,7 @@ const submit = () => {
 // decides the order of the list, and a number that moves before the server
 // agrees is a number people stop trusting.
 const vote = (wish, value) => {
-    if (!user.value) return;
+    if (!user.value || wish.pending) return;
     router.post(`/wishlist/${wish.id}/vote`, { value }, { preserveScroll: true, preserveState: true });
 };
 
@@ -137,10 +137,16 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                         placeholder="Briefly: what it does, and why it would help."></textarea>
                     <div v-if="form.errors.body" class="text-red-400 text-sm mt-1">{{ form.errors.body }}</div>
                 </div>
-                <button type="submit" :disabled="form.processing"
-                    class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors disabled:opacity-50">
-                    Post it
-                </button>
+                <div class="flex flex-wrap items-center gap-3">
+                    <button type="submit" :disabled="form.processing"
+                        class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors disabled:opacity-50">
+                        Post it
+                    </button>
+                    <span class="text-sm text-gray-500">
+                        An admin reads it before it goes on the list. You will see it here with a
+                        "waiting" mark until then.
+                    </span>
+                </div>
             </form>
 
             <!-- Project first, status second: which of our things you care
@@ -183,8 +189,8 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                     <!-- Score column. The net number is the big one because it
                          is what the list is sorted by; the split sits under it
                          so a contested wish does not read like an ignored one. -->
-                    <div class="flex flex-col items-center gap-1 w-16 shrink-0">
-                        <button @click="vote(wish, 1)" :disabled="!user"
+                    <div class="flex flex-col items-center gap-1 w-16 shrink-0" :class="wish.pending ? 'opacity-40' : ''">
+                        <button @click="vote(wish, 1)" :disabled="!user || wish.pending"
                             class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors disabled:opacity-40"
                             :class="wish.my_vote === 1 ? 'bg-green-500/25 text-green-300' : 'bg-white/5 text-gray-400 hover:bg-white/10'">
                             <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 4l8 10h-6v6h-4v-6H4z"/></svg>
@@ -193,7 +199,7 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                             {{ wish.score > 0 ? '+' : '' }}{{ wish.score }}
                         </div>
                         <div class="text-[10px] text-gray-600 whitespace-nowrap">+{{ wish.upvotes }} / -{{ wish.downvotes }}</div>
-                        <button @click="vote(wish, -1)" :disabled="!user"
+                        <button @click="vote(wish, -1)" :disabled="!user || wish.pending"
                             class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors disabled:opacity-40"
                             :class="wish.my_vote === -1 ? 'bg-red-500/25 text-red-300' : 'bg-white/5 text-gray-400 hover:bg-white/10'">
                             <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 20L4 10h6V4h4v6h6z"/></svg>
@@ -202,6 +208,10 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
 
                     <div class="min-w-0 flex-1">
                         <div class="flex flex-wrap items-center gap-2 mb-1">
+                            <span v-if="wish.pending"
+                                class="text-[11px] px-2 py-0.5 rounded border border-amber-400/40 bg-amber-500/15 text-amber-200 font-bold">
+                                Waiting for approval
+                            </span>
                             <button type="button" @click="setProject(wish.project)"
                                 class="text-[11px] px-2 py-0.5 rounded border border-blue-400/30 bg-blue-500/15 text-blue-200 font-bold hover:bg-blue-500/25 transition-colors">
                                 {{ wish.project_label }}

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -220,7 +220,7 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                         <!-- Your votes. Sits next to the list rather than in a
                              help page, because the number changes as you use
                              it and that is the whole point of showing it. -->
-                        <div v-if="budget"
+                        <div v-if="budget && budget.total"
                             class="flex items-center gap-2 px-3 py-1.5 rounded-xl bg-black/40 border"
                             :class="votesLeft ? 'border-white/10' : 'border-amber-400/40'">
                             <span class="text-sm font-bold" :class="votesLeft ? 'text-green-300' : 'text-amber-300'">
@@ -236,7 +236,7 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                         </div>
                     </div>
 
-                    <div v-if="budget && !votesLeft" class="mb-4 text-xs text-gray-500">
+                    <div v-if="budget && budget.total && !votesLeft" class="mb-4 text-xs text-gray-500">
                         You have spent all your votes. Take one back from a wish you care less about to
                         free it up - downvotes and your own wishes never cost you anything.
                     </div>

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -1,0 +1,184 @@
+<script>
+import MainLayout from '@/Layouts/MainLayout.vue';
+
+export default {
+    layout: MainLayout,
+};
+</script>
+
+<script setup>
+import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+
+const props = defineProps({
+    wishes: { type: Array, default: () => [] },
+    statuses: { type: Object, default: () => ({}) },
+    filter: { type: String, default: null },
+});
+
+const page = usePage();
+const user = computed(() => page.props.auth?.user);
+
+const showForm = ref(false);
+
+const form = useForm({
+    title: '',
+    body: '',
+});
+
+const submit = () => {
+    form.post('/wishlist', {
+        preserveScroll: true,
+        onSuccess: () => {
+            form.reset();
+            showForm.value = false;
+        },
+    });
+};
+
+// Voting is a plain POST rather than an optimistic local update: the score
+// decides the order of the list, and a number that moves before the server
+// agrees is a number people stop trusting.
+const vote = (wish, value) => {
+    if (!user.value) return;
+    router.post(`/wishlist/${wish.id}/vote`, { value }, { preserveScroll: true, preserveState: true });
+};
+
+const remove = (wish) => {
+    if (!confirm('Remove this wish?')) return;
+    router.delete(`/wishlist/${wish.id}`, { preserveScroll: true });
+};
+
+const setFilter = (status) => {
+    router.get('/wishlist', status ? { status } : {}, { preserveScroll: true, preserveState: true, replace: true });
+};
+
+const statusClass = (status) => ({
+    considering: 'bg-white/5 border-white/15 text-gray-300',
+    planned: 'bg-blue-500/15 border-blue-400/30 text-blue-300',
+    done: 'bg-green-500/15 border-green-400/30 text-green-300',
+    rejected: 'bg-red-500/15 border-red-400/30 text-red-300',
+}[status] || 'bg-white/5 border-white/15 text-gray-300');
+
+const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
+</script>
+
+<template>
+    <Head title="Wishlist" />
+
+    <div class="min-h-screen py-10">
+        <div class="max-w-8xl mx-auto px-4 md:px-6 lg:px-8">
+
+            <div class="mb-8 flex flex-wrap items-end justify-between gap-4">
+                <div>
+                    <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-500/15 border border-amber-400/30 text-amber-300 text-xs font-bold uppercase tracking-wider mb-4">
+                        Book of wishes
+                    </div>
+                    <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Wishlist</h1>
+                    <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
+                        What do you want built here? Write it down, and vote on what everyone else wants.
+                        The list is ordered by score, so what the community actually wants sits at the top.
+                    </p>
+                </div>
+
+                <button v-if="user" @click="showForm = !showForm"
+                    class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors">
+                    {{ showForm ? 'Close' : 'Add a wish' }}
+                </button>
+                <Link v-else href="/login"
+                    class="px-5 py-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-gray-200 font-bold transition-colors">
+                    Log in to add or vote
+                </Link>
+            </div>
+
+            <form v-if="showForm && user" @submit.prevent="submit"
+                class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5 mb-6 space-y-4">
+                <div>
+                    <label class="block text-sm text-gray-300 mb-1">Title</label>
+                    <input v-model="form.title" type="text" maxlength="120"
+                        class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50"
+                        placeholder="One line - what do you want?" />
+                    <div v-if="form.errors.title" class="text-red-400 text-sm mt-1">{{ form.errors.title }}</div>
+                </div>
+                <div>
+                    <label class="block text-sm text-gray-300 mb-1">Description</label>
+                    <textarea v-model="form.body" rows="4" maxlength="2000"
+                        class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50"
+                        placeholder="Briefly: what it does, and why it would help."></textarea>
+                    <div v-if="form.errors.body" class="text-red-400 text-sm mt-1">{{ form.errors.body }}</div>
+                </div>
+                <button type="submit" :disabled="form.processing"
+                    class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors disabled:opacity-50">
+                    Post it
+                </button>
+            </form>
+
+            <div class="flex flex-wrap gap-2 mb-4">
+                <button @click="setFilter(null)"
+                    class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
+                    :class="!filter ? 'bg-purple-500/20 border-purple-400/40 text-purple-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
+                    All
+                </button>
+                <button v-for="(label, key) in statuses" :key="key" @click="setFilter(key)"
+                    class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
+                    :class="filter === key ? 'bg-purple-500/20 border-purple-400/40 text-purple-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
+                    {{ label }}
+                </button>
+            </div>
+
+            <div v-if="!wishes.length" class="bg-black/40 border border-white/10 rounded-2xl p-10 text-center text-gray-500">
+                Nothing here yet. Be the first.
+            </div>
+
+            <div v-else class="space-y-3">
+                <div v-for="wish in wishes" :key="wish.id"
+                    class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-4 md:p-5 flex gap-4">
+
+                    <!-- Score column. The net number is the big one because it
+                         is what the list is sorted by; the split sits under it
+                         so a contested wish does not read like an ignored one. -->
+                    <div class="flex flex-col items-center gap-1 w-16 shrink-0">
+                        <button @click="vote(wish, 1)" :disabled="!user"
+                            class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors disabled:opacity-40"
+                            :class="wish.my_vote === 1 ? 'bg-green-500/25 text-green-300' : 'bg-white/5 text-gray-400 hover:bg-white/10'">
+                            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 4l8 10h-6v6h-4v-6H4z"/></svg>
+                        </button>
+                        <div class="text-xl font-black" :class="wish.score > 0 ? 'text-green-300' : wish.score < 0 ? 'text-red-300' : 'text-gray-400'">
+                            {{ wish.score > 0 ? '+' : '' }}{{ wish.score }}
+                        </div>
+                        <div class="text-[10px] text-gray-600 whitespace-nowrap">+{{ wish.upvotes }} / -{{ wish.downvotes }}</div>
+                        <button @click="vote(wish, -1)" :disabled="!user"
+                            class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors disabled:opacity-40"
+                            :class="wish.my_vote === -1 ? 'bg-red-500/25 text-red-300' : 'bg-white/5 text-gray-400 hover:bg-white/10'">
+                            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 20L4 10h6V4h4v6h6z"/></svg>
+                        </button>
+                    </div>
+
+                    <div class="min-w-0 flex-1">
+                        <div class="flex flex-wrap items-center gap-2 mb-1">
+                            <h2 class="text-lg font-bold text-white">{{ wish.title }}</h2>
+                            <span class="text-[11px] px-2 py-0.5 rounded border font-bold" :class="statusClass(wish.status)">
+                                {{ wish.status_label }}
+                            </span>
+                        </div>
+                        <p class="text-gray-300 whitespace-pre-line leading-relaxed">{{ wish.body }}</p>
+
+                        <div v-if="wish.status_note" class="mt-3 border-l-2 border-purple-400/40 pl-3 text-sm text-purple-200">
+                            {{ wish.status_note }}
+                        </div>
+
+                        <div class="mt-3 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                            <Link v-if="wish.author" :href="`/profile/${wish.author.id}`" class="hover:underline">
+                                {{ wish.author.name }}
+                            </Link>
+                            <span v-else>deleted account</span>
+                            <span>{{ fmtDate(wish.created_at) }}</span>
+                            <button v-if="wish.mine" @click="remove(wish)" class="text-red-400 hover:underline">Remove</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -13,7 +13,10 @@ import { computed, ref } from 'vue';
 const props = defineProps({
     wishes: { type: Array, default: () => [] },
     statuses: { type: Object, default: () => ({}) },
+    projects: { type: Object, default: () => ({}) },
+    projectCounts: { type: Object, default: () => ({}) },
     filter: { type: String, default: null },
+    projectFilter: { type: String, default: null },
 });
 
 const page = usePage();
@@ -22,6 +25,7 @@ const user = computed(() => page.props.auth?.user);
 const showForm = ref(false);
 
 const form = useForm({
+    project: 'web',
     title: '',
     body: '',
 });
@@ -49,9 +53,18 @@ const remove = (wish) => {
     router.delete(`/wishlist/${wish.id}`, { preserveScroll: true });
 };
 
-const setFilter = (status) => {
-    router.get('/wishlist', status ? { status } : {}, { preserveScroll: true, preserveState: true, replace: true });
+// Both filters go through the same call so picking one never silently drops
+// the other.
+const applyFilters = (status, project) => {
+    const query = {};
+    if (status) query.status = status;
+    if (project) query.project = project;
+
+    router.get('/wishlist', query, { preserveScroll: true, preserveState: true, replace: true });
 };
+
+const setFilter = (status) => applyFilters(status, props.projectFilter);
+const setProject = (project) => applyFilters(props.filter, project);
 
 const statusClass = (status) => ({
     considering: 'bg-white/5 border-white/15 text-gray-300',
@@ -71,10 +84,14 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
 
             <div class="mb-8 flex flex-wrap items-end justify-between gap-4">
                 <div>
-                    <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-500/15 border border-amber-400/30 text-amber-300 text-xs font-bold uppercase tracking-wider mb-4">
-                        Book of wishes
+                    <!-- Label beside the heading, not above it: on its own line
+                         it cost a whole row of the fold to say one word. -->
+                    <div class="flex items-center gap-3 flex-wrap mb-3">
+                        <h1 class="text-2xl md:text-3xl font-black text-white">Wishlist</h1>
+                        <span class="px-3 py-1 rounded-full bg-amber-500/15 border border-amber-400/30 text-amber-300 text-xs font-bold uppercase tracking-wider">
+                            Book of wishes
+                        </span>
                     </div>
-                    <h1 class="text-2xl md:text-3xl font-black text-white mb-3">Wishlist</h1>
                     <p class="text-gray-300 text-lg leading-relaxed max-w-3xl">
                         What do you want built here? Write it down, and vote on what everyone else wants.
                         The list is ordered by score, so what the community actually wants sits at the top.
@@ -93,6 +110,19 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
 
             <form v-if="showForm && user" @submit.prevent="submit"
                 class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-5 mb-6 space-y-4">
+                <div>
+                    <label class="block text-sm text-gray-300 mb-2">Which project is it about?</label>
+                    <div class="flex flex-wrap gap-2">
+                        <button v-for="(label, key) in projects" :key="key" type="button" @click="form.project = key"
+                            class="px-3 py-1.5 rounded-lg text-sm font-semibold border transition-colors"
+                            :class="form.project === key
+                                ? 'bg-purple-500/20 border-purple-400/50 text-purple-200'
+                                : 'bg-black/40 border-white/10 text-gray-400 hover:text-white hover:border-white/25'">
+                            {{ label }}
+                        </button>
+                    </div>
+                    <div v-if="form.errors.project" class="text-red-400 text-sm mt-1">{{ form.errors.project }}</div>
+                </div>
                 <div>
                     <label class="block text-sm text-gray-300 mb-1">Title</label>
                     <input v-model="form.title" type="text" maxlength="120"
@@ -113,11 +143,27 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                 </button>
             </form>
 
+            <!-- Project first, status second: which of our things you care
+                 about narrows the list far harder than what state it is in. -->
+            <div class="flex flex-wrap gap-2 mb-3">
+                <button @click="setProject(null)"
+                    class="px-3 py-1.5 rounded-lg text-sm font-bold border transition-colors"
+                    :class="!projectFilter ? 'bg-blue-500/20 border-blue-400/40 text-blue-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
+                    All projects
+                </button>
+                <button v-for="(label, key) in projects" :key="key" @click="setProject(key)"
+                    class="px-3 py-1.5 rounded-lg text-sm font-bold border transition-colors"
+                    :class="projectFilter === key ? 'bg-blue-500/20 border-blue-400/40 text-blue-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
+                    {{ label }}
+                    <span class="ml-1 text-xs opacity-60">{{ projectCounts[key] || 0 }}</span>
+                </button>
+            </div>
+
             <div class="flex flex-wrap gap-2 mb-4">
                 <button @click="setFilter(null)"
                     class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
                     :class="!filter ? 'bg-purple-500/20 border-purple-400/40 text-purple-200' : 'bg-black/30 border-white/10 text-gray-400 hover:text-white'">
-                    All
+                    Any status
                 </button>
                 <button v-for="(label, key) in statuses" :key="key" @click="setFilter(key)"
                     class="px-4 py-2 rounded-lg text-sm font-bold border transition-colors"
@@ -156,6 +202,10 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
 
                     <div class="min-w-0 flex-1">
                         <div class="flex flex-wrap items-center gap-2 mb-1">
+                            <button type="button" @click="setProject(wish.project)"
+                                class="text-[11px] px-2 py-0.5 rounded border border-blue-400/30 bg-blue-500/15 text-blue-200 font-bold hover:bg-blue-500/25 transition-colors">
+                                {{ wish.project_label }}
+                            </button>
                             <h2 class="text-lg font-bold text-white">{{ wish.title }}</h2>
                             <span class="text-[11px] px-2 py-0.5 rounded border font-bold" :class="statusClass(wish.status)">
                                 {{ wish.status_label }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,9 +116,11 @@ Route::post('/wishlist', [\App\Http\Controllers\WishlistController::class, 'stor
 Route::post('/wishlist/{wish}/vote', [\App\Http\Controllers\WishlistController::class, 'vote'])
     ->middleware(['auth', 'verified', 'throttle:120,60'])
     ->name('wishlist.vote');
-Route::delete('/wishlist/{wish}', [\App\Http\Controllers\WishlistController::class, 'destroy'])
-    ->middleware(['auth', 'verified'])
-    ->name('wishlist.destroy');
+// Authors ask, they do not delete: by the time a wish is on the list other
+// people have voted on it. Removal itself is an admin action in the panel.
+Route::post('/wishlist/{wish}/request-removal', [\App\Http\Controllers\WishlistController::class, 'requestRemoval'])
+    ->middleware(['auth', 'verified', 'throttle:20,60'])
+    ->name('wishlist.request-removal');
 
 Route::get('/ranking', [RankingController::class, 'index'])->name('ranking');
 Route::get('/ranking/how-it-works', [RankingController::class, 'howItWorks'])->name('ranking.how-it-works');

--- a/routes/web.php
+++ b/routes/web.php
@@ -98,15 +98,15 @@ Route::post('/serverdemo-validators/vote/{application}', [\App\Http\Controllers\
 // what was reported and what came of it.
 Route::get('/validation-log', [\App\Http\Controllers\ValidationLogController::class, 'index'])->name('validation-log');
 
-// Self-report amnesty: withdrawing your own invalid time. Verified account
-// only - it deletes a record, so it has to be a real person's own account -
-// and throttled like the other forms.
-Route::get('/self-report', [\App\Http\Controllers\SelfReportController::class, 'index'])
+// The amnesty: withdrawing your own invalid time. Verified account only - it
+// takes a record off the leaderboard, so it has to be a real person's own
+// account - and throttled like the other forms.
+Route::get('/amnesty', [\App\Http\Controllers\SelfReportController::class, 'index'])
     ->middleware(['auth', 'verified'])
-    ->name('self-report.index');
-Route::post('/self-report', [\App\Http\Controllers\SelfReportController::class, 'store'])
+    ->name('amnesty.index');
+Route::post('/amnesty', [\App\Http\Controllers\SelfReportController::class, 'store'])
     ->middleware(['auth', 'verified', 'throttle:30,60'])
-    ->name('self-report.store');
+    ->name('amnesty.store');
 
 // Wishlist. Reading is public, writing and voting need an account.
 Route::get('/wishlist', [\App\Http\Controllers\WishlistController::class, 'index'])->name('wishlist.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -139,6 +139,12 @@ Route::get('/defraghq/validation-demo/{flag}', \App\Http\Controllers\ServerdemoV
     ->middleware(['auth', 'signed'])
     ->name('defraghq.validation-demo');
 
+// The serverdemo of a run its own owner withdrew. Admin only - a withdrawal
+// is private, and so is the demo that shows which run it was.
+Route::get('/defraghq/amnesty-demo/{report}', \App\Http\Controllers\AmnestyDemoDownloadController::class)
+    ->middleware(['auth', 'signed'])
+    ->name('defraghq.amnesty-demo');
+
 // DefragLive most-watched-player contest (public leaderboard + raffle odds).
 Route::get('/defraglive/contest', [DefragliveContestController::class, 'index'])->name('defraglive.contest');
 // OBS Browser Source overlay (transparent top-3 widget) + its JSON feed.

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,33 @@ Route::post('/serverdemo-validators/vote/{application}', [\App\Http\Controllers\
     ->middleware(['auth', 'verified', 'throttle:60,60'])
     ->name('serverdemo-validators.vote');
 
+// The public validation log. Deliberately open to everyone including logged
+// out visitors: it exists so that somebody who does not trust us can check
+// what was reported and what came of it.
+Route::get('/validation-log', [\App\Http\Controllers\ValidationLogController::class, 'index'])->name('validation-log');
+
+// Self-report amnesty: withdrawing your own invalid time. Verified account
+// only - it deletes a record, so it has to be a real person's own account -
+// and throttled like the other forms.
+Route::get('/self-report', [\App\Http\Controllers\SelfReportController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('self-report.index');
+Route::post('/self-report', [\App\Http\Controllers\SelfReportController::class, 'store'])
+    ->middleware(['auth', 'verified', 'throttle:30,60'])
+    ->name('self-report.store');
+
+// Wishlist. Reading is public, writing and voting need an account.
+Route::get('/wishlist', [\App\Http\Controllers\WishlistController::class, 'index'])->name('wishlist.index');
+Route::post('/wishlist', [\App\Http\Controllers\WishlistController::class, 'store'])
+    ->middleware(['auth', 'verified', 'throttle:20,60'])
+    ->name('wishlist.store');
+Route::post('/wishlist/{wish}/vote', [\App\Http\Controllers\WishlistController::class, 'vote'])
+    ->middleware(['auth', 'verified', 'throttle:120,60'])
+    ->name('wishlist.vote');
+Route::delete('/wishlist/{wish}', [\App\Http\Controllers\WishlistController::class, 'destroy'])
+    ->middleware(['auth', 'verified'])
+    ->name('wishlist.destroy');
+
 Route::get('/ranking', [RankingController::class, 'index'])->name('ranking');
 Route::get('/ranking/how-it-works', [RankingController::class, 'howItWorks'])->name('ranking.how-it-works');
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -97,54 +97,31 @@ fi
 
 # ===== 3) Serverdemos mirror (storage VPS -> defrag-serverdemos) =====
 sekce_serverdemos() {
-# Archiv, ne sync: rclone copy jen přidává - smazání na storage nikdy
-# nesmaže nic v B2. Čte se přes dlbrowser SFTP účet (read ACL na
-# /var/lib/serverdemos), takže na storage VPS nic neinstalujeme.
-B2_SERVERDEMOS_KEY_ID="$(read_env B2_SERVERDEMOS_KEY_ID)"
-B2_SERVERDEMOS_APP_KEY="$(read_env B2_SERVERDEMOS_APP_KEY)"
-B2_SERVERDEMOS_BUCKET="$(read_env B2_SERVERDEMOS_BUCKET)"; B2_SERVERDEMOS_BUCKET="${B2_SERVERDEMOS_BUCKET:-defrag-serverdemos}"
-SD_HOST="$(read_env STORAGE_VPS_DL_HOST)"
-SD_PORT="$(read_env STORAGE_VPS_DL_PORT)"; SD_PORT="${SD_PORT:-2258}"
-SD_USER="$(read_env STORAGE_VPS_DL_USER)"; SD_USER="${SD_USER:-dlbrowser}"
-SD_KEY_PATH="$(read_env STORAGE_VPS_DL_KEY_PATH)"
+# Tahle sekce měla vlastní `rclone copy` s `|| true` a hláškou "OK" pod ním,
+# takže selhání spolkla úplně všechna - vypršelý klíč i odstavený storage by
+# vypadaly stejně jako úspěch.
+#
+# A hlavně jí chyběla polovina práce. Kolizi jmen (mapa[čas][mdd] není
+# unikátní) umí vyřešit přejmenováním na [2] jen serverdemos-mirror.sh, jenže
+# ten jede s --max-age 6h a archivu se schválně nastavuje čas původního dema,
+# takže archiv starého dema do jeho okna nikdy nespadne. Kolize na takovém
+# souboru tedy neřešil nikdo: noční běh ji každou noc odmítl, napsal ERROR,
+# napsal OK a šel dál. V logu k 7.8.2026 tak stálo pět dem, která ležela na
+# storage v jediné kopii a v B2 nebyla pod žádným jménem.
+#
+# Proto se tu nekopíruje ručně, ale zavolá se ten samý skript v režimu
+# CATCH_UP=1, tedy plný průchod bez omezení stáří. Získáme tím přejmenování
+# kolizí, zálohu nezabalených syrových dem i poctivé hlášení chyb, a nemáme
+# zrcadlení napsané dvakrát. Svůj zámek si drží sám, takže se to nepopere se
+# souběžným patnáctiminutovým během.
+MIRROR="$APP_DIR/scripts/serverdemos-mirror.sh"
 
-if [ -n "$B2_SERVERDEMOS_KEY_ID" ] && [ -n "$B2_SERVERDEMOS_APP_KEY" ] && [ -n "$SD_HOST" ] && [ -n "$SD_KEY_PATH" ]; then
-  export RCLONE_CONFIG_SDSFTP_TYPE=sftp
-  export RCLONE_CONFIG_SDSFTP_HOST="$SD_HOST"
-  export RCLONE_CONFIG_SDSFTP_PORT="$SD_PORT"
-  export RCLONE_CONFIG_SDSFTP_USER="$SD_USER"
-  export RCLONE_CONFIG_SDSFTP_KEY_FILE="$SD_KEY_PATH"
-  # Bez tohohle si rclone klíč hostitele vůbec neověřuje a jen na to upozorní
-  # v logu - spojení by tak šlo podvrhnout a dema poslat jinam. Soubor se plní
-  # ručně z ověřeného otisku, takže neexistující nebo prázdný known_hosts je
-  # důvod k selhání, ne k tichému pokračování.
-  export RCLONE_CONFIG_SDSFTP_KNOWN_HOSTS_FILE="${HOME:-/root}/.ssh/known_hosts"
-  export RCLONE_CONFIG_SDB2_TYPE=b2
-  export RCLONE_CONFIG_SDB2_ACCOUNT="$B2_SERVERDEMOS_KEY_ID"
-  export RCLONE_CONFIG_SDB2_KEY="$B2_SERVERDEMOS_APP_KEY"
-
-  # --exclude *.part viz serverdemos-mirror.sh: rozdělaný archiv z ingestu
-  # se do B2 nesmí dostat, protože odtud už se nikdy nesmaže.
-  #
-  # --immutable taky viz serverdemos-mirror.sh: jméno dema není unikátní a bez
-  # tohohle přepínače by se dvě různé jízdy se stejným časem od jednoho hráče
-  # přepsaly v B2 navzájem. Přejmenování kolizí řeší ten patnáctiminutový běh,
-  # tady jde jen o to nepřepsat nic dřív, než se k tomu dostane. Kolizní
-  # soubor se nenahraje, ostatní projdou.
-  # --exclude *.dm_68 taky viz serverdemos-mirror.sh: syrové demo je na disku
-  # jen tu chvíli, než ho ingest zabalí, a nahrát ho sem znamená nechat ho v
-  # B2 navždy vedle jeho vlastního archivu. To, co se opravdu nezabalilo,
-  # zálohuje ten patnáctiminutový běh, který si u každého ověří, že vedle
-  # sebe archiv nemá.
-  rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemos/ \
-    --exclude "*.part" \
-    --exclude "*.dm_68" \
-    --immutable \
-    --transfers 4 --sftp-concurrency 8 || true
-  echo "[$(date)] Serverdemos mirror na B2 OK"
-else
-  echo "[$(date)] Serverdemos přeskočeny (B2_SERVERDEMOS_* / STORAGE_VPS_DL_* není v .env)"
+if [ ! -x "$MIRROR" ]; then
+  echo "[$(date)] Serverdemos přeskočeny (chybí $MIRROR)" >&2
+  return 1
 fi
+
+CATCH_UP=1 "$MIRROR"
 }
 
 # ---- Spuštění ----

--- a/scripts/serverdemos-mirror.sh
+++ b/scripts/serverdemos-mirror.sh
@@ -120,8 +120,13 @@ rclone copy sdsftp:/var/lib/serverdemos sdb2:"$B2_SERVERDEMOS_BUCKET"/serverdemo
 rc=${PIPESTATUS[0]}
 set -e
 
+# Kotva na začátek řádku tu byla špatně: rclone píše do souboru s datem
+# vepředu ("2026/08/07 23:45:06 ERROR : cesta: ..."), takže `^ERROR : ` nesedlo
+# nikdy a seznam kolizí byl vždycky prázdný. Nic se proto nepřejmenovalo a
+# každý běh s kolizí se navíc tvářil jako skutečné selhání - od 5.8.2026 jich
+# takhle v logu bylo 135. Hledá se tedy kdekoliv na řádku.
 mapfile -t KOLIZE < <(
-  grep -oP '^ERROR : \K.*(?=: Source and destination exist but do not match: immutable file modified$)' \
+  grep -oP 'ERROR\s*:\s*\K.*(?=: Source and destination exist but do not match: immutable file modified$)' \
     "$RUN_LOG" | sort -u
 )
 


### PR DESCRIPTION
Validation log (/validation-log): every closed case with names, open cases anonymously. Self-reports are deliberately absent - they are admin-only by design.

Amnesty (/amnesty): a player files a request to have their own runs taken down. Nothing is deleted on submit; the request carries a handling choice (hide now, or wait for the MDD merge) and an admin approves the hide. Requests auto-close as beaten when the player improves the time, via the hourly amnesty:resolve-beaten. Abuse sets users.amnesty_blocked_at. The admin panel is two levels: a player list with per-player counts, and their runs behind it with tabs, batch actions, and a signed admin-only serverdemo download. Hiding a run snapshots the demos it detaches so restoring is a real undo, and demos:rematch-all is barred from demos an open withdrawal holds down.

Wishlist (/wishlist): a request board, admin-approved before publication, authors may only request removal. Upvotes are budgeted at min(wishes, max(5, wishes/3)) per person; downvotes and self-votes are exempt.

Fastcap demos (MapsController): the page decided a map was fastcap by its name, so 1518 of the 1584 maps holding fastcap records fell through to CPM% - which matches CPM.1 through CPM.8. One ctf mode's demos appeared in another's leaderboard and time history.

Mirror (serverdemos-mirror.sh): the collision pattern was anchored ^ERROR, but rclone prefixes the date when not on a terminal, so no collision was ever recognised - nothing was renamed to [2] and every colliding run reported itself as a failure, 135 times since 5 August. The nightly backup ran its own copy with || true and an unconditional OK; it now calls the mirror with CATCH_UP=1.

Nine additive migrations. Deploy needs php artisan filament:cache-components.