### PR TITLE
Give freestyle and trick demos a place on the map they belong to

### DIFF
--- a/app/Http/Controllers/DemosController.php
+++ b/app/Http/Controllers/DemosController.php
@@ -489,6 +489,111 @@ class DemosController extends Controller
     }
 
     /**
+     * Accounts to offer when assigning a demo to a player. Unlike
+     * searchUploaders this is every account, not just people who have uploaded
+     * something - the whole point is attributing a demo to somebody who never
+     * touched the upload form.
+     */
+    public function searchPlayers(Request $request)
+    {
+        if (! $this->canAssignDemoToUser(Auth::user())) {
+            abort(403, 'Staff only');
+        }
+
+        $q = trim((string) $request->input('q', ''));
+
+        if (strlen($q) < 2) {
+            return response()->json([]);
+        }
+
+        return response()->json(
+            \App\Models\User::where('plain_name', 'LIKE', "%{$q}%")
+                ->orWhere('name', 'LIKE', "%{$q}%")
+                ->orderBy('plain_name')
+                ->limit(15)
+                ->get(['id', 'name', 'plain_name', 'country', 'profile_photo_path'])
+        );
+    }
+
+    /**
+     * Attribute a demo to an account. Written for freestyle and trick demos,
+     * which hang off no record and so had nothing that could say whose they
+     * are; the alias resolver only reaches 1 in 4 of them.
+     *
+     * With `apply_to_nick` it does the same for every other demo carrying that
+     * exact nick, which is the difference between one click and forty on a map
+     * where somebody has been at it all evening. Same nick only, colours
+     * stripped, never a similar one - a guess under somebody's avatar asserts
+     * the run is theirs.
+     *
+     * Staff only, and `user_id = null` takes an assignment back off.
+     */
+    public function assignToUser(Request $request, UploadedDemo $demo)
+    {
+        $currentUser = Auth::user();
+
+        if (! $this->canAssignDemoToUser($currentUser)) {
+            abort(403, 'Only staff can attribute a demo to an account');
+        }
+
+        $request->validate([
+            'user_id' => 'nullable|exists:users,id',
+            'apply_to_nick' => 'boolean',
+        ]);
+
+        $userId = $request->input('user_id') ?: null;
+
+        $values = [
+            'assigned_user_id' => $userId,
+            'assigned_by_user_id' => $userId ? $currentUser->id : null,
+            'assigned_user_at' => $userId ? now() : null,
+        ];
+
+        $demo->update($values);
+        $touched = 1;
+
+        if ($request->boolean('apply_to_nick') && $demo->player_name) {
+            $touched += UploadedDemo::where('id', '!=', $demo->id)
+                ->where('player_name', $demo->player_name)
+                ->update($values);
+        }
+
+        Log::info('Demo attributed to account', [
+            'demo_id' => $demo->id,
+            'user_id' => $userId,
+            'by_user' => $currentUser->id,
+            'nick' => $demo->player_name,
+            'demos_touched' => $touched,
+        ]);
+
+        // The map page reads its demo list through the Demos Top cache, which
+        // holds hydrated models - without this the attribution shows up an hour
+        // later. See RebuildDemosTopRanksJob.
+        if ($demo->map_name) {
+            Cache::increment('demostop_gen:' . $demo->map_name);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'demos_touched' => $touched,
+            'user' => $userId ? \App\Models\User::find($userId, ['id', 'name', 'plain_name', 'country', 'profile_photo_path']) : null,
+        ]);
+    }
+
+    /**
+     * Saying "this run is yours" in public is a claim about somebody else, so
+     * it stays with the people who already answer for the leaderboard.
+     */
+    private function canAssignDemoToUser($user): bool
+    {
+        if (! $user) {
+            return false;
+        }
+
+        return (bool) ($user->admin ?? false) || (bool) ($user->is_moderator ?? false);
+    }
+
+    /**
      * Upload demos with rate limiting and queue processing
      */
     public function upload(Request $request)

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -268,10 +268,36 @@ class MapsController extends Controller
         $demos = $vq3->getCollection()->concat($cpm->getCollection());
         $validityFlags = $this->validityFlagsByDemo($demos->pluck('id')->all());
 
+        // Attribute them the way everything else on the site does: approved
+        // aliases, through the same resolver Demos Top clusters with. A
+        // freestyle demo can never hang off a record, so without this the rows
+        // showed a question mark for an avatar and led nowhere, even for people
+        // whose nick the site knows perfectly well.
+        //
+        // Deliberately NOT suggested_user_id, which 11596 of the 11640
+        // freestyle demos carry: that is the fuzzy matcher's guess, and putting
+        // a guess under somebody's avatar asserts the run is theirs.
+        $resolver = new DemoProfileResolver();
+        $priorityKeys = \App\Models\Record::where('mapname', $map->name)
+            ->select(['user_id', 'mdd_id'])->get()
+            ->flatMap(fn ($r) => array_filter([
+                $r->user_id ? 'user:' . (int) $r->user_id : null,
+                $r->mdd_id ? 'mdd:' . (int) $r->mdd_id : null,
+            ]))->unique()->values()->all();
+
+        $profileKeys = $demos->mapWithKeys(fn ($d) => [$d->id => $resolver->resolve($d, $priorityKeys)]);
+        $users = \App\Models\User::whereIn('id', $profileKeys
+            ->filter(fn ($k) => $k && str_starts_with($k, 'user:'))
+            ->map(fn ($k) => (int) substr($k, 5))->unique()->values())
+            ->get()->keyBy('id');
+
         // MapRecord's shape, so the list gets the same chips, download button,
         // video and report actions the leaderboard rows have.
