### PR TITLE
Fix the name on the record too, tighten the map record row, and end the deploy where you need to stand

### DIFF
--- a/app/Console/Commands/ReparseDemoMetadata.php
+++ b/app/Console/Commands/ReparseDemoMetadata.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Models\OfflineRecord;
 use App\Models\UploadedDemo;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
@@ -63,6 +64,7 @@ class ReparseDemoMetadata extends Command
             'unchanged' => 0,
             'changed' => 0,
             'assigned' => 0,
+            'physics_left' => 0,
         ];
 
         $query->orderBy('id')->chunkById(50, function ($demos) use ($apply, $limit, $journal, &$stats) {
@@ -91,8 +93,9 @@ class ReparseDemoMetadata extends Command
                 }
 
                 $changes = $this->diff($demo, $meta);
+                $offline = $this->offlineDiff($demo, $meta);
 
-                if (! $changes) {
+                if (! $changes && ! $offline) {
                     $stats['unchanged']++;
                     continue;
                 }
@@ -103,6 +106,20 @@ class ReparseDemoMetadata extends Command
 
                 foreach ($changes as $column => [$was, $now]) {
                     $this->line("      {$column}: " . var_export($was, true) . ' -> ' . var_export($now, true));
+                }
+
+                foreach ($offline['changes'] ?? [] as $column => [$was, $now]) {
+                    $this->line("      offline record {$offline['id']} {$column}: "
+                        . var_export($was, true) . ' -> ' . var_export($now, true));
+                }
+
+                // The offline record's physics decides which group it is ranked
+                // in, so moving it would leave both groups holding stale ranks.
+                // Say so and leave it; that one is a decision, not a typo.
+                if (isset($changes['physics']) && $offline) {
+                    $stats['physics_left']++;
+                    $this->line('      <fg=yellow>offline record keeps physics ' . $offline['physics']
+                        . ' - it is what the record is ranked under</>');
                 }
 
                 $this->line('      check: ' . url('/maps/' . $demo->map_name) . '  |  ' . url('/demos/' . $demo->id . '/download'));
@@ -123,9 +140,17 @@ class ReparseDemoMetadata extends Command
                         'id' => $demo->id,
                         'at' => now()->toIso8601String(),
                         'changes' => $changes,
+                        'offline' => $offline ? ['id' => $offline['id'], 'changes' => $offline['changes']] : null,
                     ]) . "\n");
 
-                    $demo->forceFill(array_map(fn ($pair) => $pair[1], $changes))->save();
+                    if ($changes) {
+                        $demo->forceFill(array_map(fn ($pair) => $pair[1], $changes))->save();
+                    }
+
+                    if ($offline) {
+                        OfflineRecord::where('id', $offline['id'])
+                            ->update(array_map(fn ($pair) => $pair[1], $offline['changes']));
+                    }
                 }
 
                 if ($sleep = (float) $this->option('sleep')) {
@@ -144,6 +169,7 @@ class ReparseDemoMetadata extends Command
             ['file unreadable', $stats['unreadable']],
             ['parse failed', $stats['unparsed']],
             ['of the corrected, already assigned', $stats['assigned']],
+            ['offline record left on its old physics', $stats['physics_left']],
         ]);
 
         if (! $apply && $stats['changed'] > 0) {
@@ -220,6 +246,27 @@ class ReparseDemoMetadata extends Command
                 $demo->forceFill($restore)->save();
                 $reverted++;
                 $this->line("  <fg=green>{$demo->id}</> back to " . json_encode($restore));
+            }
+
+            if ($offline = ($entry['offline'] ?? null)) {
+                $record = OfflineRecord::find($offline['id']);
+
+                foreach ($offline['changes'] ?? [] as $column => [$was, $now]) {
+                    if (! $record) {
+                        $missing++;
+                        break;
+                    }
+
+                    if ($record->{$column} !== $now) {
+                        $conflicts++;
+                        $this->line("  <fg=yellow>offline record {$record->id}</> {$column} is now "
+                            . var_export($record->{$column}, true) . ' - left alone');
+                        continue;
+                    }
+
+                    $record->forceFill([$column => $was])->save();
+                    $this->line("  <fg=green>offline record {$record->id}</> {$column} back to " . var_export($was, true));
+                }
             }
         }
 
