### PR TITLE
Stop offering a Time History that has nothing to show

### DIFF
--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -989,9 +989,18 @@ class MapsController extends Controller
             }
         }
 
-        // Group items by root.
+        // Group items by root. Flagged demos are skipped here as well, not only
+        // in the linking above: they never join a bucket, so each one survived
+        // as a cluster of its own and the singleton branch below then published
+        // a profile-key badge for it. Both time-history endpoints drop flagged
+        // demos outright, so that badge opened on "No matching demos found" -
+        // four of the seven profile badges on 2plyr did exactly that.
         $clusters = [];
         foreach ($demosArr as $i => $d) {
+            if (isset($flaggedSet[$d->id])) {
+                continue;
+            }
+
             $r = $find($i);
             $clusters[$r][] = $d;
         }


### PR DESCRIPTION
A record row could open its Time History drawer on "No matching demos found" -
four of the seven profile badges on 2plyr did.

`computeClusterMetadataForMap` skips flagged demos when it links demos into
clusters, but not when it groups them, so each flagged demo survived as a
cluster of one. Since 9ad7bc1 the singleton branch publishes a profile-key badge
for exactly that shape. Both time-history endpoints drop flagged demos outright,
so the badge promised a count the drawer refused to serve.

Skipping them in the grouping pass as well is enough: they never join a bucket,
so they can only ever be singletons and no other cluster loses a member. The row
now offers no drawer, which is what the endpoints have always meant.

Verified by calling the endpoint behind every badge on 2plyr and 4and - 51
badges, no disagreement, and the four empty ones are gone.

Note for anyone reading `validity_flag` next: it is not a cheat verdict. It
holds whatever cvar the parser saw deviating (`sv_fps=120.0` is the biggest
bucket site-wide), and `DemoProcessorService` already ranks each value in its own
leaderboard. That policy is untouched here.
