### PR TITLE
Add a time format preference and wishlist media, fix the server list filter and lone demos on map pages

### DIFF
--- a/app/Filament/Resources/WishResource.php
+++ b/app/Filament/Resources/WishResource.php
@@ -10,6 +10,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * The admin side of the wishlist: answering wishes and removing the ones that
@@ -120,7 +121,17 @@ class WishResource extends Resource
 
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Author')
-                    ->searchable(),
+                    // Raw, the column printed the colour codes themselves:
+                    // ^3[^nS^mH^3]^7neyo^4. instead of a nick.
+                    ->formatStateUsing(fn (?string $state) => UserResource::q3tohtml($state ?? ''))
+                    ->html()
+                    // Searching the coloured name never matched what is on
+                    // screen, since the codes sit between the letters.
+                    ->searchable(query: fn (Builder $query, string $search) => $query->whereHas(
+                        'user',
+                        fn ($q) => $q->where('plain_name', 'like', "%{$search}%")
+                            ->orWhere('name', 'like', "%{$search}%")
+                    )),
 
                 Tables\Columns\TextColumn::make('status')
                     ->badge()

--- a/app/Filament/Resources/WishResource.php
+++ b/app/Filament/Resources/WishResource.php
@@ -119,6 +119,25 @@ class WishResource extends Resource
                         : str($record->body)->limit(140))
                     ->color(fn (Wish $record) => $record->removal_requested_at ? 'warning' : null),
 
+                // A wish is approved before anyone else sees it, so whatever
+                // it carries has to be visible at the point of approving it.
+                Tables\Columns\ImageColumn::make('image_path')
+                    ->label('Shot')
+                    ->disk(Wish::IMAGE_DISK)
+                    ->height(40)
+                    ->extraImgAttributes(['class' => 'rounded object-cover'])
+                    ->url(fn (Wish $record) => $record->imageUrl(), shouldOpenInNewTab: true)
+                    ->placeholder('-'),
+
+                Tables\Columns\TextColumn::make('youtube_id')
+                    ->label('Video')
+                    ->formatStateUsing(fn (?string $state) => $state ? 'Watch' : null)
+                    ->url(fn (Wish $record) => $record->youtube_id
+                        ? 'https://www.youtube.com/watch?v=' . $record->youtube_id
+                        : null, shouldOpenInNewTab: true)
+                    ->color('info')
+                    ->placeholder('-'),
+
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Author')
                     // Raw, the column printed the colour codes themselves:

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -1022,6 +1022,32 @@ class MapsController extends Controller
             if (count($members) === 1) {
                 $d = $members[0];
                 $meta[(string) $d->id] = ['count' => 0, 'signals' => 0];
+
+                // A cluster of one still has a drawer worth opening, and the
+                // profile-key entry below used to be skipped for it.
+                //
+                // One online demo, slower than its own player's MDD record on
+                // this map, and belonging to nobody else's cluster: Demos Top
+                // drops it on purpose (a slower online run is an attempt on
+                // the way to the PB, not a separate result), the main record
+                // has no demo of its own to hang a badge on, and with no
+                // profile key here the row offered no way in either. The demo
+                // existed, was processed, and could be reached by nothing on
+                // the map page. /time-history lists it perfectly well when
+                // asked by mdd_id.
+                //
+                // Only for a demo that is not attached to a main record - one
+                // that is attached is already the row you are looking at, and
+                // giving that row a badge counting its own demo would put a
+                // "1" on rows that today correctly have none.
+                if ($d->gametype && str_starts_with($d->gametype, 'm') && ! $d->record_id) {
+                    $rk = $profileResolver->resolve($d, $priorityProfileKeys);
+
+                    if ($rk !== null && ($meta[$rk]['count'] ?? 0) < 1) {
+                        $meta[$rk] = ['count' => 1, 'signals' => 0, 'profileKey' => $rk];
+                    }
+                }
+
                 continue;
             }
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -310,6 +310,7 @@ class SettingsController extends Controller
             'hidden_stat_boxes' => ['present', 'array'],
             'hidden_stat_boxes.*' => ['string', 'in:performance,activity,record_types,map_features,renders'],
             'date_format' => ['sometimes', 'string', 'in:ymd,dmy,Ymd,dmY'],