@@ -333,5 +380,30 @@ class ReparseDemoMetadata extends Command
         }
 
         return $changes;
+    }
+
+    /**
+     * The name lives twice: the demo carries it, and the offline record built
+     * from it took a copy at the time. The map page shows the record's copy,
+     * so fixing only the demo leaves the wrong name exactly where it was
+     * reported. Returns null when there is nothing to do.
+     */
+    private function offlineDiff(UploadedDemo $demo, array $meta): ?array
+    {
+        $record = OfflineRecord::where('demo_id', $demo->id)->first();
+
+        if (! $record || empty($meta['player_name'])) {
+            return null;
+        }
+
+        if ($record->player_name === $meta['player_name']) {
+            return null;
+        }
+
+        return [
+            'id' => $record->id,
+            'physics' => $record->physics,
+            'changes' => ['player_name' => [$record->player_name, $meta['player_name']]],
+        ];
     }
 }

--- a/deploy.py
+++ b/deploy.py
@@ -263,6 +263,16 @@ def deploy(force=False):
     print(f"\n==> Pruning old releases (keeping {KEEP_RELEASES})...", flush=True)
     prune_releases()
 
+    # A shell that was sitting in `current` before this ran is now standing in
+    # the release we just replaced: bash resolved that symlink when you cd'd,
+    # and it holds the old directory, not the new one. Artisan there runs the
+    # previous deploy's code, and once that release is pruned it runs nothing
+    # at all. The script cannot fix that from here - a child process cannot
+    # move its parent shell - so it says so, with the line to paste.
+    print("\n==> Live.", flush=True)
+    print("    Any shell already open in `current` is now in the OLD release. Re-enter it:", flush=True)
+    print(f"\n    cd {PROJECT_PATH}/current\n", flush=True)
+
 if __name__ == "__main__":
     deploy(force="--force" in sys.argv)
 

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -469,18 +469,29 @@
             'border-l-2 border-transparent': compact,
         }"
     >
-        <!-- Rank Number - LARGE and prominent with pop animation -->
+        <!-- Rank Number - LARGE and prominent with pop animation. The score
+             took a column of its own and pushed the row's own buttons off the
+             edge on a narrower screen, so it borrows this one on hover: the
+             rank is what you read down the list, the score is what you look up
+             for one row at a time. -->
         <div
             v-if="!hideRank"
-            class="font-black text-sm w-8 flex-shrink-0 text-center leading-none transition-all duration-200 group-hover:scale-110"
+            class="font-black text-sm w-10 flex-shrink-0 text-center leading-none transition-all duration-200"
             :class="rankColorClass"
             :title="isVerified ? 'Verified - demo attached' : ''"
+            @mouseenter="record.map_score && $emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
+            @mouseleave="$emit('scoreHover', null)"
         >
-            <span v-if="hasValidityIssue || !record.rank" class="text-red-500/50" title="Flagged - does not count for ranking">&#x2715;</span>
-            <template v-else>{{ record.rank }}</template>
+            <span :class="record.map_score ? 'group-hover:hidden' : ''" class="inline-block transition-transform duration-200 group-hover:scale-110">
+                <span v-if="hasValidityIssue || !record.rank" class="text-red-500/50" title="Flagged - does not count for ranking">&#x2715;</span>
+                <template v-else>{{ record.rank }}</template>
+            </span>
+            <span v-if="record.map_score" class="hidden group-hover:inline text-yellow-400/90 tabular-nums cursor-help">
+                {{ Math.round(record.map_score) }}
+            </span>
         </div>
         <!-- Empty spacer preserves horizontal alignment with the parent row when rank is hidden -->