-        $shape = function ($d) use ($validityFlags) {
+        $shape = function ($d) use ($validityFlags, $profileKeys, $users) {
             $isOnline = $d->gametype && str_starts_with($d->gametype, 'm');
+            $key = $profileKeys[$d->id] ?? null;
+            $owner = $key && str_starts_with($key, 'user:') ? $users->get((int) substr($key, 5)) : null;
+            $mddId = $key && str_starts_with($key, 'mdd:') ? (int) substr($key, 4) : null;
 
             return [
                 'id' => $d->id,
@@ -281,13 +307,14 @@ class MapsController extends Controller
                 'time_ms' => $d->time_ms,
                 'date_set' => $d->record_date ?? $d->created_at,
                 'player_name' => $d->player_name,
-                'name' => $d->record?->user?->name ?? $d->player_name,
-                'country' => $d->country ?? '_404',
+                'name' => $owner?->name ?? $d->record?->user?->name ?? $d->player_name,
+                'country' => $d->country ?? $owner?->country ?? '_404',
                 'is_online' => $isOnline,
                 'verification_type' => $validityFlags[$d->id]
                     ?? ($d->record_id ? 'verified' : ($isOnline ? 'ONLINE' : 'OFFLINE')),
                 'rank' => null,
-                'user' => $d->record?->user,
+                'user' => $owner ?? $d->record?->user,
+                'mdd_id' => $mddId,
                 'demo' => $d,
                 'demo_label' => $this->demoLabel($d),
                 'uploaded_demos' => [],

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -249,7 +249,10 @@ class MapsController extends Controller
         // not one run per person: on csu1_a two people have a hundred apiece,
         // and 1523 demos come down to 258 names.
         $base = fn (string $physics) => UploadedDemo::where('map_name', $map->name)
-            ->whereIn('status', ['assigned', 'fallback-assigned', 'processed'])
+            // failed-validity belongs here too: it means the demo deviated on
+            // some cvar, not that it is unusable, and 567 freestyle demos carry
+            // it. They are listed with the flag on a chip, same as everywhere.
+            ->whereIn('status', ['assigned', 'fallback-assigned', 'processed', 'failed-validity'])
             ->where(fn ($q) => $q->where('physics', $physics)->orWhere('physics', 'LIKE', $physics . '.%'))
             ->where(fn ($q) => $q->whereIn('gametype', ['fs', 'mfs'])->orWhereNull('time_ms'));
 

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -238,29 +238,41 @@ class MapsController extends Controller
      */
     private function untimedDemos($map, $cpmRecords, $vq3Records): ?\Illuminate\Support\Collection
     {
+        // A freestyle map always gets the list: its demos are the content, and
+        // it can still hold a stray ranked row. Any other map gets it only when
+        // there is nothing to rank at all, so ordinary map pages are untouched.
+        $untimedMap = in_array($map->gametype, ['freestyle', 'unknown'], true);
         $hasTimes = ($cpmRecords && $cpmRecords->total() > 0) || ($vq3Records && $vq3Records->total() > 0);
 
-        if ($hasTimes) {
+        if (! $untimedMap && $hasTimes) {
             return null;
         }
 
-        $demos = UploadedDemo::where('map_name', $map->name)
+        // Paginated per physics, 50 a page, the same as the leaderboards - a
+        // freestyle map is not a handful of demos (csu1_a holds 1502 VQ3 and
+        // 115 CPM) and a flat cap just hid the rest.
+        $page = fn (string $base, string $pageName) => UploadedDemo::where('map_name', $map->name)
             ->whereIn('status', ['assigned', 'fallback-assigned', 'processed'])
+            ->where(fn ($q) => $q->where('physics', $base)->orWhere('physics', 'LIKE', $base . '.%'))
             ->with(['renderedVideo', 'user', 'record.user'])
             ->orderByDesc('record_date')
             ->orderByDesc('created_at')
-            ->limit(500)
-            ->get();
+            ->paginate(50, ['*'], $pageName)
+            ->withQueryString();
 
-        if ($demos->isEmpty()) {
+        $vq3 = $page('VQ3', 'vq3DemosPage');
+        $cpm = $page('CPM', 'cpmDemosPage');
+
+        if ($vq3->total() === 0 && $cpm->total() === 0) {
             return null;
         }
 
+        $demos = $vq3->getCollection()->concat($cpm->getCollection());
         $validityFlags = $this->validityFlagsByDemo($demos->pluck('id')->all());
 
         // MapRecord's shape, so the list gets the same chips, download button,
         // video and report actions the leaderboard rows have.
-        return $demos->map(function ($d) use ($validityFlags) {
+        $shape = function ($d) use ($validityFlags) {
             $isOnline = $d->gametype && str_starts_with($d->gametype, 'm');
 
             return [
@@ -285,7 +297,12 @@ class MapsController extends Controller
                 'q3df_login_name' => $d->q3df_login_name,
                 'q3df_login_name_colored' => $d->q3df_login_name_colored,
             ];
-        })->values();
+        };
+
+        $vq3->setCollection($vq3->getCollection()->map($shape)->values());
+        $cpm->setCollection($cpm->getCollection()->map($shape)->values());
+
+        return collect(['vq3' => $vq3, 'cpm' => $cpm]);
     }
 
     /**

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -225,6 +225,49 @@ class MapsController extends Controller
     }
 
     /**
+     * The mode a demo was recorded in, off its gametype. The 'm' prefix only
+     * says the run happened online, so it does not change the mode.
+     */
+    private const GAMETYPE_FAMILIES = [
+        'df' => 'run',      'mdf' => 'run',
+        'fc' => 'fastcap',  'mfc' => 'fastcap',
+        'fs' => 'freestyle', 'mfs' => 'freestyle',
+    ];
+
+    private static function familyOf(?string $gametype): ?string
+    {
+        return self::GAMETYPE_FAMILIES[$gametype] ?? null;
+    }
+
+    /**
+     * Keep a demo set to one mode. Physics alone does not separate them: a
+     * freestyle demo is stored as `[fs.cpm.2]` -> physics `CPM.2`, the same
+     * value a fastcap run on flag 2 carries, so the fastcap's time history was
+     * pulling in freestyle demos and listing them at 00.000 because freestyle
+     * has no time to show. Reported by Enter with prince_quake and cos1_beta7b;
+     * measured there, 20 of the 36 demos behind one fastcap run were freestyle.
+     *
+     * Demos with no gametype at all (2947, all but 24 of them failed uploads)
+     * are left in rather than silently dropped - they are unclassifiable, not
+     * known to be a different mode.
+     */
+    private function scopeDemoFamily($query, ?string $family)
+    {
+        if ($family === null) {
+            return $query;
+        }
+
+        $types = array_keys(array_filter(
+            self::GAMETYPE_FAMILIES,
+            fn ($f) => $f === $family
+        ));
+
+        return $query->where(function ($q) use ($types) {
+            $q->whereIn('gametype', $types)->orWhereNull('gametype');
+        });
+    }
+
+    /**
      * Demos a history must not contain at all. Only approved community flags
      * count: somebody looked at the run and decided it is not what it claims.
      *
@@ -302,6 +345,7 @@ class MapsController extends Controller
         // they landed in one history together.
         $demos = UploadedDemo::where('map_name', $mapname)
             ->where(fn ($q) => $this->scopeDemoPhysics($q, $physics, self::fastcapOf($seed->physics)))
+            ->where(fn ($q) => $this->scopeDemoFamily($q, self::familyOf($seed->gametype)))
             ->with(['renderedVideo', 'user', 'record.user'])
             ->get();
 
@@ -458,8 +502,11 @@ class MapsController extends Controller
             return response()->json(['history' => [], 'signals' => 0]);
         }
 
+        // A main record is a run or a fastcap, never freestyle, so the mode the
+        // caller is looking at is whichever one the fastcap number says.
         $demos = UploadedDemo::where('map_name', $mapname)
             ->where(fn ($q) => $this->scopeDemoPhysics($q, $physics, $fastcap))
+            ->where(fn ($q) => $this->scopeDemoFamily($q, $fastcap !== null ? 'fastcap' : 'run'))
             ->with(['renderedVideo', 'user', 'record.user'])
             ->get();
 
@@ -937,8 +984,11 @@ class MapsController extends Controller
     {
         // Same gametype rule as the drawer itself, or the badge would promise
         // a count the drawer then refuses to show.
+        // Same mode rule as the drawer, or the badge counts freestyle demos the
+        // drawer then refuses to list.
         $demos = UploadedDemo::where('map_name', $mapname)
             ->where(fn ($q) => $this->scopeDemoPhysics($q, $physics, $fastcap))
+            ->where(fn ($q) => $this->scopeDemoFamily($q, $fastcap !== null ? 'fastcap' : 'run'))
             ->get(['id', 'player_name', 'q3df_login_name', 'q3df_login_name_colored',
                    'time_ms', 'gametype', 'record_date', 'record_id', 'file_hash', 'created_at']);
 

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -258,7 +258,8 @@ class MapsController extends Controller
         // relations loaded further down.
         $light = fn (string $physics) => $base($physics)
             ->orderByDesc('record_date')->orderByDesc('created_at')
-            ->get(['id', 'player_name', 'q3df_login_name', 'q3df_login_name_colored', 'record_date', 'created_at']);
+            ->get(['id', 'player_name', 'q3df_login_name', 'q3df_login_name_colored',
+                   'assigned_user_id', 'record_date', 'created_at']);
 
         $vq3Light = $light('VQ3');
         $cpmLight = $light('CPM');
@@ -287,7 +288,10 @@ class MapsController extends Controller
         // No profile: fall back to the nick on the demo, colours stripped, so
         // somebody the site does not know still gets one row instead of forty.
         // Only ever merges identical nicks, never two different ones.
-        $keyOf = fn ($d) => $resolver->resolve($d, $priorityKeys)
+        // A staff assignment outranks the resolver: somebody looked at the demo
+        // and said whose it is, which beats matching a nick.
+        $keyOf = fn ($d) => ($d->assigned_user_id ? 'user:' . $d->assigned_user_id : null)
+            ?: $resolver->resolve($d, $priorityKeys)
             ?: 'name:' . strtolower(trim(preg_replace('/\^[0-9a-zA-Z]/', '', $d->player_name ?? '')));
 
         // Biggest first, the way a freestyle map reads: who has been at it.
@@ -355,6 +359,7 @@ class MapsController extends Controller
                 'mdd_id' => $mddId,
                 'demo' => $d,
                 'demo_label' => $this->demoLabel($d),
+                'assigned_user_id' => $d->assigned_user_id,
                 'uploaded_demos' => [],
                 'rendered_videos' => $d->renderedVideo ? [$d->renderedVideo] : [],
                 'q3df_login_name' => $d->q3df_login_name,

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -245,28 +245,27 @@ class MapsController extends Controller
         // hold both these and real records (cos1_beta7b has 267 freestyle demos
         // beside 21 records), which is why the page offers both.
         //
-        // Paginated per physics, 50 a page, the same as the leaderboards - a
-        // freestyle map is not a handful of demos (csu1_a holds 1502 VQ3 and
-        // 115 CPM) and a flat cap just hid the rest.
-        $page = fn (string $base, string $pageName) => UploadedDemo::where('map_name', $map->name)
+        // Grouped by player, one row each, opening to their demos. Freestyle is
+        // not one run per person: on csu1_a two people have a hundred apiece,
+        // and 1523 demos come down to 258 names.
+        $base = fn (string $physics) => UploadedDemo::where('map_name', $map->name)
             ->whereIn('status', ['assigned', 'fallback-assigned', 'processed'])
-            ->where(fn ($q) => $q->where('physics', $base)->orWhere('physics', 'LIKE', $base . '.%'))
-            ->where(fn ($q) => $q->whereIn('gametype', ['fs', 'mfs'])->orWhereNull('time_ms'))
-            ->with(['renderedVideo', 'user', 'record.user'])
-            ->orderByDesc('record_date')
-            ->orderByDesc('created_at')
-            ->paginate(50, ['*'], $pageName)
-            ->withQueryString();
+            ->where(fn ($q) => $q->where('physics', $physics)->orWhere('physics', 'LIKE', $physics . '.%'))
+            ->where(fn ($q) => $q->whereIn('gametype', ['fs', 'mfs'])->orWhereNull('time_ms'));
 
-        $vq3 = $page('VQ3', 'vq3DemosPage');
-        $cpm = $page('CPM', 'cpmDemosPage');
+        // Grouping needs the identity fields and nothing else, so the whole map
+        // is read cheaply; only the demos on the page being looked at get their
+        // relations loaded further down.
+        $light = fn (string $physics) => $base($physics)
+            ->orderByDesc('record_date')->orderByDesc('created_at')
+            ->get(['id', 'player_name', 'q3df_login_name', 'q3df_login_name_colored', 'record_date', 'created_at']);
 
-        if ($vq3->total() === 0 && $cpm->total() === 0) {
+        $vq3Light = $light('VQ3');
+        $cpmLight = $light('CPM');
+
+        if ($vq3Light->isEmpty() && $cpmLight->isEmpty()) {
             return null;
         }
-
-        $demos = $vq3->getCollection()->concat($cpm->getCollection());
-        $validityFlags = $this->validityFlagsByDemo($demos->pluck('id')->all());
 
         // Attribute them the way everything else on the site does: approved
         // aliases, through the same resolver Demos Top clusters with. A
@@ -278,26 +277,65 @@ class MapsController extends Controller
         // freestyle demos carry: that is the fuzzy matcher's guess, and putting
         // a guess under somebody's avatar asserts the run is theirs.
         $resolver = new DemoProfileResolver();
-        $priorityKeys = \App\Models\Record::where('mapname', $map->name)
+        $priorityKeys = Record::where('mapname', $map->name)
             ->select(['user_id', 'mdd_id'])->get()
             ->flatMap(fn ($r) => array_filter([
                 $r->user_id ? 'user:' . (int) $r->user_id : null,
                 $r->mdd_id ? 'mdd:' . (int) $r->mdd_id : null,
             ]))->unique()->values()->all();
 
-        $profileKeys = $demos->mapWithKeys(fn ($d) => [$d->id => $resolver->resolve($d, $priorityKeys)]);
-        $users = \App\Models\User::whereIn('id', $profileKeys
-            ->filter(fn ($k) => $k && str_starts_with($k, 'user:'))
+        // No profile: fall back to the nick on the demo, colours stripped, so
+        // somebody the site does not know still gets one row instead of forty.
+        // Only ever merges identical nicks, never two different ones.
+        $keyOf = fn ($d) => $resolver->resolve($d, $priorityKeys)
+            ?: 'name:' . strtolower(trim(preg_replace('/\^[0-9a-zA-Z]/', '', $d->player_name ?? '')));
+
+        // Biggest first, the way a freestyle map reads: who has been at it.
+        $group = fn ($rows) => $rows->groupBy($keyOf)
+            ->map(fn ($g) => $g->pluck('id')->all())
+            ->sortByDesc(fn ($ids) => count($ids));
+
+        $paginate = function ($groups, string $pageName) {
+            $page = max(1, (int) request()->input($pageName, 1));
+
+            return new \Illuminate\Pagination\LengthAwarePaginator(
+                // Ten a page, not fifty: the groups arrive open, and the
+                // biggest ones here run to a hundred demos apiece.
+                $groups->slice(($page - 1) * 10, 10),
+                $groups->count(),
+                10,
+                $page,
+                ['path' => request()->url(), 'pageName' => $pageName, 'query' => request()->query()]
+            );
+        };
+
+        $vq3Page = $paginate($group($vq3Light), 'vq3DemosPage');
+        $cpmPage = $paginate($group($cpmLight), 'cpmDemosPage');
+
+        // values() before merging: both are keyed by profile key, and a
+        // player with demos in both physics would otherwise have one side
+        // silently overwrite the other.
+        $shownIds = collect($vq3Page->items())->values()
+            ->merge(collect($cpmPage->items())->values())
+            ->flatten()->unique()->values();
+
+        $demos = UploadedDemo::whereIn('id', $shownIds)
+            ->with(['renderedVideo', 'user', 'record.user'])
+            ->orderByDesc('record_date')->orderByDesc('created_at')
+            ->get()->keyBy('id');
+
+        $validityFlags = $this->validityFlagsByDemo($shownIds->all());
+
+        $users = User::whereIn('id', collect($vq3Page->items())->keys()
+            ->merge(collect($cpmPage->items())->keys())
+            ->filter(fn ($k) => str_starts_with($k, 'user:'))
             ->map(fn ($k) => (int) substr($k, 5))->unique()->values())
             ->get()->keyBy('id');
 
-        // MapRecord's shape, so the list gets the same chips, download button,
-        // video and report actions the leaderboard rows have.
-        $shape = function ($d) use ($validityFlags, $profileKeys, $users) {
+        // MapRecord's shape, so the demos inside a group get the same chips,
+        // download button, video and report actions the leaderboard rows have.
+        $shape = function ($d, $owner, $mddId) use ($validityFlags) {
             $isOnline = $d->gametype && str_starts_with($d->gametype, 'm');
-            $key = $profileKeys[$d->id] ?? null;
-            $owner = $key && str_starts_with($key, 'user:') ? $users->get((int) substr($key, 5)) : null;
-            $mddId = $key && str_starts_with($key, 'mdd:') ? (int) substr($key, 4) : null;
 
             return [
                 'id' => $d->id,
@@ -307,13 +345,13 @@ class MapsController extends Controller
                 'time_ms' => $d->time_ms,
                 'date_set' => $d->record_date ?? $d->created_at,
                 'player_name' => $d->player_name,
-                'name' => $owner?->name ?? $d->record?->user?->name ?? $d->player_name,
+                'name' => $owner?->name ?? $d->player_name,
                 'country' => $d->country ?? $owner?->country ?? '_404',
                 'is_online' => $isOnline,
                 'verification_type' => $validityFlags[$d->id]
                     ?? ($d->record_id ? 'verified' : ($isOnline ? 'ONLINE' : 'OFFLINE')),
                 'rank' => null,
-                'user' => $owner ?? $d->record?->user,
+                'user' => $owner,
                 'mdd_id' => $mddId,
                 'demo' => $d,
                 'demo_label' => $this->demoLabel($d),
@@ -324,10 +362,41 @@ class MapsController extends Controller
             ];
         };
 
-        $vq3->setCollection($vq3->getCollection()->map($shape)->values());
-        $cpm->setCollection($cpm->getCollection()->map($shape)->values());
+        $buildGroups = function ($paginator) use ($demos, $users, $shape) {
+            $out = [];
 
-        return collect(['vq3' => $vq3, 'cpm' => $cpm]);
+            foreach ($paginator->items() as $key => $ids) {
+                $owner = str_starts_with($key, 'user:') ? $users->get((int) substr($key, 5)) : null;
+                $mddId = str_starts_with($key, 'mdd:') ? (int) substr($key, 4) : null;
+
+                $rows = collect($ids)->map(fn ($id) => $demos->get($id))->filter()
+                    ->map(fn ($d) => $shape($d, $owner, $mddId))->values();
+
+                if ($rows->isEmpty()) {
+                    continue;
+                }
+
+                $out[] = [
+                    'key' => $key,
+                    'name' => $owner?->name ?? $rows->first()['player_name'],
+                    'user' => $owner,
+                    'mdd_id' => $mddId,
+                    'country' => $rows->first()['country'],
+                    'count' => $rows->count(),
+                    'latest' => $rows->first()['date_set'],
+                    'demos' => $rows,
+                ];
+            }
+
+            $paginator->setCollection(collect($out));
+
+            return $paginator;
+        };
+
+        return collect([
+            'vq3' => $buildGroups($vq3Page),
+            'cpm' => $buildGroups($cpmPage),
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -225,6 +225,95 @@ class MapsController extends Controller
     }
 
     /**
+     * The demos on a map that has no leaderboard to put them in.
+     *
+     * A freestyle map has no timer, so nothing it holds can be ranked, and its
+     * page was two empty tables however many demos people had uploaded to it -
+     * csu1_a alone carries 1617. The same happens to a run map nobody has ever
+     * set a record on. 88 maps and 4176 demos site-wide, all of them with a
+     * thumbnail, an author and a pk3 already in hand.
+     *
+     * Returns null when the map does have times to show, so the page keeps its
+     * leaderboards and nothing else changes.
+     */
+    private function untimedDemos($map, $cpmRecords, $vq3Records): ?\Illuminate\Support\Collection
+    {
+        $hasTimes = ($cpmRecords && $cpmRecords->total() > 0) || ($vq3Records && $vq3Records->total() > 0);
+
+        if ($hasTimes) {
+            return null;
+        }
+
+        $demos = UploadedDemo::where('map_name', $map->name)
+            ->whereIn('status', ['assigned', 'fallback-assigned', 'processed'])
+            ->with(['renderedVideo', 'user', 'record.user'])
+            ->orderByDesc('record_date')
+            ->orderByDesc('created_at')
+            ->limit(500)
+            ->get();
+
+        if ($demos->isEmpty()) {
+            return null;
+        }
+
+        $validityFlags = $this->validityFlagsByDemo($demos->pluck('id')->all());
+
+        // MapRecord's shape, so the list gets the same chips, download button,
+        // video and report actions the leaderboard rows have.
+        return $demos->map(function ($d) use ($validityFlags) {
+            $isOnline = $d->gametype && str_starts_with($d->gametype, 'm');
+
+            return [
+                'id' => $d->id,
+                'demo_id' => $d->id,
+                'record_id' => $d->record_id,
+                'time' => $d->time_ms,
+                'time_ms' => $d->time_ms,
+                'date_set' => $d->record_date ?? $d->created_at,
+                'player_name' => $d->player_name,
+                'name' => $d->record?->user?->name ?? $d->player_name,
+                'country' => $d->country ?? '_404',
+                'is_online' => $isOnline,
+                'verification_type' => $validityFlags[$d->id]
+                    ?? ($d->record_id ? 'verified' : ($isOnline ? 'ONLINE' : 'OFFLINE')),
+                'rank' => null,
+                'user' => $d->record?->user,
+                'demo' => $d,
+                'demo_label' => $this->demoLabel($d),
+                'uploaded_demos' => [],
+                'rendered_videos' => $d->renderedVideo ? [$d->renderedVideo] : [],
+                'q3df_login_name' => $d->q3df_login_name,
+                'q3df_login_name_colored' => $d->q3df_login_name_colored,
+            ];
+        })->values();
+    }
+
+    /**
+     * What the uploader called the demo, with everything the row already shows
+     * taken out: the map, the mode brackets, the (player.country) and the
+     * {cvars}. On a freestyle map that leftover is the whole point of the demo
+     * - "oups-fs-b1_jpad_1xR_3xR" or "Szak_white2-to-blue1" - and with no time
+     * to tell the runs apart it is the only thing that does.
+     */
+    private function demoLabel(UploadedDemo $d): ?string
+    {
+        $name = $d->original_filename ?: $d->processed_filename;
+
+        if (! $name) {
+            return null;
+        }
+
+        $name = preg_replace('/\.(dm_6\d|7z|zip)$/i', '', $name);
+        $name = preg_replace('/^' . preg_quote($d->map_name ?? '', '/') . '/i', '', $name);
+        $name = preg_replace('/\[[^\]]*\]/', '', $name);      // [fs.vq3.2]
+        $name = preg_replace('/\{[^}]*\}?/', '', $name);      // {sv_fps=120}, unclosed included
+        $name = preg_replace('/\([^)]*\)?/', '', $name);      // (player.country)
+        $name = trim($name, " \t-_.");
+
+        return $name !== '' ? $name : null;
+    }
+
+    /**
      * The mode a demo was recorded in, off its gametype. The 'm' prefix only
      * says the run happened online, so it does not change the mode.
      */
@@ -945,6 +1034,7 @@ class MapsController extends Controller
 
         return Inertia::render('MapView')
             ->with('map', $map)
+            ->with('untimedDemos', $this->untimedDemos($map, $cpmRecords, $vq3Records))
             ->with('cpmRecords', $cpmRecords)
             ->with('vq3Records', $vq3Records)
             ->with('my_cpm_record', $my_cpm_record)

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -314,20 +314,10 @@ class MapsController extends Controller
      */
     private function demoLabel(UploadedDemo $d): ?string
     {
-        $name = $d->original_filename ?: $d->processed_filename;
-
-        if (! $name) {
-            return null;
-        }
-
-        $name = preg_replace('/\.(dm_6\d|7z|zip)$/i', '', $name);
-        $name = preg_replace('/^' . preg_quote($d->map_name ?? '', '/') . '/i', '', $name);
-        $name = preg_replace('/\[[^\]]*\]/', '', $name);      // [fs.vq3.2]
-        $name = preg_replace('/\{[^}]*\}?/', '', $name);      // {sv_fps=120}, unclosed included
-        $name = preg_replace('/\([^)]*\)?/', '', $name);      // (player.country)
-        $name = trim($name, " \t-_.");
-
-        return $name !== '' ? $name : null;
+        return \App\Services\VideoMetadataService::demoLabel(
+            $d->original_filename ?: $d->processed_filename,
+            $d->map_name
+        );
     }
 
     /**

--- a/app/Http/Controllers/MapsController.php
+++ b/app/Http/Controllers/MapsController.php
@@ -236,24 +236,22 @@ class MapsController extends Controller
      * Returns null when the map does have times to show, so the page keeps its
      * leaderboards and nothing else changes.
      */
-    private function untimedDemos($map, $cpmRecords, $vq3Records): ?\Illuminate\Support\Collection
+    private function untimedDemos($map): ?\Illuminate\Support\Collection
     {
-        // A freestyle map always gets the list: its demos are the content, and
-        // it can still hold a stray ranked row. Any other map gets it only when
-        // there is nothing to rank at all, so ordinary map pages are untouched.
-        $untimedMap = in_array($map->gametype, ['freestyle', 'unknown'], true);
-        $hasTimes = ($cpmRecords && $cpmRecords->total() > 0) || ($vq3Records && $vq3Records->total() > 0);
-
-        if (! $untimedMap && $hasTimes) {
-            return null;
-        }
-
+        // Everything on the map that is not a timed run: freestyle, and any
+        // demo with no time at all - a trick, a tutorial, a run that never
+        // finished. Neither can be ranked and neither belongs in a history of
+        // times, so without this list they are reachable from nowhere. 183 maps
+        // hold both these and real records (cos1_beta7b has 267 freestyle demos
+        // beside 21 records), which is why the page offers both.
+        //
         // Paginated per physics, 50 a page, the same as the leaderboards - a
         // freestyle map is not a handful of demos (csu1_a holds 1502 VQ3 and
         // 115 CPM) and a flat cap just hid the rest.
         $page = fn (string $base, string $pageName) => UploadedDemo::where('map_name', $map->name)
             ->whereIn('status', ['assigned', 'fallback-assigned', 'processed'])
             ->where(fn ($q) => $q->where('physics', $base)->orWhere('physics', 'LIKE', $base . '.%'))
+            ->where(fn ($q) => $q->whereIn('gametype', ['fs', 'mfs'])->orWhereNull('time_ms'))
             ->with(['renderedVideo', 'user', 'record.user'])
             ->orderByDesc('record_date')
             ->orderByDesc('created_at')
@@ -349,6 +347,13 @@ class MapsController extends Controller
      */
     private function scopeDemoFamily($query, ?string $family)
     {
+        // A history of times cannot hold a demo with no time. Tricks, tutorials
+        // and runs that never finished were listed at 00.000 among real
+        // attempts; they belong in the map's demo list, which is where they are
+        // now. Applied whatever the mode, so it also covers a trick recorded in
+        // a fastcap or a run slot.
+        $query->whereNotNull('time_ms');
+
         if ($family === null) {
             return $query;
         }
@@ -1041,7 +1046,7 @@ class MapsController extends Controller
 
         return Inertia::render('MapView')
             ->with('map', $map)
-            ->with('untimedDemos', $this->untimedDemos($map, $cpmRecords, $vq3Records))
+            ->with('untimedDemos', $this->untimedDemos($map))
             ->with('cpmRecords', $cpmRecords)
             ->with('vq3Records', $vq3Records)
             ->with('my_cpm_record', $my_cpm_record)

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -139,6 +139,10 @@ class HandleInertiaRequests extends Middleware
             'dangerRandom'                 =>      random_int(0, 1_000_000_000),
             'successRandom'                 =>      random_int(0, 1_000_000_000),
             'canReportDemos'            =>      $request->user() ? (\App\Models\Record::where('user_id', $request->user()->id)->count() >= 30) : false,
+            // Attributing somebody else's demo to their account is a public
+            // claim about them, so it sits with the people who already answer
+            // for the leaderboard. Mirrors DemosController::canAssignDemoToUser.
+            'canAssignDemoToUser'       =>      $request->user() ? ((bool) $request->user()->admin || (bool) $request->user()->is_moderator) : false,
             'canUploadDemos'            =>      $request->user() ? $request->user()->canUploadDemos() : true,
             'isVerified'                =>      $request->user() ? $request->user()->hasVerifiedEmail() : false,
             'recordsCount'              =>      $request->user() ? \App\Models\Record::where('user_id', $request->user()->id)->count() : 0,

--- a/app/Models/UploadedDemo.php
+++ b/app/Models/UploadedDemo.php
@@ -52,6 +52,9 @@ class UploadedDemo extends Model
         'name_confidence',
         'match_method',
         'suggested_user_id',
+        'assigned_user_id',
+        'assigned_by_user_id',
+        'assigned_user_at',
         'matched_alias',
         'manually_assigned',
         'download_count',
@@ -105,6 +108,16 @@ class UploadedDemo extends Model
     public function suggestedUser()
     {
         return $this->belongsTo(User::class, 'suggested_user_id');
+    }
+
+    /**
+     * The account a human decided this demo belongs to. Only ever set by staff,
+     * and it outranks the alias resolver: somebody looked at the demo and said
+     * so. See the 2026_08_09 migration for why it is not user_id.
+     */
+    public function assignedUser()
+    {
+        return $this->belongsTo(User::class, 'assigned_user_id');
     }
 
     public function renderedVideo()

--- a/app/Services/DemoProcessor/bin/console_commands_parser.py
+++ b/app/Services/DemoProcessor/bin/console_commands_parser.py
@@ -59,6 +59,8 @@ class ConsoleComandsParser:
             elif any(token in value for token in (
                 'broke the server record',
                 'you are now rank',
+                'is now rank',
+                'set the first record with',
                 'equalled the server record with',
             )):
                 result = get_name_q3df(value)

--- a/app/Services/DemoProcessor/bin/console_string_utils.py
+++ b/app/Services/DemoProcessor/bin/console_string_utils.py
@@ -105,6 +105,14 @@ def get_name_q3df(demo_time_cmd: str) -> Optional[Q3DFResult]:
     stripped = text.replace('chat "', '').rstrip('"')
     stripped_colored = text_colored.replace('chat "', '').rstrip('"')
 
+    # Servers that print the announcement through the console put "console: "
+    # in front of the player. Taken off here rather than in one branch, or the
+    # first branch that matches keeps it and the name comes out "consolebert".
+    if stripped.startswith('console: '):
+        stripped = stripped[len('console: '):]
+        if stripped_colored.startswith('console: '):
+            stripped_colored = stripped_colored[len('console: '):]
+
     def parse_prefix(prefix: str, prefix_colored: Optional[str] = None) -> tuple[str, Optional[str], Optional[str]]:
         prefix = prefix.strip()
         if '(' in prefix and ')' in prefix:
@@ -156,22 +164,25 @@ def get_name_q3df(demo_time_cmd: str) -> Optional[Q3DFResult]:
         time_part = parse_time(rest)
         return Q3DFResult(name=name, q3dfName=q3df, q3dfNameColored=q3df_colored, time=get_time_span(time_part))
 
-    if ', you are now rank' in stripped and ' with ' in stripped:
-        prefix, rest = stripped.split(', you are now rank', 1)
-        prefix_colored = split_colored(', you are now rank', stripped_colored)
+    # The very first time on a map has no record to beat, so the server says
+    # so differently. Same shape otherwise.
+    if ' set the first record with ' in stripped:
+        prefix, rest = stripped.split(' set the first record with ', 1)
+        prefix_colored = split_colored(' set the first record with ', stripped_colored)
         name, q3df, q3df_colored = parse_prefix(prefix, prefix_colored)
-        if ' with ' in rest:
-            time_part = parse_time(rest.split(' with ', 1)[1])
-            return Q3DFResult(name=name, q3dfName=q3df, q3dfNameColored=q3df_colored, time=get_time_span(time_part))
-
-    if stripped.startswith('console: ') and ' with ' in stripped:
-        body = stripped[len('console: '):]
-        body_colored = stripped_colored[len('console: '):] if stripped_colored.startswith('console: ') else None
-        name_part, rest = body.split(' is now rank', 1)
-        name_part_colored = split_colored(' is now rank', body_colored) if body_colored else None
-        name, q3df, q3df_colored = parse_prefix(name_part, name_part_colored)
-        time_part = parse_time(rest.split(' with ', 1)[1])
+        time_part = parse_time(rest)
         return Q3DFResult(name=name, q3dfName=q3df, q3dfNameColored=q3df_colored, time=get_time_span(time_part))
+
+    # Addressed to the runner it reads "you are now rank", printed for everyone
+    # else "<name> is now rank". Both carry the same time.
+    for marker in (', you are now rank', ' is now rank'):
+        if marker in stripped and ' with ' in stripped:
+            prefix, rest = stripped.split(marker, 1)
+            prefix_colored = split_colored(marker, stripped_colored)
+            name, q3df, q3df_colored = parse_prefix(prefix, prefix_colored)
+            if ' with ' in rest:
+                time_part = parse_time(rest.split(' with ', 1)[1])
+                return Q3DFResult(name=name, q3dfName=q3df, q3dfNameColored=q3df_colored, time=get_time_span(time_part))
 
     return None
 

--- a/app/Services/DemoProcessor/bin/demo.py
+++ b/app/Services/DemoProcessor/bin/demo.py
@@ -376,11 +376,21 @@ class Demo:
 
     @staticmethod
     def _try_get_time_from_brackets(part: str) -> Optional[timedelta]:
+        # Only defrag's own shape counts: MM.SS.mmm, minutes two or three
+        # digits. Any two numbers with a dot between them used to pass, so a
+        # filename fragment like "run_vq3cj_607.1_scripted" - a speed - became a
+        # run of ten minutes and seven seconds, and "Tutorial_4.1" became four
+        # seconds. Measured over the demos whose time came from their name:
+        # 491 carry the real shape, 8 carried a speed, a chapter or a date.
         tokens = re.split(r"[-.]", part)
-        if not 2 <= len(tokens) <= 3:
+
+        if len(tokens) != 3:
             return None
         if any(not token or not token.isdigit() for token in tokens):
             return None
+        if not (2 <= len(tokens[0]) <= 3) or len(tokens[1]) != 2 or len(tokens[2]) != 3:
+            return None
+
         return get_time_span(part)
 
     @staticmethod

--- a/app/Services/DemosTopService.php
+++ b/app/Services/DemosTopService.php
@@ -43,7 +43,14 @@ class DemosTopService
                 'user',
                 'renderedVideos' => fn ($q) => $q->visible()->latest(),
             ])
-            ->get();
+            ->get()
+            // A freestyle demo is not a result. The map has no timer, so
+            // whatever time reached the record came out of the filename, and on
+            // csu1_a that was the "607.1" of a speed in `run_vq3cj_607.1` read
+            // as ten minutes - one bogus row standing in for 1617 demos. They
+            // belong in the map's demo list, which is where they go now.
+            ->reject(fn ($r) => in_array($r->demo?->gametype, ['fs', 'mfs'], true))
+            ->values();
 
         // Pool 2: assigned online demos not already in main records table
         $onlineDemosQuery = UploadedDemo::where('map_name', $mapName)

--- a/app/Services/VideoMetadataService.php
+++ b/app/Services/VideoMetadataService.php
@@ -37,11 +37,63 @@ class VideoMetadataService
         $prefix = !empty($prefixes) ? '[' . implode('] [', $prefixes) . '] ' : '';
 
         $physics = strtoupper($video->physics ?? '');
-        $time = self::formatTime($video->time_ms);
         $mapName = ContentFilter::filterText($video->map_name ?? 'Unknown');
         $playerName = self::cleanPlayerName($video->player_name ?? 'Unknown');
+        $what = self::titleSubject($video);
 
-        return "{$prefix}{$mapName} | {$time} by {$playerName} ({$physics}) - Quake 3 DeFRaG";
+        return "{$prefix}{$mapName} | {$what} by {$playerName} ({$physics}) - Quake 3 DeFRaG";
+    }
+
+    /**
+     * What the title says the video is of. A timed run says its time; a
+     * freestyle run has none - the map has no timer - and printing "00.000"
+     * called it a zero-second run. Those are named after the trick they show,
+     * so the uploader's own name for the demo goes there instead.
+     */
+    private static function titleSubject(RenderedVideo $video): string
+    {
+        $isFreestyle = in_array($video->gametype, ['fs', 'mfs'], true);
+
+        if (! $isFreestyle && $video->time_ms) {
+            return self::formatTime($video->time_ms);
+        }
+
+        $label = self::demoLabel($video->demo_filename, $video->map_name);
+
+        if ($label) {
+            // Straight from a filename somebody chose, and it is going on
+            // YouTube, so it goes through the same filter the map name does.
+            return ContentFilter::filterText(mb_substr($label, 0, 60));
+        }
+
+        return $isFreestyle ? 'Freestyle' : 'Trick';
+    }
+
+    /**
+     * What the uploader called the demo, with the parts a title states anyway
+     * taken out: the map, the [mode] brackets, the (player.country) and the
+     * {cvars}. "oups-fs-b1_jpad_1xR_3xR", "Szak_white2-to-blue1". Null when
+     * nothing is left, which is the case for a plain generated name.
+     */
+    public static function demoLabel(?string $filename, ?string $mapName): ?string
+    {
+        if (! $filename) {
+            return null;
+        }
+
+        $name = preg_replace('/\.(dm_6\d|7z|zip)$/i', '', $filename);
+
+        if ($mapName) {
+            $name = preg_replace('/^' . preg_quote($mapName, '/') . '/i', '', $name);
+        }
+
+        $name = preg_replace('/\[[^\]]*\]/', '', $name);      // [fs.vq3.2]
+        $name = preg_replace('/\{[^}]*\}?/', '', $name);      // {sv_fps=120}, unclosed included
+        $name = preg_replace('/\([^)]*\)?/', '', $name);      // (player.country)
+        $name = preg_replace('/^\d{2}\.\d{2}\.\d{3}/', '', trim($name, " \t-_."));
+        $name = trim($name, " \t-_.");
+
+        return $name !== '' ? $name : null;
     }
 
     /**
@@ -57,7 +109,12 @@ class VideoMetadataService
         $time = self::formatTime($video->time_ms);
 
         $desc = "Nickname: {$playerName}\n";
-        $desc .= "Time: {$time}\n";
+        // A freestyle run has no time to report - say what it is instead.
+        if (in_array($video->gametype, ['fs', 'mfs'], true) || ! $video->time_ms) {
+            $desc .= "Trick: " . self::titleSubject($video) . "\n";
+        } else {
+            $desc .= "Time: {$time}\n";
+        }
         $desc .= "Physics: {$physics}\n";
         $desc .= "Map: {$mapName}\n";
 

--- a/database/migrations/2026_08_09_000100_add_assigned_user_to_uploaded_demos.php
+++ b/database/migrations/2026_08_09_000100_add_assigned_user_to_uploaded_demos.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Who a demo belongs to, when no record can say it.
+ *
+ * A freestyle demo hangs off no record, so the only thing that ever attributed
+ * one was an approved alias - and 3 in 4 of them resolve to nobody, leaving the
+ * row with a question mark for an avatar. This is a staff decision recorded on
+ * the demo itself, kept apart from `user_id` (whoever uploaded the file, which
+ * is often an admin doing a bulk import) and from `suggested_user_id` (the
+ * fuzzy matcher's guess, which asserts nothing).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('uploaded_demos', function (Blueprint $table) {
+            $table->foreignId('assigned_user_id')->nullable()->after('suggested_user_id')
+                ->constrained('users')->nullOnDelete();
+            $table->foreignId('assigned_by_user_id')->nullable()->after('assigned_user_id')
+                ->constrained('users')->nullOnDelete();
+            $table->timestamp('assigned_user_at')->nullable()->after('assigned_by_user_id');
+
+            $table->index('assigned_user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('uploaded_demos', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('assigned_user_id');
+            $table->dropConstrainedForeignId('assigned_by_user_id');
+            $table->dropColumn('assigned_user_at');
+        });
+    }
+};

--- a/resources/js/Components/AssignDemoToUserModal.vue
+++ b/resources/js/Components/AssignDemoToUserModal.vue
@@ -1,0 +1,145 @@
+<script setup>
+    import { ref, watch, computed } from 'vue';
+    import axios from 'axios';
+
+    // Attributing a freestyle or trick demo to an account. Those demos hang off
+    // no record, so nothing else on the site can say whose they are, and the
+    // alias resolver only reaches one in four.
+    const props = defineProps({
+        show: { type: Boolean, default: false },
+        demo: { type: Object, default: null },
+    });
+
+    const emit = defineEmits(['close', 'assigned']);
+
+    const query = ref('');
+    const results = ref([]);
+    const searching = ref(false);
+    const saving = ref(false);
+    const error = ref(null);
+    const applyToNick = ref(false);
+    const nick = computed(() => props.demo?.player_name || '');
+
+    let searchTimer = null;
+
+    watch(query, (value) => {
+        clearTimeout(searchTimer);
+        error.value = null;
+
+        if (value.trim().length < 2) {
+            results.value = [];
+            return;
+        }
+
+        searchTimer = setTimeout(async () => {
+            searching.value = true;
+            try {
+                const { data } = await axios.get('/demos/search-players', { params: { q: value.trim() } });
+                results.value = data;
+            } catch (e) {
+                error.value = e.response?.status === 403
+                    ? 'Only staff can do this.'
+                    : 'Could not search accounts.';
+            } finally {
+                searching.value = false;
+            }
+        }, 250);
+    });
+
+    watch(() => props.show, (open) => {
+        if (open) {
+            query.value = '';
+            results.value = [];
+            error.value = null;
+            applyToNick.value = false;
+        }
+    });
+
+    const assign = async (userId) => {
+        if (! props.demo || saving.value) return;
+
+        saving.value = true;
+        error.value = null;
+
+        try {
+            const { data } = await axios.post(`/demos/${props.demo.demo_id || props.demo.id}/assign-user`, {
+                user_id: userId,
+                apply_to_nick: userId ? applyToNick.value : false,
+            });
+            emit('assigned', data);
+            emit('close');
+        } catch (e) {
+            error.value = e.response?.data?.message || 'Could not save that.';
+        } finally {
+            saving.value = false;
+        }
+    };
+</script>
+
+<template>
+    <div v-if="show" class="fixed inset-0 z-[100] flex items-center justify-center p-4" @click.self="emit('close')">
+        <div class="absolute inset-0 bg-black/70 backdrop-blur-sm"></div>
+
+        <div class="relative w-full max-w-md bg-gray-900 border border-white/10 rounded-xl shadow-2xl overflow-hidden">
+            <div class="px-4 py-3 border-b border-white/10">
+                <h3 class="font-bold text-white">Attribute this demo to an account</h3>
+                <p class="text-xs text-gray-400 mt-1">
+                    <span class="text-gray-300">{{ demo?.demo_label || demo?.demo?.original_filename }}</span>
+                    <span v-if="nick"> - recorded as <span class="text-gray-300">{{ nick }}</span></span>
+                </p>
+            </div>
+
+            <div class="p-4 space-y-3">
+                <input
+                    v-model="query"
+                    type="text"
+                    placeholder="Search accounts by name..."
+                    class="w-full bg-gray-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-teal-500/50 focus:ring-0"
+                    autofocus
+                />
+
+                <label v-if="nick" class="flex items-start gap-2 text-xs text-gray-300 cursor-pointer">
+                    <input v-model="applyToNick" type="checkbox" class="mt-0.5 rounded bg-gray-800 border-white/20 text-teal-500 focus:ring-0" />
+                    <span>
+                        Do the same for every other demo recorded as <span class="font-semibold text-white">{{ nick }}</span>.
+                        <span class="text-gray-500">Exact nick only, so it never picks up a similar one.</span>
+                    </span>
+                </label>
+
+                <div v-if="error" class="text-xs text-red-400">{{ error }}</div>
+                <div v-if="searching" class="text-xs text-gray-500">Searching...</div>
+
+                <div v-if="results.length" class="max-h-64 overflow-y-auto divide-y divide-white/[0.04] border border-white/10 rounded-lg">
+                    <button
+                        v-for="user in results"
+                        :key="user.id"
+                        @click="assign(user.id)"
+                        :disabled="saving"
+                        class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.04] transition-colors disabled:opacity-50"
+                    >
+                        <img
+                            class="h-6 w-6 rounded-full object-cover border border-gray-600"
+                            :src="user.profile_photo_path ? '/storage/' + user.profile_photo_path : '/images/null.jpg'"
+                            :alt="user.plain_name"
+                        />
+                        <span class="text-sm text-gray-200 truncate">{{ user.plain_name }}</span>
+                        <span class="ml-auto text-[10px] text-gray-500">#{{ user.id }}</span>
+                    </button>
+                </div>
+
+                <div v-else-if="query.trim().length >= 2 && ! searching" class="text-xs text-gray-500">No account matches that.</div>
+            </div>
+
+            <div class="px-4 py-3 border-t border-white/10 flex items-center justify-between gap-2">
+                <button
+                    v-if="demo?.assigned_user_id"
+                    @click="assign(null)"
+                    :disabled="saving"
+                    class="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
+                >Remove the current assignment</button>
+                <span v-else></span>
+                <button @click="emit('close')" class="px-3 py-1.5 rounded-lg text-sm bg-gray-800 text-gray-300 hover:bg-gray-700">Cancel</button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -541,6 +541,17 @@
                 v-html="q3tohtml(displayName)"
             ></span>
 
+            <!-- What the uploader called the demo. On a map with no timer the
+                 run has no time to identify it by, and the trick is the whole
+                 point - "oups-fs-b1_jpad_1xR_3xR" says more than any nick does.
+                 Only set where the backend put one on the row. -->
+            <span
+                v-if="record.demo_label"
+                class="ml-2 truncate text-gray-400"
+                :class="compact ? 'text-[10px]' : 'text-xs'"
+                :title="record.demo_label"
+            >{{ record.demo_label }}</span>
+
             <!-- Source type chips (shown in mixed views) -->
             <template v-if="showSourceChips">
                 <!-- Primary chip: what type of entry is this (clickable with download icon if demo available) -->

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -48,6 +48,20 @@
             type: Boolean,
             default: false,
         },
+        // Inside a freestyle group the player is named once, on the group
+        // header, so the rows underneath drop the avatar, flag and nick and
+        // give the space to what the demo actually is.
+        hideIdentity: {
+            type: Boolean,
+            default: false,
+        },
+        // Reporting says "this demo is on the wrong record" and flagging says
+        // "this record is not legitimate". A freestyle demo sits on no record
+        // and claims no result, so neither has anything to act on.
+        hideReport: {
+            type: Boolean,
+            default: false,
+        },
     });
 
     const emit = defineEmits(['assign', 'assign-from-record', 'reassign-record', 'scoreHover', 'toggle-history']);
@@ -163,6 +177,7 @@
     const isLoggedIn = computed(() => !!page.props.auth?.user);
 
     const canReportDemo = computed(() => {
+        if (props.hideReport) return false;
         return isLoggedIn.value && page.props.canReportDemos;
     });
 
@@ -170,7 +185,7 @@
     // enough of a history here to be worth listening to. Flagging a record is
     // a different thing - it only says "this time looks off", staff decide
     // the rest - so it asks for nothing but an account.
-    const canFlagRecord = computed(() => isLoggedIn.value);
+    const canFlagRecord = computed(() => ! props.hideReport && isLoggedIn.value);
 
     const isAdmin = computed(() => {
         return page.props.auth?.user?.is_admin || page.props.auth?.user?.admin;
@@ -507,7 +522,7 @@
                 !getRoute && isLoggedIn && !isOfflineRecord ? 'cursor-default opacity-70' : !getRoute && !isOfflineRecord ? 'cursor-help opacity-70' : !getRoute && isOfflineRecord ? 'cursor-default' : 'cursor-pointer'
             ]"
         >
-            <div class="overflow-visible flex-shrink-0">
+            <div v-if="! hideIdentity" class="overflow-visible flex-shrink-0">
                 <!-- Show user's avatar with effects (effects suppressed in compact mode) -->
                 <div
                     :class="compact ? 'avatar-effect-none' : 'avatar-effect-' + (record.user?.avatar_effect || 'none')"
@@ -522,6 +537,7 @@
                 </div>
             </div>
             <img
+                v-if="! hideIdentity"
                 :src="`/images/flags/${bestrecordCountry}.png`"
                 :class="['flex-shrink-0', compact ? 'w-3.5 h-2.5' : 'w-5 h-4']"
                 onerror="this.src='/images/flags/_404.png'"
@@ -539,6 +555,7 @@
                 ]"
                 :style="compact ? '--effect-color: #ffffff' : `--effect-color: ${record.user?.color || '#ffffff'}`"
                 v-html="q3tohtml(displayName)"
+                v-if="! hideIdentity"
             ></span>
 
             <!-- What the uploader called the demo. On a map with no timer the

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -547,7 +547,7 @@
                  Only set where the backend put one on the row. -->
             <span
                 v-if="record.demo_label"
-                class="ml-2 truncate text-gray-400"
+                class="ml-2 truncate font-semibold text-teal-300/90 bg-teal-500/10 border border-teal-500/20 rounded px-1.5 py-0.5"
                 :class="compact ? 'text-[10px]' : 'text-xs'"
                 :title="record.demo_label"
             >{{ record.demo_label }}</span>

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -55,16 +55,17 @@
             type: Boolean,
             default: false,
         },
-        // Reporting says "this demo is on the wrong record" and flagging says
-        // "this record is not legitimate". A freestyle demo sits on no record
-        // and claims no result, so neither has anything to act on.
-        hideReport: {
+        // Everything on the row that only makes sense against a record:
+        // reporting ("this demo is on the wrong record"), flagging ("this
+        // record is not legitimate") and assigning to one. A freestyle demo
+        // sits on no record and claims no result, so none of them apply.
+        hideRecordActions: {
             type: Boolean,
             default: false,
         },
     });
 
-    const emit = defineEmits(['assign', 'assign-from-record', 'reassign-record', 'scoreHover', 'toggle-history']);
+    const emit = defineEmits(['assign', 'assign-from-record', 'reassign-record', 'scoreHover', 'toggle-history', 'assign-user']);
 
     const page = usePage();
     const showReportModal = ref(false);
@@ -177,7 +178,7 @@
     const isLoggedIn = computed(() => !!page.props.auth?.user);
 
     const canReportDemo = computed(() => {
-        if (props.hideReport) return false;
+        if (props.hideRecordActions) return false;
         return isLoggedIn.value && page.props.canReportDemos;
     });
 
@@ -185,7 +186,7 @@
     // enough of a history here to be worth listening to. Flagging a record is
     // a different thing - it only says "this time looks off", staff decide
     // the rest - so it asks for nothing but an account.
-    const canFlagRecord = computed(() => ! props.hideReport && isLoggedIn.value);
+    const canFlagRecord = computed(() => ! props.hideRecordActions && isLoggedIn.value);
 
     const isAdmin = computed(() => {
         return page.props.auth?.user?.is_admin || page.props.auth?.user?.admin;
@@ -864,9 +865,23 @@
 
         <!-- Action Icons -->
         <div class="flex items-center justify-end flex-shrink-0 gap-0.5 ml-auto">
+            <!-- A demo on no record has nothing that can say whose it is. Staff
+                 can put a name on it; there is room on these rows for words. -->
+            <button
+                v-if="hideRecordActions && $page.props.canAssignDemoToUser"
+                @click.stop="emit('assign-user', record)"
+                class="mr-1 px-2 py-0.5 rounded text-[10px] font-semibold border transition-colors"
+                :class="record.assigned_user_id
+                    ? 'bg-teal-500/15 text-teal-300 border-teal-500/30 hover:bg-teal-500/25'
+                    : 'bg-gray-700/40 text-gray-300 border-white/10 hover:bg-gray-700/70 hover:text-white'"
+                :title="record.assigned_user_id ? 'Attributed to an account - click to change' : 'Attribute this demo to an account'"
+            >
+                {{ record.assigned_user_id ? 'Assigned' : 'Assign to account' }}
+            </button>
+
             <!-- Always visible: assign/match/reassign -->
             <button
-                v-if="isLoggedIn && isOnlineDemo && !record.record_id && record.demo"
+                v-if="! hideRecordActions && isLoggedIn && isOnlineDemo && !record.record_id && record.demo"
                 @click.stop="emit('assign', record)"
                 class="p-0.5 rounded transition-all hover:scale-110 bg-gray-700/50 text-gray-400 hover:text-green-400 hover:bg-green-500/10"
                 title="Assign to online record"
@@ -877,7 +892,7 @@
             </button>
 
             <button
-                v-if="isLoggedIn && !isOnlineDemo && !isOfflineRecord && demoMatches.length > 0 && !(record.uploaded_demos && record.uploaded_demos.length > 0)"
+                v-if="! hideRecordActions && isLoggedIn && !isOnlineDemo && !isOfflineRecord && demoMatches.length > 0 && !(record.uploaded_demos && record.uploaded_demos.length > 0)"
                 @click.stop="emit('assign-from-record', record)"
                 class="p-0.5 rounded transition-all hover:scale-110 bg-purple-500/20 text-purple-400 hover:text-purple-300 hover:bg-purple-500/30 animate-pulse"
                 :title="`${demoMatches.length} possible demo match${demoMatches.length > 1 ? 'es' : ''}`"
@@ -888,7 +903,7 @@
             </button>
 
             <button
-                v-if="isLoggedIn && !isOnlineDemo && !isOfflineRecord && record.uploaded_demos && record.uploaded_demos.length > 0"
+                v-if="! hideRecordActions && isLoggedIn && !isOnlineDemo && !isOfflineRecord && record.uploaded_demos && record.uploaded_demos.length > 0"
                 @click.stop="emit('reassign-record', record)"
                 class="p-0.5 rounded transition-all hover:scale-110 bg-gray-700/50 text-gray-400 hover:text-yellow-400 hover:bg-yellow-500/10"
                 title="Reassign demo"

--- a/resources/js/Components/MapRecord.vue
+++ b/resources/js/Components/MapRecord.vue
@@ -949,7 +949,10 @@
                         'text-gray-300': compact,
                     }"
                 >
-                    {{ formatTime(record.time) }}
+                    <!-- A trick, tutorial or pads demo never finished a run, so
+                         it has no time. Printing formatTime(null) put "00.000"
+                         on it, which reads as a run of zero seconds. -->
+                    {{ record.time ? formatTime(record.time) : '-' }}
                 </div>
                 <div v-if="timeDiff" class="text-[10px] text-red-400 tabular-nums leading-none mt-0.5 drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]">
                     -{{ formatTime(timeDiff) }}

--- a/resources/js/Pages/Clans/ClanAchievements.vue
+++ b/resources/js/Pages/Clans/ClanAchievements.vue
@@ -470,7 +470,7 @@ const formatNumber = (num) => {
                                 <div class="flex-1 min-w-0 flex items-center gap-2">
                                     <div class="text-white text-sm font-semibold group-hover:text-purple-400 transition-colors truncate" v-html="q3tohtml(record.user_name)"></div>
                                     <div class="flex items-center gap-1 text-xs text-gray-400 flex-shrink-0">
-                                        <Link :href="`/maps/${record.mapname}`" class="truncate max-w-[100px] hover:text-blue-400 transition-colors" @click.stop>{{ record.mapname }}</Link>
+                                        <Link :href="`/maps/${encodeURIComponent(record.mapname)}`" class="truncate max-w-[100px] hover:text-blue-400 transition-colors" @click.stop>{{ record.mapname }}</Link>
                                         <img :src="`/images/modes/${record.physics}-icon.svg`" class="w-3 h-3 flex-shrink-0" :alt="record.physics" />
                                     </div>
                                 </div>

--- a/resources/js/Pages/DefragliveMapLog.vue
+++ b/resources/js/Pages/DefragliveMapLog.vue
@@ -143,7 +143,7 @@ const byDay = computed(() => {
                             <div class="flex-1 p-4 min-w-0">
                                 <div class="flex items-start justify-between gap-3 mb-3">
                                     <div class="min-w-0">
-                                        <a :href="`/maps/${b.map}`"
+                                        <a :href="`/maps/${encodeURIComponent(b.map)}`"
                                             class="hidden sm:block font-bold text-white hover:text-[#a970ff] truncate transition-colors">{{ b.map }}</a>
                                         <div class="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
                                             <span>{{ time(b.started_at) }}</span>

--- a/resources/js/Pages/Headhunter/Show.vue
+++ b/resources/js/Pages/Headhunter/Show.vue
@@ -396,7 +396,7 @@ const getParticipantStatusLabel = (status) => {
                     <!-- Map with thumbnail -->
                     <div class="bg-black/40 border border-white/10 rounded-xl p-4">
                         <div class="text-sm text-gray-400 mb-1">Map</div>
-                        <Link :href="`/maps/${challenge.mapname}`" class="block hover:opacity-80 transition-opacity">
+                        <Link :href="`/maps/${encodeURIComponent(challenge.mapname)}`" class="block hover:opacity-80 transition-opacity">
                             <div v-if="map?.thumbnail" class="mb-2">
                                 <img :src="`/storage/${map.thumbnail}`" @error="$event.target.style.display='none'" class="w-full h-16 object-cover rounded" />
                             </div>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1230,7 +1230,25 @@
 
             <!-- Hero Content (compact) -->
             <div class="relative max-w-8xl mx-auto px-4 md:px-6 lg:px-8 pt-10 pb-6" style="z-index: 10;">
-                <div class="w-full max-w-4xl mx-auto rounded-2xl px-6 pt-6 pb-3 shadow-2xl relative border border-white/10 group">
+                <!-- What the page is showing, flanking the card. Only on a map
+                     that holds both; one that ranks nothing has no choice to
+                     offer and one with no freestyle demos has nothing to switch
+                     to. Records is where the page always opens. -->
+                <div class="flex items-stretch justify-center gap-3 lg:gap-4 max-w-6xl mx-auto">
+                    <button
+                        v-if="untimedDemos && hasAnyRecords"
+                        @click="showFreestyle = false"
+                        :class="!showFreestyle
+                            ? 'bg-blue-600/90 border-blue-400 text-white shadow-lg shadow-blue-500/30'
+                            : 'bg-gray-800/70 border-gray-600 text-gray-300 hover:bg-gray-700/80 hover:text-white'"
+                        class="hidden lg:flex flex-col items-center justify-center rounded-2xl border px-5 py-6 font-bold transition-all w-40 flex-shrink-0"
+                    >
+                        <span class="text-2xl mb-1">🏁</span>
+                        <span class="text-sm leading-tight">Records</span>
+                        <span class="text-xs opacity-70 mt-1">{{ (getVq3Records?.total || 0) + (getCpmRecords?.total || 0) }}</span>
+                    </button>
+
+                <div class="w-full max-w-4xl rounded-2xl px-6 pt-6 pb-3 shadow-2xl relative border border-white/10 group">
                     <!-- Map thumbnail as card background -->
                     <div v-if="map.thumbnail" class="absolute inset-0 bg-cover bg-center rounded-2xl overflow-hidden" :style="`background-image: url('/storage/${map.thumbnail}');`">
                         <!-- Dark overlay for readability, lightens on hover -->
@@ -1698,20 +1716,6 @@
                             >
                                 Demos Top
                             </button>
-                            <!-- A map can hold both real records and demos that
-                                 cannot be ranked. 183 of them do. The switch
-                                 gives the second kind a place instead of
-                                 leaving it reachable from nowhere. -->
-                            <button
-                                v-if="untimedDemos && hasAnyRecords"
-                                @click="showFreestyle = !showFreestyle"
-                                :class="showFreestyle ? 'bg-teal-600 text-white border-teal-400 shadow-lg shadow-teal-500/30' : 'bg-gray-800 text-gray-200 border-gray-600 hover:bg-gray-700 hover:text-white'"
-                                class="px-3.5 py-1.5 rounded-lg border text-xs font-bold transition-all"
-                                title="Freestyle runs, tricks and tutorials - everything this map holds that has no time"
-                            >
-                                Freestyle &amp; Tricks
-                                <span class="opacity-70">({{ untimedTotal }})</span>
-                            </button>
                             <div class="text-xs text-gray-500">
                                 <Link v-if="page.props.auth?.user" href="/user/settings?tab=customize" class="hover:text-teal-400 transition-colors underline decoration-dotted underline-offset-2">
                                     Set your defaults
@@ -1743,6 +1747,36 @@
                     </div>
 
 </div> <!-- Close content layer -->
+                </div>
+
+                    <button
+                        v-if="untimedDemos && hasAnyRecords"
+                        @click="showFreestyle = true"
+                        :class="showFreestyle
+                            ? 'bg-teal-600/90 border-teal-400 text-white shadow-lg shadow-teal-500/30'
+                            : 'bg-gray-800/70 border-gray-600 text-gray-300 hover:bg-gray-700/80 hover:text-white'"
+                        class="hidden lg:flex flex-col items-center justify-center rounded-2xl border px-5 py-6 font-bold transition-all w-40 flex-shrink-0"
+                        title="Freestyle runs, tricks and tutorials - everything on this map that has no time"
+                    >
+                        <span class="text-2xl mb-1">🎬</span>
+                        <span class="text-sm leading-tight text-center">Freestyle<br />&amp; Tricks</span>
+                        <span class="text-xs opacity-70 mt-1">{{ untimedTotal }}</span>
+                    </button>
+                </div>
+
+                <!-- Same switch for narrow screens, where there is no room
+                     beside the card. -->
+                <div v-if="untimedDemos && hasAnyRecords" class="lg:hidden flex gap-2 justify-center mt-3">
+                    <button
+                        @click="showFreestyle = false"
+                        :class="!showFreestyle ? 'bg-blue-600/90 border-blue-400 text-white' : 'bg-gray-800/70 border-gray-600 text-gray-300'"
+                        class="px-4 py-2 rounded-lg border text-sm font-bold transition-all"
+                    >Records ({{ (getVq3Records?.total || 0) + (getCpmRecords?.total || 0) }})</button>
+                    <button
+                        @click="showFreestyle = true"
+                        :class="showFreestyle ? 'bg-teal-600/90 border-teal-400 text-white' : 'bg-gray-800/70 border-gray-600 text-gray-300'"
+                        class="px-4 py-2 rounded-lg border text-sm font-bold transition-all"
+                    >Freestyle &amp; Tricks ({{ untimedTotal }})</button>
                 </div>
             </div>
 
@@ -1803,7 +1837,8 @@
                                     <span class="text-sm font-semibold" :class="side.accent === 'blue' ? 'text-blue-400/60' : 'text-purple-400/60'">({{ side.list.total }})</span>
                                 </h2>
                                 <div class="text-xs text-gray-400">
-                                    <template v-if="map.gametype === 'freestyle'">No timer on this map, so nothing here is ranked.</template>
+                                    <template v-if="hasAnyRecords">No time on these - freestyle, tricks, tutorials.</template>
+                                    <template v-else-if="map.gametype === 'freestyle'">No timer on this map, so nothing here is ranked.</template>
                                     <template v-else>No records on this map yet.</template>
                                 </div>
                             </div>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1029,6 +1029,15 @@
         (getVq3Records.value?.total || 0) > 0 || (getCpmRecords.value?.total || 0) > 0
     );
 
+    const untimedTotal = computed(() =>
+        (props.untimedDemos?.vq3?.total || 0) + (props.untimedDemos?.cpm?.total || 0)
+    );
+
+    // On a map with nothing to rank the demo list is the page; on one that has
+    // records too it waits behind the switch.
+    const showFreestyle = ref(false);
+    const showingUntimed = computed(() => !! props.untimedDemos && (! hasAnyRecords.value || showFreestyle.value));
+
     // Helper functions for weapon/item/function icons and names
     const getWeaponIcon = (abbr) => {
         const icons = {
@@ -1689,6 +1698,20 @@
                             >
                                 Demos Top
                             </button>
+                            <!-- A map can hold both real records and demos that
+                                 cannot be ranked. 183 of them do. The switch
+                                 gives the second kind a place instead of
+                                 leaving it reachable from nowhere. -->
+                            <button
+                                v-if="untimedDemos && hasAnyRecords"
+                                @click="showFreestyle = !showFreestyle"
+                                :class="showFreestyle ? 'bg-teal-600 text-white border-teal-400 shadow-lg shadow-teal-500/30' : 'bg-gray-800 text-gray-200 border-gray-600 hover:bg-gray-700 hover:text-white'"
+                                class="px-3.5 py-1.5 rounded-lg border text-xs font-bold transition-all"
+                                title="Freestyle runs, tricks and tutorials - everything this map holds that has no time"
+                            >
+                                Freestyle &amp; Tricks
+                                <span class="opacity-70">({{ untimedTotal }})</span>
+                            </button>
                             <div class="text-xs text-gray-500">
                                 <Link v-if="page.props.auth?.user" href="/user/settings?tab=customize" class="hover:text-teal-400 transition-colors underline decoration-dotted underline-offset-2">
                                     Set your defaults
@@ -1757,7 +1780,7 @@
                      set a record on. Two empty leaderboards said nothing while
                      the demos people uploaded sat there unreachable, so the
                      panel lists them instead, newest first. -->
-                <div v-if="untimedDemos" class="lg:flex gap-4 justify-center">
+                <div v-if="showingUntimed" class="lg:flex gap-4 justify-center">
                     <div
                         v-for="side in [
                             { key: 'vq3', label: 'VQ3', page: 'vq3DemosPage', accent: 'blue', list: untimedDemos.vq3 },
@@ -1807,7 +1830,7 @@
                     </div>
                 </div>
 
-                <div v-if="!untimedDemos || hasAnyRecords" :class="untimedDemos ? 'lg:flex gap-4 justify-center mt-4' : 'lg:flex gap-4 justify-center'">
+                <div v-if="!showingUntimed" class="lg:flex gap-4 justify-center">
                     <!-- VQ3 Leaderboard -->
                     <div v-show="mobilePhysics === 'both' || mobilePhysics === 'VQ3'" :style="{ order: cpmFirst ? 2 : 1 }" class="flex-1 bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl overflow-hidden shadow-xl border border-white/10 hover:border-white/20 transition-all duration-300">
                     <!-- VQ3 Header -->

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -7,6 +7,7 @@
     // import MapRecordSmall from '@/Components/MapRecordSmall.vue'; // Obsolete - using MapRecord for all screen sizes now
     import MapCardLineSmall from '@/Components/MapCardLineSmall.vue';
     import Pagination from '@/Components/Basic/Pagination.vue';
+    import AssignDemoToUserModal from '@/Components/AssignDemoToUserModal.vue';
     import ToggleButton from '@/Components/Basic/ToggleButton.vue';
     import Dropdown from '@/Components/Laravel/Dropdown.vue';
     import AddToMaplistModal from '@/Components/Maplists/AddToMaplistModal.vue';
@@ -1041,6 +1042,11 @@
         closedDemoGroups.value = next;
     };
 
+    // Staff attributing a freestyle demo to an account.
+    const assignUserDemo = ref(null);
+    const openAssignUser = (record) => { assignUserDemo.value = record; };
+    const onDemoAssigned = () => { router.reload({ only: ['untimedDemos'] }); };
+
     const untimedTotal = computed(() =>
         (props.untimedDemos?.vq3?.total || 0) + (props.untimedDemos?.cpm?.total || 0)
     );
@@ -1892,7 +1898,8 @@
                                         :showSourceChips="true"
                                         :hideRank="true"
                                         :hideIdentity="true"
-                                        :hideReport="true"
+                                        :hideRecordActions="true"
+                                        @assign-user="openAssignUser"
                                     />
                                 </div>
                             </div>
@@ -2425,6 +2432,13 @@
             :server="instantPlayServer"
             :map-name="map.name"
             @close="instantPlayConfirm = false"
+        />
+
+        <AssignDemoToUserModal
+            :show="!! assignUserDemo"
+            :demo="assignUserDemo"
+            @close="assignUserDemo = null"
+            @assigned="onDemoAssigned"
         />
     </div>
 </template>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1234,7 +1234,7 @@
                      that holds both; one that ranks nothing has no choice to
                      offer and one with no freestyle demos has nothing to switch
                      to. Records is where the page always opens. -->
-                <div class="flex items-stretch justify-center gap-3 lg:gap-4 max-w-6xl mx-auto">
+                <div class="flex items-stretch justify-center gap-3 lg:gap-4 max-w-7xl mx-auto">
                     <button
                         v-if="untimedDemos && hasAnyRecords"
                         @click="showFreestyle = false"
@@ -1248,7 +1248,7 @@
                         <span class="text-xs opacity-70 mt-1">{{ (getVq3Records?.total || 0) + (getCpmRecords?.total || 0) }}</span>
                     </button>
 
-                <div class="w-full max-w-4xl rounded-2xl px-6 pt-6 pb-3 shadow-2xl relative border border-white/10 group">
+                <div class="w-full max-w-4xl flex-shrink rounded-2xl px-6 pt-6 pb-3 shadow-2xl relative border border-white/10 group">
                     <!-- Map thumbnail as card background -->
                     <div v-if="map.thumbnail" class="absolute inset-0 bg-cover bg-center rounded-2xl overflow-hidden" :style="`background-image: url('/storage/${map.thumbnail}');`">
                         <!-- Dark overlay for readability, lightens on hover -->

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -249,7 +249,7 @@
         // MapsController::untimedDemos. Null on every other map, which is what
         // keeps the leaderboards in place.
         untimedDemos: {
-            type: Array,
+            type: Object,
             default: null
         },
         // Server-computed cluster metadata for time-history badges. Keyed by
@@ -1022,6 +1022,13 @@
         return props.cpmRecords;
     })
 
+    // A freestyle map gets its demo list either way, but it can still hold a
+    // ranked row, and then both belong on the page - the tables only disappear
+    // when there is nothing in them at all.
+    const hasAnyRecords = computed(() =>
+        (getVq3Records.value?.total || 0) > 0 || (getCpmRecords.value?.total || 0) > 0
+    );
+
     // Helper functions for weapon/item/function icons and names
     const getWeaponIcon = (abbr) => {
         const icons = {
@@ -1750,31 +1757,57 @@
                      set a record on. Two empty leaderboards said nothing while
                      the demos people uploaded sat there unreachable, so the
                      panel lists them instead, newest first. -->
-                <div v-if="untimedDemos" class="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl overflow-hidden shadow-xl border border-white/10">
-                    <div class="bg-gradient-to-r from-teal-600/20 to-teal-500/10 border-b border-teal-500/30 px-4 py-2">
-                        <div class="flex items-center justify-between flex-wrap gap-2">
-                            <h2 class="text-lg font-bold text-teal-300">
-                                Demos <span class="text-sm font-semibold text-teal-300/60">({{ untimedDemos.length }})</span>
-                            </h2>
-                            <div class="text-xs text-gray-400">
-                                <template v-if="map.gametype === 'freestyle'">This map has no timer, so its runs are not ranked.</template>
-                                <template v-else>No records on this map yet.</template>
+                <div v-if="untimedDemos" class="lg:flex gap-4 justify-center">
+                    <div
+                        v-for="side in [
+                            { key: 'vq3', label: 'VQ3', page: 'vq3DemosPage', accent: 'blue', list: untimedDemos.vq3 },
+                            { key: 'cpm', label: 'CPM', page: 'cpmDemosPage', accent: 'purple', list: untimedDemos.cpm },
+                        ]"
+                        :key="side.key"
+                        v-show="(mobilePhysics === 'both' || mobilePhysics === side.label) && side.list.total"
+                        :style="{ order: cpmFirst ? (side.key === 'cpm' ? 1 : 2) : (side.key === 'cpm' ? 2 : 1) }"
+                        class="flex-1 bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl overflow-hidden shadow-xl border border-white/10"
+                    >
+                        <div
+                            class="border-b px-4 py-2"
+                            :class="side.accent === 'blue'
+                                ? 'bg-gradient-to-r from-blue-600/20 to-blue-500/10 border-blue-500/30'
+                                : 'bg-gradient-to-r from-purple-600/20 to-purple-500/10 border-purple-500/30'"
+                        >
+                            <div class="flex items-center justify-between flex-wrap gap-2">
+                                <h2 class="text-lg font-bold" :class="side.accent === 'blue' ? 'text-blue-400' : 'text-purple-400'">
+                                    {{ side.label }} Demos
+                                    <span class="text-sm font-semibold" :class="side.accent === 'blue' ? 'text-blue-400/60' : 'text-purple-400/60'">({{ side.list.total }})</span>
+                                </h2>
+                                <div class="text-xs text-gray-400">
+                                    <template v-if="map.gametype === 'freestyle'">No timer on this map, so nothing here is ranked.</template>
+                                    <template v-else>No records on this map yet.</template>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="divide-y divide-white/[0.04]">
-                        <MapRecord
-                            v-for="demo in untimedDemos"
-                            :key="demo.demo_id"
-                            :record="demo"
-                            :physics="(demo.demo?.physics || 'VQ3').split('.')[0]"
-                            :showSourceChips="true"
-                            :hideRank="true"
-                        />
+                        <div class="divide-y divide-white/[0.04]">
+                            <MapRecord
+                                v-for="demo in side.list.data"
+                                :key="demo.demo_id"
+                                :record="demo"
+                                :physics="side.label"
+                                :showSourceChips="true"
+                                :hideRank="true"
+                            />
+                        </div>
+                        <div v-if="side.list.last_page > 1" class="px-4 py-2 border-t border-white/[0.06]">
+                            <Pagination
+                                :pageName="side.page"
+                                :last_page="side.list.last_page"
+                                :current_page="side.list.current_page"
+                                :link="side.list.first_page_url"
+                                :only="['untimedDemos']"
+                            />
+                        </div>
                     </div>
                 </div>
 
-                <div v-else class="lg:flex gap-4 justify-center">
+                <div v-if="!untimedDemos || hasAnyRecords" :class="untimedDemos ? 'lg:flex gap-4 justify-center mt-4' : 'lg:flex gap-4 justify-center'">
                     <!-- VQ3 Leaderboard -->
                     <div v-show="mobilePhysics === 'both' || mobilePhysics === 'VQ3'" :style="{ order: cpmFirst ? 2 : 1 }" class="flex-1 bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl overflow-hidden shadow-xl border border-white/10 hover:border-white/20 transition-all duration-300">
                     <!-- VQ3 Header -->

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -245,6 +245,13 @@
             type: Object,
             default: () => ({ average: null, total: 0, distribution: {}, user_rating: null })
         },
+        // Present only on a map with nothing to rank - see
+        // MapsController::untimedDemos. Null on every other map, which is what
+        // keeps the leaderboards in place.
+        untimedDemos: {
+            type: Array,
+            default: null
+        },
         // Server-computed cluster metadata for time-history badges. Keyed by
         // uploaded_demo.id; each value is { count, signals }. Pre-computed so
         // the collapsed leaderboard badge matches the opened drawer numbers
@@ -1739,7 +1746,35 @@
                     </button>
                 </div>
 
-                <div class="lg:flex gap-4 justify-center">
+                <!-- A map with no times to rank: freestyle, or one nobody has
+                     set a record on. Two empty leaderboards said nothing while
+                     the demos people uploaded sat there unreachable, so the
+                     panel lists them instead, newest first. -->
+                <div v-if="untimedDemos" class="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl overflow-hidden shadow-xl border border-white/10">
+                    <div class="bg-gradient-to-r from-teal-600/20 to-teal-500/10 border-b border-teal-500/30 px-4 py-2">
+                        <div class="flex items-center justify-between flex-wrap gap-2">
+                            <h2 class="text-lg font-bold text-teal-300">
+                                Demos <span class="text-sm font-semibold text-teal-300/60">({{ untimedDemos.length }})</span>
+                            </h2>
+                            <div class="text-xs text-gray-400">
+                                <template v-if="map.gametype === 'freestyle'">This map has no timer, so its runs are not ranked.</template>
+                                <template v-else>No records on this map yet.</template>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="divide-y divide-white/[0.04]">
+                        <MapRecord
+                            v-for="demo in untimedDemos"
+                            :key="demo.demo_id"
+                            :record="demo"
+                            :physics="(demo.demo?.physics || 'VQ3').split('.')[0]"
+                            :showSourceChips="true"
+                            :hideRank="true"
+                        />
+                    </div>
+                </div>
+
+                <div v-else class="lg:flex gap-4 justify-center">
                     <!-- VQ3 Leaderboard -->
                     <div v-show="mobilePhysics === 'both' || mobilePhysics === 'VQ3'" :style="{ order: cpmFirst ? 2 : 1 }" class="flex-1 bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl overflow-hidden shadow-xl border border-white/10 hover:border-white/20 transition-all duration-300">
                     <!-- VQ3 Header -->

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1891,7 +1891,8 @@
                                         :physics="side.label"
                                         :showSourceChips="true"
                                         :hideRank="true"
-                                        :compact="true"
+                                        :hideIdentity="true"
+                                        :hideReport="true"
                                     />
                                 </div>
                             </div>

--- a/resources/js/Pages/MapView.vue
+++ b/resources/js/Pages/MapView.vue
@@ -1029,6 +1029,18 @@
         (getVq3Records.value?.total || 0) > 0 || (getCpmRecords.value?.total || 0) > 0
     );
 
+    // Freestyle groups open by default - the demos are what the section is
+    // for, and a page of names you have to click through would hide them
+    // again. Tracks what has been CLOSED, keyed per side so the same nick in
+    // VQ3 and CPM collapses independently.
+    const closedDemoGroups = ref(new Set());
+    const isDemoGroupOpen = (key) => ! closedDemoGroups.value.has(key);
+    const toggleDemoGroup = (key) => {
+        const next = new Set(closedDemoGroups.value);
+        next.has(key) ? next.delete(key) : next.add(key);
+        closedDemoGroups.value = next;
+    };
+
     const untimedTotal = computed(() =>
         (props.untimedDemos?.vq3?.total || 0) + (props.untimedDemos?.cpm?.total || 0)
     );
@@ -1844,14 +1856,45 @@
                             </div>
                         </div>
                         <div class="divide-y divide-white/[0.04]">
-                            <MapRecord
-                                v-for="demo in side.list.data"
-                                :key="demo.demo_id"
-                                :record="demo"
-                                :physics="side.label"
-                                :showSourceChips="true"
-                                :hideRank="true"
-                            />
+                            <div v-for="group in side.list.data" :key="group.key">
+                                <!-- One row per player. Freestyle is not one
+                                     run each - somebody can have a hundred on a
+                                     map - so the name is said once and their
+                                     demos open under it. -->
+                                <button
+                                    @click="toggleDemoGroup(side.key + ':' + group.key)"
+                                    class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.03] transition-colors"
+                                >
+                                    <svg
+                                        class="w-3.5 h-3.5 flex-shrink-0 text-gray-500 transition-transform"
+                                        :class="{ 'rotate-90': isDemoGroupOpen(side.key + ':' + group.key) }"
+                                        fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"
+                                    >
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m9 5 7 7-7 7" />
+                                    </svg>
+                                    <img
+                                        v-if="group.country"
+                                        :src="`/images/flags/${group.country}.png`"
+                                        class="w-5 h-3.5 flex-shrink-0 rounded-sm"
+                                        @error="(e) => e.target.style.display = 'none'"
+                                    />
+                                    <span class="text-sm font-semibold truncate" v-html="q3tohtml(group.name)"></span>
+                                    <span class="text-[10px] text-gray-500 flex-shrink-0">{{ group.count }} demo{{ group.count === 1 ? '' : 's' }}</span>
+                                    <span class="flex-1"></span>
+                                    <span class="text-[10px] text-gray-500 flex-shrink-0">{{ (group.latest || '').slice(0, 10) }}</span>
+                                </button>
+                                <div v-if="isDemoGroupOpen(side.key + ':' + group.key)" class="bg-black/20 border-l-2 border-teal-500/30 divide-y divide-white/[0.03]">
+                                    <MapRecord
+                                        v-for="demo in group.demos"
+                                        :key="demo.demo_id"
+                                        :record="demo"
+                                        :physics="side.label"
+                                        :showSourceChips="true"
+                                        :hideRank="true"
+                                        :compact="true"
+                                    />
+                                </div>
+                            </div>
                         </div>
                         <div v-if="side.list.last_page > 1" class="px-4 py-2 border-t border-white/[0.06]">
                             <Pagination

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -564,7 +564,7 @@ const getFunctionName = (abbr) => {
                                  transparent so the image dissolves
                                  directly into the glass card body.
                                  No separate overlay slab needed. -->
-                            <a v-if="server.map" :href="`/maps/${server.map}`" class="block">
+                            <a v-if="server.map" :href="`/maps/${encodeURIComponent(server.map)}`" class="block">
                                 <img :src="`/storage/${server.mapdata?.thumbnail}`" @error="$event.target.src='/images/unknown.jpg'" class="w-full object-contain object-top pointer-events-auto cursor-pointer" style="max-height: 450px; -webkit-mask-image: linear-gradient(to bottom, black 65%, transparent 100%); mask-image: linear-gradient(to bottom, black 65%, transparent 100%);" />
                             </a>
                             <img v-else :src="`/storage/${server.mapdata?.thumbnail}`" @error="$event.target.src='/images/unknown.jpg'" class="w-full object-contain object-top" style="max-height: 450px; -webkit-mask-image: linear-gradient(to bottom, black 65%, transparent 100%); mask-image: linear-gradient(to bottom, black 65%, transparent 100%);" />
@@ -606,8 +606,8 @@ const getFunctionName = (abbr) => {
                                     <div class="flex items-center justify-between gap-2">
                                         <div class="flex items-center gap-2">
                                             <div class="flex items-center gap-2" @mouseenter="hoveredMapServer = server.id" @mouseleave="hoveredMapServer = null">
-                                                <a :href="`/maps/${server.map}`" class="text-gray-300 text-base font-semibold hover:text-blue-400 transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);">Map:</a>
-                                                <a :href="`/maps/${server.map}`" class="font-bold text-white text-lg hover:text-blue-400 transition-colors map-name-highlight" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);">{{ server.map }}</a>
+                                                <a :href="`/maps/${encodeURIComponent(server.map)}`" class="text-gray-300 text-base font-semibold hover:text-blue-400 transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);">Map:</a>
+                                                <a :href="`/maps/${encodeURIComponent(server.map)}`" class="font-bold text-white text-lg hover:text-blue-400 transition-colors map-name-highlight" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);">{{ server.map }}</a>
                                             </div>
                                             <!-- Copy map name -->
                                             <CopyButton :text="server.map" size="xs" />
@@ -782,7 +782,7 @@ const getFunctionName = (abbr) => {
                                     <div class="inline-flex flex-col bg-black/40  px-2 py-1 rounded border border-white/20">
                                         <h3 class="text-base font-bold text-white transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);" v-html="q3tohtml(server.name)"></h3>
                                         <div class="flex items-center gap-2 text-xs text-gray-300 transition-colors">
-                                            <a v-if="server.map" :href="`/maps/${server.map}`" class="hover:text-blue-400 transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 4px rgba(0,0,0,0.8);">{{ server.map }}</a>
+                                            <a v-if="server.map" :href="`/maps/${encodeURIComponent(server.map)}`" class="hover:text-blue-400 transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 4px rgba(0,0,0,0.8);">{{ server.map }}</a>
                                         </div>
                                     </div>
                                 </div>
@@ -893,7 +893,7 @@ const getFunctionName = (abbr) => {
                                     <div class="inline-flex flex-col bg-black/40  px-2 py-1 rounded border border-white/20">
                                         <h3 class="text-base font-bold text-white transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);" v-html="q3tohtml(server.name)"></h3>
                                         <div class="flex items-center gap-2 text-xs text-gray-300 transition-colors">
-                                            <a v-if="server.map" :href="`/maps/${server.map}`" class="hover:text-purple-400 transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 4px rgba(0,0,0,0.8);">{{ server.map }}</a>
+                                            <a v-if="server.map" :href="`/maps/${encodeURIComponent(server.map)}`" class="hover:text-purple-400 transition-colors" style="text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 4px rgba(0,0,0,0.8);">{{ server.map }}</a>
                                         </div>
                                     </div>
                                 </div>

--- a/resources/js/Pages/Youtube.vue
+++ b/resources/js/Pages/Youtube.vue
@@ -213,7 +213,7 @@
                     </div>
                     <div class="flex items-center justify-between">
                         <div>
-                            <Link :href="`/maps/${currentlyRendering.map_name}`" class="text-lg font-bold text-white hover:text-blue-400 transition-colors">
+                            <Link :href="`/maps/${encodeURIComponent(currentlyRendering.map_name)}`" class="text-lg font-bold text-white hover:text-blue-400 transition-colors">
                                 {{ currentlyRendering.map_name }}
                             </Link>
                             <div class="text-sm text-gray-400 mt-0.5">
@@ -390,7 +390,7 @@
                         <div class="p-3">
                             <div class="flex items-center justify-between mb-1">
                                 <Link
-                                    :href="`/maps/${video.map_name}`"
+                                    :href="`/maps/${encodeURIComponent(video.map_name)}`"
                                     class="text-sm font-semibold text-white hover:text-blue-400 transition-colors truncate"
                                 >
                                     {{ video.map_name }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -219,6 +219,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/demos/maps/{mapname}/records', [DemosController::class, 'getRecords'])->name('demos.records');
     Route::post('/demos/{demo}/assign', [DemosController::class, 'assign'])->name('demos.assign');
     Route::post('/demos/{demo}/unassign', [DemosController::class, 'unassign'])->name('demos.unassign');
+    // Attributing a demo to an account, for the freestyle and trick demos that
+    // sit on no record. Staff only, enforced in the controller.
+    Route::get('/demos/search-players', [DemosController::class, 'searchPlayers'])->name('demos.search-players');
+    Route::post('/demos/{demo}/assign-user', [DemosController::class, 'assignToUser'])->name('demos.assign-user');
     Route::post('/demos/{demo}/link-youtube', [DemosController::class, 'linkYoutube'])->name('demos.link-youtube');
 
     // OAuth routes


### PR DESCRIPTION
Fourteen commits, all off reports from Enter and follow-up digging.

**Maps with nothing to rank had nothing to show.** A freestyle map has no timer,
so it cannot rank anything, and its page was two empty leaderboards however many
demos people had uploaded - csu1_a alone carries 1617. The same happened to a run
map nobody has ever set a record on. Those maps now list their demos: the same
rows the leaderboard uses, minus the rank and the time nobody has. 12561 demos
across 1073 maps.

**Grouped by player.** Freestyle is not one run each - two people have a hundred
apiece on csu1_a, and 1523 demos come down to 258 names. The name is said once,
with the count and the latest date, and the demos open underneath. Grouping goes
through the alias resolver, so a registered account and an unclaimed q3df profile
land together. The row carries the name the uploader gave the demo, stripped of
what the row already shows: on a map with no times, "oups-fs-b1_jpad_1xR_3xR" is
the only thing telling two runs apart.

**A switch, on the 183 maps that hold both.** Records on the left of the map
card, Freestyle & Tricks on the right, Records always the default.

**Freestyle no longer ranks itself.** An offline record built from a freestyle
demo was a result that could not exist; on csu1_a one such row stood in front of
1617 demos. Keyed on the mode, never on the validity flag - of the 499
client_finish=false records, 5 are freestyle and the other 494 rank exactly as
before.

**A history of times no longer holds demos without one.** Physics does not
separate the modes - `[fs.cpm.2]` is physics CPM.2, the same value a fastcap on
flag 2 carries - so freestyle demos were padding fastcap histories at 00.000: 20
of the 36 demos behind one run. Tricks and tutorials with no time are out too,
and a demo with no time renders a dash instead of claiming a zero-second run.

**Staff can put a name on a demo that sits on no record**, optionally on every
other demo under that exact nick. Its own column, kept apart from the uploader
and from the matcher's guess - 11596 of the 11640 freestyle demos carry a guess,
and a guess under an avatar asserts the run is theirs. Admin and moderator only.

**A speed in a filename was being read as a run time.** When a demo carries no
time the parser falls back to the filename, and any two dot-separated numbers
counted, so "run_vq3cj_607.1_scripted" became ten minutes seven seconds. Only
defrag's own MM.SS.mmm shape counts now: of the demos whose time came from their
name, 491 carry that shape and are genuine, 8 carried a speed, a chapter number
or a date. Those 8 rows are corrected separately, since it changes what ranks.

**Three server messages the parser walked past**, from Enter's list of every line
defrag prints a time on: "console: X is now rank", "console: X set the first
record with", and "console: X broke the server record" which came back as a
player named "consolebert". All sixteen of his shapes parse now.

**Maps with a "#" in the name.** 33 of them, 590 demos and 924 records. A "#" in
a URL starts the fragment, so ten links built by hand pointed at the map list -
five of them in the server list.

Includes a migration (`assigned_user_id` on uploaded_demos). Deploy needs
`cache:clear`: the Demos Top cache stores hydrated models.
