### PR TITLE
Stop handing out emails and linked-account tokens on public pages

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -21,6 +21,23 @@ class HandleInertiaRequests extends Middleware
     protected $rootView = 'app';
 
     /**
+     * User::$hidden keeps the email out of every payload, because a User gets
+     * serialized into public pages wherever it hangs off something else - a
+     * demo's uploader, a record's owner - and those pages are readable by
+     * anyone. A person's own address is theirs to see, though, and the settings
+     * page reads it from `auth.user`, which Jetstream builds from
+     * `$request->user()->toArray()`. Unhiding it on that one instance here, in
+     * handle(), puts it back before any prop is resolved without widening what
+     * the other User objects in the payload expose.
+     */
+    public function handle($request, \Closure $next)
+    {
+        $request->user()?->makeVisible('email');
+
+        return parent::handle($request, $next);
+    }
+
+    /**
      * Determines the current asset version.
      *
      * @see https://inertiajs.com/asset-versioning

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -107,6 +107,22 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
         'oldhash',
         'two_factor_recovery_codes',
         'two_factor_secret',
+
+        // A User is serialized into public page payloads wherever it hangs off
+        // something else - a demo's uploader, a record's owner - and those
+        // payloads are readable by anyone. Measured on production 2026-08-08:
+        // /maps/2plyr with Demos Top on handed out 8 addresses and a live
+        // Discord access + refresh token to an unauthenticated request. The
+        // linked-account tokens are credentials; the address is nobody's
+        // business. Own-account email is put back in HandleInertiaRequests,
+        // which is the only place the settings page reads it from.
+        'email',
+        'discord_token',
+        'discord_refresh_token',
+        'twitch_token',
+        'twitch_refresh_token',
+        'twitter_token',
+        'twitter_refresh_token',
     ];
 
     /**


### PR DESCRIPTION
A User is serialized into a page payload wherever it hangs off something else - a demo's uploader, a record's owner - and those payloads are public. Measured on production: /maps/2plyr with Demos Top on returned 8 email addresses and a live Discord access token plus its refresh token to an unauthenticated request. The same objects come back from /maps/{map}/time-history, which needs no auth either.

Password, remember_token and the 2FA secrets were already hidden. The linked account tokens never were, and they are credentials: with that pair you can act as the user on Discord until they revoke it. Hide them, and the email with them.

The settings page reads the person's own address from `auth.user`, which Jetstream builds from `$request->user()->toArray()`, so handle() unhides it on that one instance - their own address, on their own settings page, and nothing else in the payload widens.

Deploying this is not enough on its own: the Demos Top cache stores serialized model instances, and $hidden travels with them, so entries written before the deploy keep their old rules for up to an hour. Flush the cache after deploying.