-        <div v-else class="w-8 flex-shrink-0"></div>
+        <div v-else class="w-10 flex-shrink-0"></div>
 
         <!-- Player Info - Compact -->
         <component
@@ -934,17 +945,6 @@
                 <div v-if="timeDiff" class="text-[10px] text-red-400 tabular-nums leading-none mt-0.5 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]">
                     -{{ formatTime(timeDiff) }}
                 </div>
-            </div>
-        </div>
-
-        <!-- Map Score -->
-        <div class="w-10 sm:w-12 text-center flex-shrink-0 -ml-1 flex items-start">
-            <div v-if="record.map_score"
-                class="text-sm font-black tabular-nums text-yellow-400/80 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] w-full cursor-help"
-                style="line-height: 16px;"
-                @mouseenter="$emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
-                @mouseleave="$emit('scoreHover', null)">
-                {{ Math.round(record.map_score) }}
             </div>
         </div>
 

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -462,7 +462,7 @@
     <div
         class="group relative flex items-center gap-1.5 rounded-md transition-all duration-200 -ml-3"
         :class="{
-            'py-1.5 hover:bg-white/10 hover:scale-[1.02] hover:shadow-lg': !compact,
+            'py-1.5 hover:bg-white/10 hover:shadow-lg': !compact,
             'py-0 opacity-70': compact,
             'bg-gradient-to-r from-emerald-500/15 to-transparent border-l-2 border-emerald-400 hover:from-emerald-500/25 hover:border-emerald-300': isMyRecord && !record.oldtop && !compact,
             'border-l-2 border-transparent hover:border-blue-500/50': !isMyRecord && !compact,
@@ -504,7 +504,6 @@
             :href="getRoute"
             :class="[
                 'flex items-center gap-2 min-w-0 flex-1 overflow-visible group/player transition-all duration-200',
-                !compact ? 'group-hover:ml-1' : '',
                 !getRoute && isLoggedIn && !isOfflineRecord ? 'cursor-default opacity-70' : !getRoute && !isOfflineRecord ? 'cursor-help opacity-70' : !getRoute && isOfflineRecord ? 'cursor-default' : 'cursor-pointer'
             ]"
         >

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -476,18 +476,21 @@
              for one row at a time. -->
         <div
             v-if="!hideRank"
-            class="font-black text-sm w-10 flex-shrink-0 text-center leading-none transition-all duration-200"
+            class="font-black text-sm w-10 flex-shrink-0 text-left pl-1.5 leading-none"
             :class="rankColorClass"
             :title="isVerified ? 'Verified - demo attached' : ''"
             @mouseenter="record.map_score && $emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
             @mouseleave="$emit('scoreHover', null)"
         >
-            <span :class="record.map_score ? 'group-hover:hidden' : ''" class="inline-block transition-transform duration-200 group-hover:scale-110">
+            <!-- Rank and score share a left edge, so the swap moves nothing:
+                 a four-digit score simply reaches further right into room the
+                 column already has. Centred, the wider one grew out of both
+                 sides at once and the row read as jumping left. No pop on
+                 hover either - the number changing is the whole effect. -->
+            <span :class="record.map_score ? 'group-hover:hidden' : ''">
                 <span v-if="hasValidityIssue || !record.rank" class="text-red-500/50" title="Flagged - does not count for ranking">&#x2715;</span>
                 <template v-else>{{ record.rank }}</template>
             </span>
-            <!-- Just wide enough for a four-digit score, so the swap moves
-                 nothing and a one-digit rank is not left sitting in a gap. -->
             <span v-if="record.map_score" class="hidden group-hover:inline whitespace-nowrap text-yellow-400/90 tabular-nums cursor-help">
                 {{ Math.round(record.map_score) }}
             </span>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -460,7 +460,7 @@
 
 <template>
     <div