+            'time_format' => ['sometimes', 'string', 'in:colon,dot'],
         ]);
 
         $user = $request->user();
@@ -317,6 +318,9 @@ class SettingsController extends Controller
             'hidden_sections' => $request->hidden_sections,
             'hidden_stat_boxes' => $request->hidden_stat_boxes,
             'date_format' => $request->date_format ?? $user->global_profile_preferences['date_format'] ?? 'dmY',
+            // Default is what the engine's own timer prints, so nobody who
+            // never opens this page sees their times change.
+            'time_format' => $request->time_format ?? $user->global_profile_preferences['time_format'] ?? 'colon',
         ];
         $user->save();
 

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -62,6 +62,8 @@ class WishlistController extends Controller
                 'project_label' => Wish::PROJECTS[$wish->project] ?? $wish->project,
                 'title' => $wish->title,
                 'body' => $wish->body,
+                'image_url' => $wish->imageUrl(),
+                'youtube_id' => $wish->youtube_id,
                 'status' => $wish->status,
                 'status_label' => Wish::STATUSES[$wish->status] ?? $wish->status,
                 'status_note' => $wish->status_note,
@@ -106,9 +108,26 @@ class WishlistController extends Controller
             'project' => ['required', 'string', 'in:' . implode(',', array_keys(Wish::PROJECTS))],
             'title' => ['required', 'string', 'min:6', 'max:120'],
             'body' => ['required', 'string', 'min:20', 'max:2000'],
+            // Extensions rather than the `image` rule, which accepts svg -
+            // an svg is a document that can carry script, and this one ends up
+            // inlined on a page everybody reads.
+            'image' => ['nullable', 'file', 'mimes:jpg,jpeg,png,webp,gif', 'max:4096'],
+            'youtube_url' => ['nullable', 'string', 'max:255'],
         ], [
             'body.min' => 'Say a bit more - at least 20 characters, so people know what they are voting on.',
+            'image.mimes' => 'The screenshot has to be a jpg, png, webp or gif.',
+            'image.max' => 'The screenshot has to be under 4 MB.',
         ]);
+
+        $youtubeId = null;
+
+        if (filled($data['youtube_url'] ?? null)) {
+            $youtubeId = Wish::youtubeId($data['youtube_url']);
+
+            if (! $youtubeId) {
+                return back()->withErrors(['youtube_url' => 'That is not a YouTube link.'])->withInput();
+            }
+        }
 
         // Not approved: it goes nowhere public until an admin lets it through.
         $wish = Wish::create([
@@ -116,6 +135,10 @@ class WishlistController extends Controller
             'project' => $data['project'],
             'title' => $data['title'],
             'body' => $data['body'],
+            'image_path' => $request->hasFile('image')
+                ? $request->file('image')->store(Wish::IMAGE_DIR, Wish::IMAGE_DISK)
+                : null,
+            'youtube_id' => $youtubeId,
         ]);
 
         // The author wants it, obviously. Saying so explicitly means a fresh

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -124,6 +124,9 @@ class HandleInertiaRequests extends Middleware
             'physicsOrder'              =>      $request->user()?->default_physics_order ?? 'vq3_first',
             'canViewRatingBreakdown'    =>      $request->user() ? ($request->user()->admin || (is_array($request->user()->moderator_permissions) && in_array('rating_breakdown', $request->user()->moderator_permissions))) : false,
             'dateFormat'                =>      $request->user()?->global_profile_preferences['date_format'] ?? 'dmY',
