### PR TITLE
Give the failed demo pile a second chance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ __pycache__/
 # Working notes about the serverdemo store. Stays out of git: it names live
 # SFTP accounts, rs server ids and player mdd ids, and this repo is public.
 /SERVERDEMOS_VERIFICATION_PLAN.md
+
+# Handover notes for the next session. Local only, same reason as above.
+/next-prompt.md

--- a/app/Console/Commands/RetryFailedDemos.php
+++ b/app/Console/Commands/RetryFailedDemos.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\UploadedDemo;
+use App\Services\DemoProcessorService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Process;
+
+/**
+ * Puts the failed pile back through the pipeline.
+ *
+ * Most of that pile is not broken demos. The old parser read any two
+ * dot-separated numbers in a filename as a run time, so a date like
+ * "2003-07-01" reached get_time_span, which threw, and the exception took the
+ * whole demo down. The stricter shape check makes those readable again, and
+ * demos with no time of their own now have the Freestyle & Tricks section to
+ * land in.
+ *
+ * The archive under demos/failed/<id>/ is never deleted, only read. A demo that
+ * fails again is left exactly as it was.
+ *
+ * Reports without touching anything unless --apply is passed.
+ */
+class RetryFailedDemos extends Command
+{
+    protected $signature = 'demos:retry-failed
+        {--id=* : Specific demo ids, instead of everything that failed}
+        {--limit=0 : Stop after this many demos (0 = all)}
+        {--apply : Actually put them back through. Without this nothing is written}
+        {--queue : Hand each demo to the queue instead of processing it here}
+        {--sleep=0 : Seconds to wait between demos}';
+
+    protected $description = 'Retry demos the old parser could not read';
+
+    public function handle(DemoProcessorService $processor): int
+    {
+        $apply = (bool) $this->option('apply');
+        $ids = $this->option('id');
+        $limit = (int) $this->option('limit');
+
+        $query = $ids
+            ? UploadedDemo::whereIn('id', $ids)
+            : UploadedDemo::where('status', 'failed');
+
+        $total = (clone $query)->count();
+
+        if ($total === 0) {
+            $this->info('Nothing matches.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(($apply ? 'Retrying ' : 'Dry run over ') . $total . ' demo(s)'
+            . ($limit > 0 ? ', stopping after ' . $limit : '') . '.');
+
+        $seen = 0;
+        $readable = 0;
+        $noSource = 0;
+        $stillUnreadable = 0;
+        $outcomes = [];
+
+        $query->orderBy('id')->chunkById(200, function ($demos) use (
+            &$seen, &$readable, &$noSource, &$stillUnreadable, &$outcomes, $apply, $limit, $processor
+        ) {
+            foreach ($demos as $demo) {
+                if ($limit > 0 && $seen >= $limit) {
+                    return false;
+                }
+
+                $seen++;
+
+                $source = $this->locateSource($demo);
+
+                if (! $source) {
+                    $noSource++;
+                    $this->line('  ' . $demo->id . '  no file on disk (' . $demo->file_path . ')');
+                    continue;
+                }
+
+                $workDir = storage_path('app/demos/temp/' . $demo->id);
+                $demoFile = $this->stage($source, $workDir, $demo->original_filename);
+
+                if (! $demoFile) {
+                    $noSource++;
+                    $this->line('  ' . $demo->id . '  could not unpack ' . basename($source));
+                    continue;
+                }
+
+                $metadata = $this->readMetadata($demoFile);
+
+                if (! $metadata) {
+                    $stillUnreadable++;
+                    $this->cleanup($workDir);
+                    continue;
+                }
+
+                $readable++;
+
+                if (! $apply) {
+                    $this->line(sprintf(
+                        '  %-8s %-22s %-18s %s',
+                        $demo->id,
+                        $metadata['map_name'] ?? '?',
+                        $metadata['player_name'] ?? '?',
+                        $metadata['time_seconds'] ? $metadata['time_seconds'] . 's' : 'no time'
+                    ));
+                    $this->cleanup($workDir);
+                    continue;
+                }
+
+                $outcome = $this->retry($demo, $processor, $source);
+                $outcomes[$outcome] = ($outcomes[$outcome] ?? 0) + 1;
+                $this->line('  ' . $demo->id . '  -> ' . $outcome);
+
+                if ($sleep = (int) $this->option('sleep')) {
+                    sleep($sleep);
+                }
+            }
+
+            return true;
+        });
+
+        $this->newLine();
+        $this->info('Looked at ' . $seen . ' demo(s).');
+        $this->line('  readable with the current parser: ' . $readable);
+        $this->line('  still unreadable: ' . $stillUnreadable);
+        $this->line('  no file to read: ' . $noSource);
+
+        foreach ($outcomes as $status => $count) {
+            $this->line('  ended as ' . $status . ': ' . $count);
+        }
+
+        if (! $apply && $readable > 0) {
+            $this->newLine();
+            $this->comment('Nothing was written. Add --apply to put these back through.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The file to read. A failed demo normally sits compressed under
+     * demos/failed/<id>/, but older ones were left uncompressed and a few still
+     * point at wherever they were when they failed.
+     */
+    private function locateSource(UploadedDemo $demo): ?string
+    {
+        $failedDir = storage_path('app/demos/failed/' . $demo->id);
+
+        $candidates = [
+            $failedDir . '/' . $demo->original_filename,
+            storage_path('app/' . $demo->file_path),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        foreach (glob($failedDir . '/*') ?: [] as $found) {
+            if (is_file($found)) {
+                return $found;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Put an uncompressed copy in the work directory and hand back its path.
+     */
+    private function stage(string $source, string $workDir, string $originalFilename): ?string
+    {
+        $this->cleanup($workDir);
+
+        if (! is_dir($workDir) && ! mkdir($workDir, 0755, true) && ! is_dir($workDir)) {
+            return null;
+        }
+
+        $target = $workDir . '/' . $originalFilename;
+
+        if (! str_ends_with(strtolower($source), '.7z')) {
+            return copy($source, $target) ? $target : null;
+        }
+
+        $process = new Process(['7z', 'e', '-y', '-o' . $workDir, $source]);
+        $process->setTimeout(120);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $extracted = glob($workDir . '/*.dm_*') ?: [];
+
+        if (! $extracted) {
+            return null;
+        }
+
+        if ($extracted[0] !== $target) {
+            rename($extracted[0], $target);
+        }
+
+        return $target;
+    }
+
+    /**
+     * What the current parser makes of the file, or null if it still cannot
+     * read it.
+     */
+    private function readMetadata(string $demoFile): ?array
+    {
+        $script = base_path('app/Services/DemoProcessor/bin/process_single_demo.py');
+
+        $process = new Process(['python3', $script, $demoFile, '--json']);
+        $process->setTimeout(120);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $decoded = json_decode(trim($process->getOutput()), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * Reset the row the way the per-demo reprocess button does, then run it.
+     */
+    private function retry(UploadedDemo $demo, DemoProcessorService $processor, string $source): string
+    {
+        // Where the file was before we pointed the row at a temp copy. The
+        // pipeline rejects a non-defrag demo by deleting that temp directory
+        // without moving anything, which would leave the row pointing at a path
+        // that no longer exists while the archive sits untouched where it was.
+        // The file we actually read is the fallback, since a row can arrive
+        // already pointing at nothing.
+        // A row can also arrive already pointing into demos/temp from an
+        // earlier retry, which is never somewhere to fall back to.
+        $stored = (string) $demo->file_path;
+        $usable = $stored !== ''
+            && ! str_starts_with($stored, 'demos/temp/')
+            && is_file(storage_path('app/' . $stored));
+
+        $originalPath = $usable
+            ? $stored
+            : ltrim(str_replace(storage_path('app'), '', $source), '/');
+
+        $demo->update([
+            'status' => 'uploaded',
+            'file_path' => 'demos/temp/' . $demo->id . '/' . $demo->original_filename,
+            'processed_filename' => null,
+            'map_name' => null,
+            'physics' => null,
+            'gametype' => null,
+            'player_name' => null,
+            'q3df_login_name' => null,
+            'q3df_login_name_colored' => null,
+            'time_ms' => null,
+            'processing_output' => null,
+            'record_id' => null,
+            'match_method' => null,
+        ]);
+
+        if ($this->option('queue')) {
+            \App\Jobs\ProcessDemoJob::dispatch($demo);
+
+            return 'queued';
+        }
+
+        try {
+            $processor->processDemo($demo);
+        } catch (\Throwable $e) {
+            Log::error('Retry of a failed demo threw', ['demo_id' => $demo->id, 'error' => $e->getMessage()]);
+
+            $demo->update([
+                'status' => 'failed',
+                'file_path' => $originalPath,
+                'processing_output' => '[' . now()->format('Y-m-d H:i:s') . '] Retry failed: ' . $e->getMessage(),
+            ]);
+
+            return 'threw: ' . substr($e->getMessage(), 0, 60);
+        }
+
+        $demo = $demo->fresh();
+
+        if ($demo->status === 'failed' && $demo->file_path !== $originalPath
+            && ! is_file(storage_path('app/' . $demo->file_path))) {
+            $demo->update(['file_path' => $originalPath]);
+        }
+
+        return (string) $demo->status;
+    }
+
+    private function cleanup(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/app/Services/DemoProcessor/bin/demo.py
+++ b/app/Services/DemoProcessor/bin/demo.py
@@ -65,6 +65,10 @@ def normalize_country_code(country: str) -> str:
 class Demo:
     mapName: str = ''
     modphysic: str = ''
+    # vq3 or cpm on its own. A demo from before Defrag existed is tagged with
+    # its mod and its game mode, osp.ffa, so the physics never reaches the name
+    # even though the mod reports it through server_promode like any other.
+    gameplayPhysic: str = ''
     timeString: str = ''
     time: timedelta = timedelta(0)
     playerName: str = ''
@@ -284,6 +288,7 @@ class Demo:
                 demo.modphysic = f"{game_info.gameTypeShort}.{game_info.gameplayTypeShort}"
         else:
             demo.modphysic = f"{game_info.gameNameShort}.{game_info.gameTypeShort}"
+        demo.gameplayPhysic = game_info.gameplayTypeShort or ''
         if demo.hasTr:
             demo.modphysic += '.tr'
         additional = raw.consoleComandsParser.additionalInfos[-1].toDictionary() if raw.consoleComandsParser.additionalInfos else None

--- a/app/Services/DemoProcessor/bin/demo.py
+++ b/app/Services/DemoProcessor/bin/demo.py
@@ -311,7 +311,11 @@ class Demo:
 
     @staticmethod
     def _remove_double(value: str) -> str:
-        match = re.search(r"[^a-zA-Z0-9\\(\\)\\]\[](?=[^a-zA-Z0-9\\(\\)\\]\[])", value)
+        # The C# these came from writes its patterns as ordinary strings, where
+        # "\\[" is the two characters \[ the regex engine then sees. Copied into
+        # a raw string here the backslash doubled, so the pattern went looking
+        # for a literal backslash in the filename and never matched anything.
+        match = re.search(r"[^a-zA-Z0-9()\]\[](?=[^a-zA-Z0-9()\]\[])", value)
         if not match:
             return value
         idx = match.start()
@@ -428,7 +432,18 @@ class Demo:
             if value < 0:
                 invalid[key] = params[key]
             elif value != expected:
-                invalid[key] = str(value)
+                invalid[key] = Demo._format_key_value(value)
+
+    @staticmethod
+    def _format_key_value(value: float) -> str:
+        # A whole number prints without its fraction, the way the C# does it.
+        # Python's str() gives "1.0", so a demo recorded with sv_cheats 1 got
+        # named {sv_cheats=1.0} while every older file says {sv_cheats=1}, and
+        # the rename could no longer recognise its own note to take it off.
+        if value == int(value):
+            return str(int(value))
+
+        return repr(value)
 
     @staticmethod
     def _get_key(params: Dict[str, str], key: str) -> float:
@@ -442,7 +457,10 @@ class Demo:
 
     @staticmethod
     def _get_validities(filename: str) -> Optional[Tuple[str, str]]:
-        match = re.match(r"^[^\\[]+\\[[^\\.\\]]+.[^\\]]+]\\d{2,3}\\.\\d{2}\\.\\d{3}\\(.+\\){(\\w+)=(\\w+)}(?:\\[\\d+\\])?\\.\\w+$", filename)
+        # Keeps a note an earlier rename put in the filename, like
+        # dfwc2014-5[df.vq3]00.36.904(Enter.Russia){old_map_version=true}.dm_68,
+        # when the demo itself reports nothing wrong.
+        match = re.match(r"^[^\[]+\[[^.\]]+.[^\]]+]\d{2,3}\.\d{2}\.\d{3}\(.+\){(\w+)=(\w+)}(?:\[\d+\])?\.\w+$", filename)
         if match:
             return match.group(1), match.group(2)
         return None
@@ -450,10 +468,10 @@ class Demo:
     @staticmethod
     def _try_get_user_id_from_file_name(file: Path) -> int:
         name_no_ext = file.stem
-        match = re.match(r"^.+\\[(\\d+)\\]\\[(\\d+)\\]$", name_no_ext)
+        match = re.match(r"^.+\[(\d+)\]\[(\d+)\]$", name_no_ext)
         if match:
             return int(match.group(2))
-        match = re.match(r"^.+\\[.+\\].+\\(.+\\)(?:{.+})*\\[(\\d+)\\]$", name_no_ext)
+        match = re.match(r"^.+\[.+\].+\(.+\)(?:{.+})*\[(\d+)\]$", name_no_ext)
         if match:
             return int(match.group(1))
         return -1

--- a/app/Services/DemoProcessor/bin/renamer.py
+++ b/app/Services/DemoProcessor/bin/renamer.py
@@ -202,6 +202,7 @@ def parse_demo_metadata(file_path: Path) -> Optional[dict]:
         "map_name": demo.mapName,
         "player_name": demo.playerName,
         "physics": demo.modphysic,
+        "gameplay_physics": getattr(demo, 'gameplayPhysic', '') or None,
         "time_seconds": demo.time.total_seconds() if demo.time else None,
         "country": demo.country if demo.country else None,
         "validity": demo.validDict if demo.validDict else None,

--- a/app/Services/DemoProcessorService.php
+++ b/app/Services/DemoProcessorService.php
@@ -84,10 +84,31 @@ class DemoProcessorService
             $format = config('app.demo_compression_format', '7z');
             $compressedFilename = pathinfo($processedFilename, PATHINFO_FILENAME) . '.' . $format;
 
-            // Block non-defrag demos (CPMA, OSP, Q3A, etc.)
-            $blockedGametypes = ['osp', 'q3a', 'cpma', 'q3uft', 'ra3', 'q3xp', 'q3w'];
+            // Quake 3 had no timer before Defrag existed, so the trick demos
+            // from 2002 and 2003 were recorded in plain Q3 or in OSP, on
+            // servers that called themselves running servers. Those belong on
+            // the map they were made on. A duel recorded in the same mod does
+            // not, and the mode in the tag is what separates them: osp.ffa is
+            // somebody running, cpma.1v1 is a match POV off a broadcast.
+            $foreignMods = ['osp', 'q3a', 'cpma', 'q3uft', 'ra3', 'q3xp', 'q3w'];
             $detectedGametype = $metadata['gametype'] ?? null;
-            if ($detectedGametype && in_array(strtolower($detectedGametype), $blockedGametypes)) {
+            $isForeignMod = $detectedGametype && in_array(strtolower($detectedGametype), $foreignMods);
+            $keepAsFreestyle = $isForeignMod && strtolower($metadata['physics'] ?? '') === 'ffa';
+
+            if ($keepAsFreestyle) {
+                // No timer ran, so nothing here is a result. Whatever the
+                // filename claims, it does not become one.
+                $metadata['time_ms'] = null;
+
+                // The map page lists demos under VQ3 or CPM, and "FFA" is
+                // neither, so the demo would be stored and then be reachable
+                // from nowhere. The mod reports the physics through
+                // server_promode; plain Quake 3, which has no such setting, is
+                // VQ3 by definition.
+                $metadata['physics'] = $metadata['gameplay_physics'] ?? 'VQ3';
+            }
+
+            if ($isForeignMod && ! $keepAsFreestyle) {
                 // Clean up temp files
                 $originalTempDir = storage_path("app/demos/temp/{$demo->id}");
                 if (is_dir($originalTempDir)) {
@@ -99,10 +120,14 @@ class DemoProcessorService
 
                 $demo->update([
                     'status' => 'failed',
-                    'processing_output' => '[' . now()->format('Y-m-d H:i:s') . '] Rejected: not a Defrag demo (gametype: ' . $detectedGametype . ')',
+                    'processing_output' => '[' . now()->format('Y-m-d H:i:s') . '] Rejected: not a Defrag demo (gametype: ' . $detectedGametype . '.' . strtolower($metadata['physics'] ?? '?') . ')',
                 ]);
 
-                Log::info("Rejected non-defrag demo", ['demo_id' => $demo->id, 'gametype' => $detectedGametype]);
+                Log::info("Rejected non-defrag demo", [
+                    'demo_id' => $demo->id,
+                    'gametype' => $detectedGametype,
+                    'mode' => $metadata['physics'] ?? null,
+                ]);
                 return;
             }
 
@@ -165,7 +190,16 @@ class DemoProcessorService
                 'will_skip_to_validity_branch' => $demo->status === 'failed-validity',
             ]);
 
-            if ($demo->status !== 'failed-validity') {
+            if ($keepAsFreestyle) {
+                // Kept for the map's Freestyle and Tricks section and nothing
+                // else. There was no timer, so there is no result to rank and
+                // no online record it could belong to.
+                Log::info('Kept a pre-Defrag demo as freestyle', [
+                    'demo_id' => $demo->id,
+                    'gametype' => $demo->gametype,
+                    'map' => $demo->map_name,
+                ]);
+            } elseif ($demo->status !== 'failed-validity') {
                 if ($demo->is_offline) {
                     // Create offline record for offline demos
                     $this->createOfflineRecord($demo, $compressedLocalPath);
@@ -317,6 +351,12 @@ class DemoProcessorService
                     'parts' => $physicsParts,
                     'result' => $metadata['physics'],
                 ]);
+            }
+            // vq3 or cpm on its own, which a demo from a mod other than Defrag
+            // carries but never gets into its name: its tag holds the mod and
+            // the game mode instead, osp.ffa.
+            if (! empty($jsonData['gameplay_physics'])) {
+                $metadata['gameplay_physics'] = strtoupper($jsonData['gameplay_physics']);
             }
             if (isset($jsonData['time_seconds'])) {
                 $metadata['time_ms'] = (int)($jsonData['time_seconds'] * 1000);


### PR DESCRIPTION
2921 demos sit in the failed pile. Most of them are not broken files.

The old parser read any two dot-separated numbers in a filename as a run time,
so a date like `2003-07-01` reached `get_time_span`, which threw, and the
exception took the whole parse down with it. The stricter time shape fixed that
going forward; this puts the pile back through the pipeline and repairs three
more things found on the way.

Measured old parser against new over the same 300 demos: **0 readable before,
26 after, none lost**. Over the whole pile: **180 readable, 2713 still not, 28
with no file left on disk**. All but two have no time of their own, on maps like
q3dm6, q3dm17, ra3map1 and hub3aeroq3, which is exactly the trick demos the
report was about. They have somewhere to land now that a map lists its untimed
demos.

## `php artisan demos:retry-failed`

Reports before it writes anything. `--apply` to write, `--limit` for a batch,
`--id` for specific demos, `--queue` to hand them to the queue instead of
processing inline. A full dry run takes about eight minutes.

The archive under `demos/failed/<id>/` is only ever read, never deleted, and a
demo the pipeline turns down keeps a `file_path` that still points at it. The
pipeline rejects a non-defrag demo by deleting the temp copy without moving
anything, which would otherwise leave the row pointing at a path that no longer
exists.

## Four parser patterns that never matched anything

They came over from DemoCleaner3, where C# writes patterns as ordinary strings:
`"\\["` is the two characters `\[` that the regex engine then sees. Copied
straight into Python raw strings the backslash stayed doubled, so each pattern
went looking for a literal backslash in the filename and matched nothing.

Three helpers were dead as a result. `_remove_double` stopped collapsing runs of
punctuation, `_get_validities` stopped carrying forward a note an earlier rename
had put in the name, and `_try_get_user_id_from_file_name` never found the id.

The fourth is the value of a cvar note. Python's `str()` turns `1.0` into
`"1.0"` where C# gives `"1"`, so a demo recorded with sv_cheats 1 was named
`{sv_cheats=1.0}` while every older file says `{sv_cheats=1}`. The rename then
no longer recognised its own note and appended a second one, leaving names like
`14-6_p1{sv_cheats=1{sv_cheats=1.0}`. That is the unclosed brace on 1593 files.
Only demos with no time of their own build their name out of the old one, so the
damage was confined to freestyle and unfinished runs. Fixed forward; renaming
the files already stored is a separate job.

## The trick demos from before Defrag existed

Quake 3 had no timer of its own, so the freestyle from 2002 and 2003 was
recorded in plain Q3 or in OSP, on servers that called themselves running
servers. The pipeline turned all of it away by mod name, which also swept up
demos on our own maps: accurun, opc1, bfgpowa, b0_beta3, one of them with
"freestyle" written into the filename.

What should be turned away is the game mode, not the mod. `osp.ffa` is somebody
running alone, on a server whose own name says running, with `server_promode 1`.
`cpma.1v1` is a duel POV off a broadcast, `g_gametype 1`, fraglimit 100, five
slots, another game entirely. So a foreign mod now passes when its mode is
`ffa` and is refused otherwise, and the refusal message says which mode it was.

What passes is kept as a demo and nothing more: no time, whatever the filename
claims, and no record, online or offline. It appears in the map's Freestyle and
Tricks section beside the modern freestyle and nowhere else.

One trap worth naming. Those demos are tagged with mod and mode, `osp.ffa`, so
their physics never reaches the name, and the map page lists demos under VQ3 or
CPM. Stored but reachable from nowhere. The mod does report the physics, through
`server_promode`, so the parser hands it over as its own field now, and plain
Quake 3, which has no such setting, counts as VQ3.

Of the 180 demos the pile gives back, this covers 72 of the 96 that were being
refused. The remaining 24 are duels and stay out.

## Checked

- Old and new parser run over the same 300 demos from the pile, in identical
  trees apart from the changed files, so the compiled huffman extension could
  not skew the comparison.
- One demo of each kind put through end to end on a local disk, then the rows
  restored: `osp.ffa` came out processed with physics CPM, no time and no
  record; `cpma.1v1` came out refused with its archive path intact.
- The map page's untimed query picks the kept demo up in the CPM bucket beside
  the sixteen freestyle demos already on that map.

## After deploy

```bash
php artisan cache:clear
php artisan demos:retry-failed              # dry run, about eight minutes
php artisan demos:retry-failed --limit=50 --apply
```

Then the rest once the first fifty look right. It has to run on the server: a
local `--apply` writes into the live bucket.