-        class="group relative flex items-center gap-1.5 -mr-1 rounded-md transition-all duration-200 -ml-3"
+        class="group relative flex items-center gap-1.5 rounded-md transition-all duration-200 -ml-3"
         :class="{
             'py-1.5 hover:bg-white/10 hover:scale-[1.02] hover:shadow-lg': !compact,
             'py-0 opacity-70': compact,
@@ -933,7 +933,10 @@
                 <span>Time</span>
                 <span class="mt-0.5">History</span>
             </button>
-            <div class="text-right">
+            <!-- Fixed width: without one the time sat wherever the row's own
+                 badges left it, so no two rows lined up and the longest ran
+                 into the date. Sized for a time with minutes in it. -->
+            <div class="text-right w-[68px] flex-shrink-0">
                 <div
                     class="font-black tabular-nums leading-none drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]"
                     :class="{

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -931,10 +931,12 @@
                 <span>Time</span>
                 <span class="mt-0.5">History</span>
             </button>
-            <!-- Fixed width: without one the time sat wherever the row's own
-                 badges left it, so no two rows lined up and the longest ran
-                 into the date. Sized for a time with minutes in it. -->
-            <div class="text-right w-[68px] flex-shrink-0">
+            <!-- Sized to the time it holds, not to the longest time there
+                 could be. The date after it is a fixed width, so every time
+                 still ends on the same line - and the history button sits
+                 against its own row's number instead of a gap left for the
+                 minutes most runs do not have. -->
+            <div class="text-right flex-shrink-0">
                 <div
                     class="font-black tabular-nums leading-none drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]"
                     :class="{

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -476,7 +476,7 @@
              for one row at a time. -->
         <div
             v-if="!hideRank"
-            class="font-black text-sm w-10 flex-shrink-0 text-center leading-none transition-all duration-200"
+            class="font-black text-sm w-12 flex-shrink-0 text-center leading-none transition-all duration-200"
             :class="rankColorClass"
             :title="isVerified ? 'Verified - demo attached' : ''"
             @mouseenter="record.map_score && $emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
@@ -486,14 +486,16 @@
                 <span v-if="hasValidityIssue || !record.rank" class="text-red-500/50" title="Flagged - does not count for ranking">&#x2715;</span>
                 <template v-else>{{ record.rank }}</template>
             </span>
-            <!-- Nudged right: a four-digit score is wider than the column, and
-                 centred it spilled past the panel's left edge. -->
-            <span v-if="record.map_score" class="hidden group-hover:inline whitespace-nowrap translate-x-1.5 text-yellow-400/90 tabular-nums cursor-help">
+            <!-- The column is sized for a four-digit score, so swapping the
+                 rank for it moves nothing: both sit centred in the same box.
+                 Sized any tighter and the score spills either side and the
+                 whole row looks like it jumped left. -->
+            <span v-if="record.map_score" class="hidden group-hover:inline whitespace-nowrap text-yellow-400/90 tabular-nums cursor-help">
                 {{ Math.round(record.map_score) }}
             </span>
         </div>
         <!-- Empty spacer preserves horizontal alignment with the parent row when rank is hidden -->
-        <div v-else class="w-10 flex-shrink-0"></div>
+        <div v-else class="w-12 flex-shrink-0"></div>
 
         <!-- Player Info - Compact -->
         <component

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -486,7 +486,9 @@
                 <span v-if="hasValidityIssue || !record.rank" class="text-red-500/50" title="Flagged - does not count for ranking">&#x2715;</span>
                 <template v-else>{{ record.rank }}</template>
             </span>