+            // Separator before the milliseconds in a run time: 'colon' is
+            // what the engine prints and what the site has always shown.
+            'timeFormat'                =>      $request->user()?->global_profile_preferences['time_format'] ?? 'colon',
             'availableBadges'           =>      $request->user() ? $this->getAvailableBadges($request->user()) : [],
             'globalLatestAnnouncement'  =>      !$request->user() ? Cache::remember('global:latest_announcement', 300, function () {
                 return Announcement::where('type', 'home')->orderBy('created_at', 'DESC')->first(['id', 'title', 'created_at']);

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -4,16 +4,28 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Storage;
 
 class Wish extends Model
 {
     use SoftDeletes;
+
+    /**
+     * Screenshots go on the local public disk, not the community bucket: they
+     * are small, they are part of the page rather than something anyone
+     * downloads, and storage/app/public is already in the nightly mirror.
+     */
+    public const IMAGE_DISK = 'public';
+
+    public const IMAGE_DIR = 'wishes';
 
     protected $fillable = [
         'user_id',
         'project',
         'title',
         'body',
+        'image_path',
+        'youtube_id',
         'status',
         'status_note',
         'approved_at',
@@ -107,6 +119,37 @@ class Wish extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    /** Where the browser fetches the screenshot, or null when there is none. */
+    public function imageUrl(): ?string
+    {
+        return $this->image_path ? Storage::disk(self::IMAGE_DISK)->url($this->image_path) : null;
+    }
+
+    /**
+     * The eleven-character id out of whatever form of YouTube link someone
+     * pasted - watch, youtu.be, embed, shorts, or the bare id itself. Null
+     * when it is not a YouTube link at all, which is what the validator
+     * reports back to the author.
+     */
+    public static function youtubeId(?string $url): ?string
+    {
+        $url = trim((string) $url);
+
+        if ($url === '') {
+            return null;
+        }
+
+        if (preg_match('~^[A-Za-z0-9_-]{11}$~', $url)) {
+            return $url;
+        }
+
+        return preg_match(
+            '~(?:youtube\.com/(?:watch\?(?:.*&)?v=|embed/|shorts/|live/)|youtu\.be/)([A-Za-z0-9_-]{11})~',
+            $url,
+            $m
+        ) ? $m[1] : null;
     }
 
     public function votes()

--- a/database/migrations/2026_08_08_000100_add_media_to_wishes_table.php
+++ b/database/migrations/2026_08_08_000100_add_media_to_wishes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A wish can carry one screenshot and one video.
+ *
+ * Half the wishes on the board are about something you can see - a layout, a
+ * badge, a filter - and describing it in prose costs the author more effort
+ * than a screenshot and still leaves the reader guessing what they are voting
+ * on. Only the id of the video is kept, not the URL people paste, so the embed
+ * is built by us and a pasted link cannot carry anything else along.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('body');
+            $table->string('youtube_id', 20)->nullable()->after('image_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wishes', function (Blueprint $table) {
+            $table->dropColumn(['image_path', 'youtube_id']);
+        });
+    }
+};

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1,5 +1,6 @@
 <script setup>
     import { Head, Link, router, usePage } from '@inertiajs/vue3';
+    import { formatTime } from '@/utils/time';
     import MapCardLine from '@/Components/MapCardLine.vue';
     import MapRecord from '@/Components/MapRecord.vue';
     import TimeHistoryExpand from '@/Components/TimeHistoryExpand.vue';
@@ -1157,16 +1158,8 @@
         return match ? match[1] : '';
     };
 
-    const formatTime = (milliseconds) => {
-        const minutes = Math.floor(milliseconds / 60000);
-        const seconds = Math.floor((milliseconds % 60000) / 1000);
-        const ms = milliseconds % 1000;
-
-        if (minutes > 0) {
-            return `${minutes}:${seconds.toString().padStart(2, '0')}:${ms.toString().padStart(3, '0')}`;
-        }
-        return `${seconds}:${ms.toString().padStart(3, '0')}`;
-    };
+    // Was a copy of the global one. It has to be the shared formatter, or the
+    // map page keeps printing colons after someone picks the decimal point.
 
     onMounted(() => {
         window.addEventListener("resize", resizeScreen);

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -384,6 +384,7 @@ const globalCustomizeSections = [
     { id: 'gc-map-view', label: 'Map View Defaults' },
     { id: 'gc-physics-order', label: 'Physics Order' },
     { id: 'gc-date-format', label: 'Date Format' },
+    { id: 'gc-time-format', label: 'Time Format' },
     { id: 'gc-hide-stats', label: 'Hide Stat Boxes' },
     { id: 'gc-hide-sections', label: 'Hide Sections' },
 ];

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -234,10 +234,12 @@ const submitAboutMeSettings = () => {
 const savedHidden = user.value.global_profile_preferences?.hidden_sections || [];
 const savedHiddenStatBoxes = user.value.global_profile_preferences?.hidden_stat_boxes || [];
 const savedDateFormat = user.value.global_profile_preferences?.date_format || 'dmY';
+const savedTimeFormat = user.value.global_profile_preferences?.time_format || 'colon';
 const globalProfileForm = useForm({
     hidden_sections: [...savedHidden],
     hidden_stat_boxes: [...savedHiddenStatBoxes],
     date_format: savedDateFormat,
+    time_format: savedTimeFormat,
 });
 
 const toggleGlobalSection = (id) => {
@@ -2113,6 +2115,40 @@ const filteredProfileSubTabs = computed(() => isVerified.value ? profileSubTabs 
                             <div class="text-[10px] font-normal mt-0.5 opacity-70">02/04/2026</div>
                         </button>
                     </div>
+                </div>
+            </div>
+
+            <!-- Time Format Card -->
+            <div id="gc-time-format" class="rounded-xl bg-black/40 backdrop-blur-sm border border-white/10 transition-all duration-500">
+                <div class="p-4">
+                    <div class="flex items-center gap-2 mb-3">
+                        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-cyan-500/20 to-blue-600/20 border border-cyan-500/30 flex items-center justify-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-cyan-400">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                            </svg>
+                        </div>
+                        <div>
+                            <h2 class="text-sm font-bold text-white">Time Format</h2>
+                            <p class="text-xs text-gray-500">What separates the milliseconds in a run time</p>
+                        </div>
+                    </div>
+                    <div class="grid grid-cols-2 gap-2">
+                        <button @click="globalProfileForm.time_format = 'colon'; saveGlobalPreferencesDebounced()"
+                            class="px-3 py-2 rounded-lg text-xs font-bold border transition-all"
+                            :class="globalProfileForm.time_format === 'colon' ? 'bg-cyan-600/20 text-cyan-300 border-cyan-500/40' : 'bg-white/5 text-gray-400 border-white/10 hover:bg-white/10'">
+                            Colon
+                            <div class="text-[10px] font-normal mt-0.5 opacity-70">12:20:108</div>
+                        </button>
+                        <button @click="globalProfileForm.time_format = 'dot'; saveGlobalPreferencesDebounced()"
+                            class="px-3 py-2 rounded-lg text-xs font-bold border transition-all"
+                            :class="globalProfileForm.time_format === 'dot' ? 'bg-cyan-600/20 text-cyan-300 border-cyan-500/40' : 'bg-white/5 text-gray-400 border-white/10 hover:bg-white/10'">
+                            Decimal point
+                            <div class="text-[10px] font-normal mt-0.5 opacity-70">12:20.108</div>
+                        </button>
+                    </div>
+                    <p class="text-[10px] text-gray-600 mt-2">
+                        Colon is what the in-game timer prints. The point reads the milliseconds as a fraction of a second.
+                    </p>
                 </div>
             </div>
 

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -173,18 +173,29 @@ const filteredAndSortedServers = computed(() => {
             const serverType = server.type?.toLowerCase() || 'run';
             const serverName = (server.name || '').replace(/\^\d|\^x[\da-fA-F]{2}|\^[\da-fA-F]{6}/g, '').toLowerCase();
 
-            // Defrag's gametype 5 = mixed (server allows run + teamrun
-            // simultaneously). Many "10gbit cpm III"-style servers are
-            // tagged type='team' in our DB but actually advertise a
-            // run leaderboard too, so they need to surface in both
-            // the 'run' and 'teamrun' tabs. The "mixed" keyword in
-            // the server name is the other signal — admins use it
-            // for the same kind of multi-mode setup.
-            const isMixed = String(server.defrag_gametype) === '5' || serverName.includes('mixed');
+            // A mixed server advertises a run leaderboard alongside
+            // whatever else it does, so it belongs in the run tab too.
+            //
+            // defrag_gametype used to be read as that signal, on the
+            // basis that 5 means "run + teamrun at once". It is 5 on
+            // every single server we know of — 76 of 76 in production —
+            // so it said nothing, and being OR'd into both the run and
+            // teamrun cases it made those two tabs return the entire
+            // list. The name keyword and type='mixed' are the signals
+            // admins actually set.
+            const isMixed = serverType === 'mixed' || serverName.includes('mixed');
 
-            // Detect effective type: DB type first, then name-based detection
+            // Detect effective type: DB type first, then name-based detection.
+            // The type column is not a clean vocabulary — it carries
+            // 'teamruns' as well as 'team', and physics values (cpm, vq3)
+            // where a gametype belongs — so it is normalised first. Without
+            // that, the twelve servers typed by physics matched no tab at
+            // all and the two 'teamruns' ones were invisible to the team tab.
             let effectiveType = serverType;
-            if (serverType === 'run') {
+            if (effectiveType === 'teamruns') effectiveType = 'team';
+            if (effectiveType === 'cpm' || effectiveType === 'vq3' || effectiveType === 'mixed') effectiveType = 'run';
+
+            if (effectiveType === 'run') {
                 if (serverName.includes('fastcap') || serverName.includes('ctf')) effectiveType = 'fastcaps';
                 else if (serverName.includes('freestyle')) effectiveType = 'freestyle';
                 else if (serverName.includes('teamrun') || serverName.includes('team run')) effectiveType = 'team';
@@ -197,8 +208,11 @@ const filteredAndSortedServers = computed(() => {
                     return effectiveType === 'ctf' || effectiveType === 'fastcaps';
                 case 'freestyle':
                     return effectiveType === 'freestyle';
+                // Not isMixed: a teamrun can be voted on any mixed server,
+                // but someone filtering here wants the servers set up for
+                // them, not the forty run servers where it is possible.
                 case 'teamrun':
-                    return effectiveType === 'teamrun' || effectiveType === 'team' || isMixed;
+                    return effectiveType === 'teamrun' || effectiveType === 'team';
                 default:
                     return true;
             }

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -8,7 +8,7 @@ export default {
 
 <script setup>
 import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 const props = defineProps({
     wishes: { type: Array, default: () => [] },
@@ -40,17 +40,65 @@ const form = useForm({
     project: 'web',
     title: '',
     body: '',
+    image: null,
+    youtube_url: '',
 });
 
+// Shown before the wish is posted, so the author sees what everyone else will.
+const imagePreview = ref(null);
+
+const pickImage = (event) => {
+    const file = event.target.files?.[0] ?? null;
+    form.image = file;
+    if (imagePreview.value) URL.revokeObjectURL(imagePreview.value);
+    imagePreview.value = file ? URL.createObjectURL(file) : null;
+};
+
+const clearImage = () => {
+    form.image = null;
+    if (imagePreview.value) URL.revokeObjectURL(imagePreview.value);
+    imagePreview.value = null;
+    if (imageInput.value) imageInput.value.value = '';
+};
+
+const imageInput = ref(null);
+
 const submit = () => {
+    // forceFormData: a file cannot go up as JSON, and Inertia only switches
+    // to multipart on its own when a File is present - which it is not when
+    // the author attached nothing.
     form.post('/wishlist', {
         preserveScroll: true,
+        forceFormData: true,
         onSuccess: () => {
             form.reset();
+            clearImage();
             showForm.value = false;
         },
     });
 };
+
+// Clicking a thumbnail opens the full picture. One at a time, and Escape or a
+// click anywhere closes it - it is a preview, not a page.
+const lightbox = ref(null);
+
+const openLightbox = (wish) => {
+    lightbox.value = wish;
+};
+
+const closeLightbox = () => {
+    lightbox.value = null;
+};
+
+const onKeydown = (event) => {
+    if (event.key === 'Escape') closeLightbox();
+};
+
+onMounted(() => window.addEventListener('keydown', onKeydown));
+onBeforeUnmount(() => {
+    window.removeEventListener('keydown', onKeydown);
+    if (imagePreview.value) URL.revokeObjectURL(imagePreview.value);
+});
 
 // Voting is a plain POST rather than an optimistic local update: the score
 // decides the order of the list, and a number that moves before the server
@@ -162,6 +210,45 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                         placeholder="Briefly: what it does, and why it would help."></textarea>
                     <div v-if="form.errors.body" class="text-red-400 text-sm mt-1">{{ form.errors.body }}</div>
                 </div>
+
+                <!-- Both optional. Half the wishes here are about something
+                     you can see, and a screenshot says it faster than a
+                     paragraph does. -->
+                <div class="grid sm:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm text-gray-300 mb-1">
+                            Screenshot <span class="text-gray-600 font-normal">optional</span>
+                        </label>
+
+                        <div v-if="imagePreview" class="flex items-start gap-3">
+                            <img :src="imagePreview" alt=""
+                                class="w-24 h-16 object-cover rounded-lg border border-white/10" />
+                            <button type="button" @click="clearImage"
+                                class="text-sm text-gray-400 hover:text-red-300 transition-colors">
+                                Remove
+                            </button>
+                        </div>
+
+                        <input v-else ref="imageInput" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
+                            @change="pickImage"
+                            class="w-full text-sm text-gray-400 file:mr-3 file:py-2 file:px-3 file:rounded-lg file:border-0 file:bg-white/10 file:text-gray-200 file:font-semibold hover:file:bg-white/20 file:cursor-pointer" />
+
+                        <div v-if="form.errors.image" class="text-red-400 text-sm mt-1">{{ form.errors.image }}</div>
+                        <p v-else class="text-xs text-gray-600 mt-1">jpg, png, webp or gif, up to 4 MB.</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm text-gray-300 mb-1">
+                            YouTube link <span class="text-gray-600 font-normal">optional</span>
+                        </label>
+                        <input v-model="form.youtube_url" type="text" maxlength="255"
+                            class="w-full bg-black/50 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400/50"
+                            placeholder="https://youtube.com/watch?v=..." />
+                        <div v-if="form.errors.youtube_url" class="text-red-400 text-sm mt-1">{{ form.errors.youtube_url }}</div>
+                        <p v-else class="text-xs text-gray-600 mt-1">Any YouTube link works - watch, youtu.be or shorts.</p>
+                    </div>
+                </div>
+
                 <div class="flex flex-wrap items-center gap-3">
                     <button type="submit" :disabled="form.processing"
                         class="px-5 py-2.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-bold transition-colors disabled:opacity-50">
@@ -292,6 +379,30 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
                         </div>
                         <p class="text-gray-300 whitespace-pre-line leading-relaxed">{{ wish.body }}</p>
 
+                        <!-- Deliberately small. A wish is read in a list of
+                             wishes, so the picture is a hint that there is one
+                             rather than the thing taking up the row. -->
+                        <div v-if="wish.image_url || wish.youtube_id" class="mt-3 flex items-center gap-2">
+                            <button v-if="wish.image_url" type="button" @click="openLightbox(wish)"
+                                class="group relative rounded-lg overflow-hidden border border-white/10 hover:border-purple-400/50 transition-colors"
+                                title="Click to enlarge">
+                                <img :src="wish.image_url" alt="" loading="lazy"
+                                    class="w-20 h-14 object-cover group-hover:opacity-80 transition-opacity" />
+                            </button>
+
+                            <button v-if="wish.youtube_id" type="button" @click="openLightbox(wish)"
+                                class="group relative w-20 h-14 rounded-lg overflow-hidden border border-white/10 hover:border-purple-400/50 transition-colors"
+                                title="Click to play">
+                                <img :src="`https://i.ytimg.com/vi/${wish.youtube_id}/mqdefault.jpg`" alt="" loading="lazy"
+                                    class="w-full h-full object-cover group-hover:opacity-80 transition-opacity" />
+                                <span class="absolute inset-0 flex items-center justify-center">
+                                    <svg class="w-6 h-6 text-white drop-shadow" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M8 5v14l11-7z" />
+                                    </svg>
+                                </span>
+                            </button>
+                        </div>
+
                         <div v-if="wish.status_note" class="mt-3 border-l-2 border-purple-400/40 pl-3 text-sm text-purple-200">
                             {{ wish.status_note }}
                         </div>
@@ -317,5 +428,34 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString() : '';
             </div>
 
         </div>
+
+        <!-- The bigger look. Backdrop click and Escape both close it; the
+             panel itself swallows the click so hitting play does not. -->
+        <Teleport to="body">
+            <div v-if="lightbox" class="fixed inset-0 z-[100] bg-black/85 backdrop-blur-sm flex items-center justify-center p-4"
+                @click="closeLightbox">
+                <div class="max-w-4xl w-full" @click.stop>
+                    <div class="flex items-start justify-between gap-4 mb-2">
+                        <h3 class="text-white font-bold">{{ lightbox.title }}</h3>
+                        <button type="button" @click="closeLightbox"
+                            class="shrink-0 text-gray-400 hover:text-white transition-colors" aria-label="Close">
+                            <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+
+                    <img v-if="lightbox.image_url" :src="lightbox.image_url" alt=""
+                        class="w-full max-h-[70vh] object-contain rounded-xl border border-white/10 bg-black" />
+
+                    <div v-if="lightbox.youtube_id" class="mt-3 aspect-video">
+                        <iframe class="w-full h-full rounded-xl border border-white/10"
+                            :src="`https://www.youtube.com/embed/${lightbox.youtube_id}`"
+                            title="YouTube" frameborder="0" allowfullscreen
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+                    </div>
+                </div>
+            </div>
+        </Teleport>
     </div>
 </template>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -28,7 +28,7 @@ window.fetch = async (...args) => {
 
 import { createApp, h } from 'vue';
 import { reactive } from 'vue'
-import { createInertiaApp } from '@inertiajs/vue3';
+import { createInertiaApp, router } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
 import Popper from "vue3-popper";
@@ -40,33 +40,10 @@ import { createVuetify } from 'vuetify'
 
 const appName = import.meta.env.VITE_APP_NAME || 'Defrag Racing';
 
-const formatTime = (milliseconds) => {
-    milliseconds = Math.max(0, milliseconds);
-
-    // Defrag's smallest practical run is sub-minute and the largest pushes
-    // a couple hours, but the engine itself only ever displays MM:SS.mmm
-    // (minutes rolling past 60, never an "H:" prefix). Match that — a
-    // 1:30:45.123 hh:mm:ss display would just confuse players used to
-    // reading "90:45.123" off the in-game timer.
-    const minutes = Math.floor(milliseconds / 60000);
-    milliseconds %= 60000;
-    const seconds = Math.floor(milliseconds / 1000);
-    milliseconds %= 1000;
-
-    let formattedTime = '';
-
-    if (minutes > 0) {
-      formattedTime += `${padZero(minutes)}:`;
-    }
-
-    formattedTime += `${padZero(seconds)}:${milliseconds.toString().padStart(3, '0')}`;
-
-    return formattedTime;
-};
-
-const padZero = (num) => {
-    return num.toString().padStart(2, '0');
-};
+// Lives in utils/time.js now, because the separator before the milliseconds
+// is a user preference and every place that prints a run time has to agree
+// on it.
+import { formatTime, setTimeFormat } from './utils/time';
 
 const q3tohtml = (name) => {
     if (!name) return '';
@@ -194,6 +171,12 @@ createInertiaApp({
         return page
     },
     setup({ el, App, props, plugin }) {
+        // Applied before the first render, and again on every visit, because
+        // saving the preference comes back as an ordinary Inertia response
+        // carrying the new shared props.
+        setTimeFormat(props.initialPage.props.timeFormat);
+        router.on('success', (event) => setTimeFormat(event.detail.page.props.timeFormat));
+
         const app = createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue)

--- a/resources/js/utils/time.js
+++ b/resources/js/utils/time.js
@@ -1,0 +1,47 @@
+import { ref } from 'vue';
+
+/**
+ * How a run time is written, site-wide.
+ *
+ * Defrag's own timer prints MM:SS:mmm, and that is what the site has always
+ * shown, but plenty of the community reads a colon before the milliseconds as
+ * a third clock field and expects a decimal point there instead. It is a
+ * preference rather than a correctness question, so it is one: `colon` keeps
+ * the engine's own punctuation, `dot` writes minutes:seconds.milliseconds.
+ *
+ * A ref, not a plain variable, so a component that renders a time re-renders
+ * when the preference changes rather than keeping the old punctuation until
+ * the next full page load.
+ */
+const separator = ref(':');
+
+/** `colon` (default, what the engine prints) or `dot`. */
+export const setTimeFormat = (format) => {
+    separator.value = format === 'dot' ? '.' : ':';
+};
+
+export const timeSeparator = () => separator.value;
+
+const padZero = (n) => n.toString().padStart(2, '0');
+
+/**
+ * Milliseconds as the game writes them.
+ *
+ * Defrag's smallest practical run is sub-minute and the largest pushes a
+ * couple of hours, but the engine only ever displays MM:SS.mmm - minutes roll
+ * past 60 and there is never an "H:" prefix. Match that: a 1:30:45.123
+ * hh:mm:ss display would confuse players used to reading "90:45.123" off the
+ * in-game timer.
+ */
+export const formatTime = (milliseconds) => {
+    milliseconds = Math.max(0, milliseconds);
+
+    const minutes = Math.floor(milliseconds / 60000);
+    milliseconds %= 60000;
+    const seconds = Math.floor(milliseconds / 1000);
+    milliseconds %= 1000;
+
+    const head = minutes > 0 ? `${padZero(minutes)}:` : '';
+
+    return `${head}${padZero(seconds)}${separator.value}${milliseconds.toString().padStart(3, '0')}`;
+};


### PR DESCRIPTION
Six changes that came out of Discord reports over the last few days.

## Server list gametype tabs actually filter now

`defrag_gametype` is 5 on all 76 production servers, so it carries no information, but it was being read as "this server does run and teamrun at once" and OR'd into both filters. Every tab returned the whole list. The `type` column is also not a clean vocabulary: it holds physics values where a gametype belongs (`cpm`, `vq3`, `mixed`) and both `team` and `teamruns`, so it is normalised before matching. Mixed is now detected by `type = 'mixed'` or the name keyword.

On real data: Teamrun 78 -> 7, Run 78 -> 56, CTF 6 -> 7, Freestyle unchanged. The Teamrun tab deliberately no longer counts mixed servers - a teamrun can be voted anywhere, but someone filtering there wants the servers set up for it. The MIXED tag stays on the card. The launcher gets the same fix separately.

## A run time can be written with a decimal point

`12:20.108` instead of `12:20:108`, since a colon in the last position reads as a third clock field. It is a user preference stored next to `date_format`, shared as an Inertia prop and applied before the first render and on every navigation, so switching it takes effect without a reload. Settings -> Global Customize -> Time Format, and it is listed in the section nav.

Worth knowing: the site was never consistent here. Only the global formatter and MapView wrote a colon; Home, Profile, Demos, Headhunter and the rest already wrote a decimal point. Picking `dot` is the first time everything agrees, picking `colon` looks exactly like it always did.

## A wish can carry a screenshot and a video

Optional image upload plus an optional YouTube URL on the wishlist form. The list shows a small thumbnail, clicking it opens a larger preview. Only the video id is stored, not the URL, so any of the seven link shapes people paste resolve to the same wish. Images go to the public disk that is mirrored nightly.

## The wish author's nick renders instead of showing its colour codes

The Filament Wishes list printed raw `^1` codes in the Author column. It now renders the same coloured markup the rest of the admin uses, and search still works against both the plain and the raw name.

## A lone demo has a way back onto its map page

A main record with no demo of its own gets its time history badge from a profile key entry, and that entry was only emitted for clusters of two or more. A single online demo slower than its player's own MDD record was therefore reachable by nothing on the map page, even though the time history endpoint returned it fine. It is now emitted for a lone demo too, but only when the demo is not already attached to a record, so rows that correctly have no history do not grow a "1".

This is a visible change across the site: 197950 online demos with no record spread over 13741 maps, roughly 3966 of which also hold an MDD record, so time history badges appear in a lot of new places. That is the intent. It also resolves the `gnj-finaltorture` report as a side effect.
