### PR TITLE
Recover the player name from demos old defrag left blank

### DIFF
--- a/app/Services/DemoProcessor/bin/console_string_utils.py
+++ b/app/Services/DemoProcessor/bin/console_string_utils.py
@@ -216,9 +216,15 @@ def get_name_offline_old1(demo_time_cmd: str) -> str:
     # then beats the one out of the demo's player info. The player is the last
     # quoted string; a line with a single quoted token, or none at all, keeps
     # the old reading.
+    #
+    # Older builds leave that last string empty and write no player at all:
+    #   NewTime 117546705 1:288 "defrag 1.7" ""
+    # Report no console name for those, so the name the demo carries in its own
+    # player info wins. Falling through to the fourth token would hand back the
+    # mod again.
     quoted = re.findall(r'"([^"]*)"', demo_time_cmd)
 
-    if len(quoted) > 1 and quoted[-1].strip():
+    if len(quoted) > 1:
         return normalize_name(remove_colors(quoted[-1]) or '')
 
     parts = demo_time_cmd.split(' ')


### PR DESCRIPTION
The backfill left 50 demos still recorded as a run by "defrag". They are not
players called defrag - each one carries a real nick in its filename - and the
console line is a shape the previous fix does not cover:

    NewTime 117546705 1:288 "defrag 1.7" ""

The mod is quoted and the player is an empty string. Taking the last quoted
string only when it has content fell through to the fourth space-separated
token, which is the mod again.

Returning the empty name instead leaves the console name absent, so the name the
demo carries in its own player info wins. Demo 237105 goes from "defrag" to
"TheUnknown", which is what its filename said all along. Both parsers were run
over the 91 demos in local storage: that one line is the only output that
changes.