-            <span v-if="record.map_score" class="hidden group-hover:inline text-yellow-400/90 tabular-nums cursor-help">
+            <!-- Nudged right: a four-digit score is wider than the column, and
+                 centred it spilled past the panel's left edge. -->
+            <span v-if="record.map_score" class="hidden group-hover:inline whitespace-nowrap translate-x-1.5 text-yellow-400/90 tabular-nums cursor-help">
                 {{ Math.round(record.map_score) }}
             </span>
         </div>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -476,7 +476,7 @@
              for one row at a time. -->
         <div
             v-if="!hideRank"
-            class="font-black text-sm w-12 flex-shrink-0 text-center leading-none transition-all duration-200"
+            class="font-black text-sm w-10 flex-shrink-0 text-center leading-none transition-all duration-200"
             :class="rankColorClass"
             :title="isVerified ? 'Verified - demo attached' : ''"
             @mouseenter="record.map_score && $emit('scoreHover', { score: record.map_score, reltime: record.reltime, base_score: record.base_score, rank_multiplier: record.rank_multiplier, multiplier: record.multiplier, el: $event.target })"
@@ -486,16 +486,14 @@
                 <span v-if="hasValidityIssue || !record.rank" class="text-red-500/50" title="Flagged - does not count for ranking">&#x2715;</span>
                 <template v-else>{{ record.rank }}</template>
             </span>
-            <!-- The column is sized for a four-digit score, so swapping the
-                 rank for it moves nothing: both sit centred in the same box.
-                 Sized any tighter and the score spills either side and the
-                 whole row looks like it jumped left. -->
+            <!-- Just wide enough for a four-digit score, so the swap moves
+                 nothing and a one-digit rank is not left sitting in a gap. -->
             <span v-if="record.map_score" class="hidden group-hover:inline whitespace-nowrap text-yellow-400/90 tabular-nums cursor-help">
                 {{ Math.round(record.map_score) }}
             </span>
         </div>
         <!-- Empty spacer preserves horizontal alignment with the parent row when rank is hidden -->
-        <div v-else class="w-12 flex-shrink-0"></div>
+        <div v-else class="w-10 flex-shrink-0"></div>
 
         <!-- Player Info - Compact -->
         <component
@@ -917,7 +915,7 @@
 
         <!-- Time - MASSIVE and eye-catching. History trigger sits next to the
              time stack, vertically centered across both rows (time + diff). -->
-        <div class="flex items-center justify-end gap-1.5 flex-shrink-0 ml-2">
+        <div class="flex items-center justify-end gap-1 flex-shrink-0 ml-0.5">
             <button
                 v-if="timeHistory && timeHistory.count"
                 type="button"

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1768,10 +1768,9 @@
                         <div v-if="getVq3Records.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mr-1 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-8 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">#</div>
+                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                                 <div class="text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
-                                <div class="w-10 sm:w-12 flex-shrink-0 text-center text-[10px] text-gray-400 uppercase tracking-wider font-semibold -ml-1">Score</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                             </div>
                             <div class="flex-grow">
@@ -1854,10 +1853,9 @@
                         <div v-if="getCpmRecords.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mr-1 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-8 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">#</div>
+                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                                 <div class="text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
-                                <div class="w-10 sm:w-12 flex-shrink-0 text-center text-[10px] text-gray-400 uppercase tracking-wider font-semibold -ml-1">Score</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                             </div>
                             <div class="flex-grow">

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1768,7 +1768,7 @@
                         <div v-if="getVq3Records.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
+                                <div class="w-10 flex-shrink-0 text-left pl-1.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                                 <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-0.5">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
@@ -1853,7 +1853,7 @@
                         <div v-if="getCpmRecords.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
+                                <div class="w-10 flex-shrink-0 text-left pl-1.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                                 <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-0.5">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1767,10 +1767,10 @@
                     <div class="p-3">
                         <div v-if="getVq3Records.total > 0">
                             <!-- Column Headers -->
-                            <div class="flex items-center gap-1.5 -ml-3 -mr-1 -mt-1 mb-0 pb-1 border-b border-white/15">
+                            <div class="flex items-center gap-1.5 -ml-3 -mt-1 mb-0 pb-1 border-b border-white/15">
                                 <div class="w-12 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
