### PR TITLE
Stop the deploy stopping to ask npx a question

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "postinstall": "npx update-browserslist-db@latest --yes || true"
+        "postinstall": "npx --yes update-browserslist-db@latest --yes || true"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^1.0.0",


### PR DESCRIPTION
The postinstall passed --yes to update-browserslist-db, but the question comes from npx, which has to fetch the package first and asks before it does. On a fresh release it sat there waiting for a keypress in the middle of a deploy. npx takes its own --yes before the package name.