-                                <div class="text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
+                                <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                             </div>
                             <div class="flex-grow">
@@ -1852,10 +1852,10 @@
                     <div class="p-3">
                         <div v-if="getCpmRecords.total > 0">
                             <!-- Column Headers -->
-                            <div class="flex items-center gap-1.5 -ml-3 -mr-1 -mt-1 mb-0 pb-1 border-b border-white/15">
+                            <div class="flex items-center gap-1.5 -ml-3 -mt-1 mb-0 pb-1 border-b border-white/15">
                                 <div class="w-12 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
-                                <div class="text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
+                                <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                             </div>
                             <div class="flex-grow">

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1768,7 +1768,7 @@
                         <div v-if="getVq3Records.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mr-1 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
+                                <div class="w-12 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                                 <div class="text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
@@ -1853,7 +1853,7 @@
                         <div v-if="getCpmRecords.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mr-1 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
+                                <div class="w-12 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
                                 <div class="text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1768,9 +1768,9 @@
                         <div v-if="getVq3Records.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-12 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
+                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
-                                <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
+                                <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-0.5">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                             </div>
                             <div class="flex-grow">
@@ -1853,9 +1853,9 @@
                         <div v-if="getCpmRecords.total > 0">
                             <!-- Column Headers -->
                             <div class="flex items-center gap-1.5 -ml-3 -mt-1 mb-0 pb-1 border-b border-white/15">
-                                <div class="w-12 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
+                                <div class="w-10 flex-shrink-0 text-center pl-0.5 text-[10px] text-gray-400 uppercase tracking-wider font-semibold" title="Hover a row to see its score here">#</div>
                                 <div class="flex-1 text-[10px] text-gray-400 uppercase tracking-wider font-semibold">Player</div>
-                                <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-2">Time</div>
+                                <div class="w-[68px] flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right ml-0.5">Time</div>
                                 <div :class="[dateColWidth, 'flex-shrink-0 text-[10px] text-gray-400 uppercase tracking-wider font-semibold text-right']">Date</div>
                             </div>
                             <div class="flex-grow">


### PR DESCRIPTION
## The reparse fixes the record, not just the demo

The player name is stored twice: the demo carries it, and the offline record built from the demo took a copy at the time. The map page shows the record's copy, so correcting the demo alone left the wrong name exactly where it was reported - demo 995 reads KiD now while its record still said defrag. Both are corrected and both are journalled, so the undo puts back both.

The record's physics is deliberately left alone when the demo's changes: it decides which group the record is ranked in, and moving one row out would leave two groups holding stale ranks. The run reports when it happens.

## The map record row

Removed the SCORE column. The score now shares the rank's column and appears on hover, which saves the row more than the rank column gained - the video button on a record was previously pushed off the edge and unreachable.

Getting the swap to sit still took a few passes, and the culprit was not where it looked: the row scaled to 102% on hover, and since a transform grows from the centre, the left edge slid out about seven pixels every time the mouse crossed a row. The rank, closest to that edge, looked like it was stretching. That is gone, along with the player cell's own four-pixel nudge; the row still lights up, it just does it without moving. Rank and score also share a left edge now, so the swap itself moves nothing.

While in there: the time cell had no width of its own, so no two rows lined up and the longest ran into the date; it is sized to its content with the fixed-width date after it keeping every time on the same line. The row no longer pokes past the panel with a negative margin, and the history button sits against its own row's number instead of a gap left for minutes most runs do not have.

## Deploy says where to stand

A shell sitting in `current` before a deploy is left in the release that just got replaced - bash resolved the symlink when you cd'd and holds the old directory. Artisan run there is the previous deploy's code, and once that release is pruned it is nothing at all. The script cannot move the shell that started it, so it prints the line to paste.
