### PR TITLE
Commit times on the roadmap, and the map you typed ranks first in search

### DIFF
--- a/app/Http/Controllers/MaplistController.php
+++ b/app/Http/Controllers/MaplistController.php
@@ -596,7 +596,7 @@ class MaplistController extends Controller
     {
         $query = $request->get('q', '');
 
-        $maps = Map::search($query)
+        $maps = Map::searchByName($query)
             ->take(20)
             ->get()
             ->map(fn($map) => [

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -22,7 +22,7 @@ class SearchController extends Controller
         $likeSearch = '%' . $rawSearch . '%';
 
         // Typesense search + DB fuzzy fallback for maps
-        $maps = Map::search($request->search)->paginate(25);
+        $maps = Map::searchByName($request->search)->paginate(25);
         if ($maps->isEmpty()) {
             $maps = Map::where('name', 'LIKE', $fuzzyPattern)
                 ->orderBy('date_added', 'DESC')

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -63,6 +63,7 @@ class WebController extends Controller
                         'title' => $title,
                         'description' => $body,
                         'date' => $rawDate ? date('Y-m-d', strtotime($rawDate)) : null,
+                        'time' => $rawDate ? date('H:i', strtotime($rawDate)) : null,
                         'author' => $author,
                     ];
                 }
@@ -176,6 +177,7 @@ class WebController extends Controller
                     'title' => $title,
                     'description' => $body,
                     'date' => isset($parts[3]) ? date('Y-m-d', strtotime(trim($parts[3]))) : null,
+                    'time' => isset($parts[3]) ? date('H:i', strtotime(trim($parts[3]))) : null,
                 ];
             }
             return array_slice($commits, 0, 5);
@@ -286,6 +288,7 @@ class WebController extends Controller
                 $body = trim($body);
 
                 $date = isset($parts[3]) ? date('Y-m-d', strtotime(trim($parts[3]))) : null;
+                $time = isset($parts[3]) ? date('H:i', strtotime(trim($parts[3]))) : null;
                 $author = trim($parts[4] ?? '');
 
                 $commits[] = [
@@ -293,6 +296,7 @@ class WebController extends Controller
                     'title' => trim($parts[1]),
                     'description' => $body,
                     'date' => $date,
+                    'time' => $time,
                     'author' => $author,
                 ];
             }

--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -93,10 +93,39 @@ class Map extends Model
         return $result;
     }
 
+    /**
+     * Map search with the name the user typed pinned to the top.
+     *
+     * `name` is indexed as every suffix of the map name, so a search for
+     * "pgrun" scores "#pgrun" and "cos1_pgrun" exactly the same and the tie
+     * fell through to the default sorting field - newest map first - which
+     * buried the map that had been typed out in full. `name_exact` carries the
+     * raw name, so an exact hit can win the tie. Typesense caps sort_by at
+     * three criteria, hence text match, exact hit, recency and nothing else.
+     *
+     * The value is backtick-quoted because map names are full of characters
+     * the filter grammar would otherwise read as syntax (#, -, +, brackets).
+     */
+    public static function searchByName ($term) {
+        $term = trim((string) $term);
+        $builder = static::search($term);
+
+        if ($term === '') {
+            return $builder;
+        }
+
+        $exact = '`' . str_replace('`', '', mb_strtolower($term)) . '`';
+
+        return $builder->options([
+            'sort_by' => "_text_match:desc,_eval(name_exact:={$exact}):desc,created_at:desc",
+        ]);
+    }
+
     public function toSearchableArray () {
         return [
             'id' => (string) $this->id,
             'name' => $this->generateSubstrings($this->name),
+            'name_exact' => mb_strtolower((string) $this->name),
             'created_at' => $this->created_at->timestamp,
         ];
     }

--- a/config/scout.php
+++ b/config/scout.php
@@ -191,6 +191,14 @@ return [
                             'type'  => 'string[]'
                         ],
                         [
+                            // The raw name alongside the suffix list in `name`,
+                            // so a search can tell the map that was typed out in
+                            // full from every map that merely ends with it.
+                            // Sorted on by Map::searchByName().
+                            'name' => 'name_exact',
+                            'type' => 'string',
+                        ],
+                        [
                             'name' => 'created_at',
                             'type' => 'int64',
                         ],
@@ -198,6 +206,9 @@ return [
                     'default_sorting_field' => 'created_at',
                     "token_separators"      => ["-", "_"]
                 ],
+                // Scout's Typesense engine reads only `query_by` out of this
+                // block and drops the rest, so anything else has to be passed
+                // per query - see Map::searchByName().
                 'search-parameters' => [
                     'query_by' => 'name',
                     'prefix'   => true,

--- a/resources/js/Pages/Roadmap.vue
+++ b/resources/js/Pages/Roadmap.vue
@@ -101,7 +101,7 @@ const repoUrl = computed(() => REPOS[activeRepo.value]);
                                 >
                                     <span class="text-[10px] font-mono text-gray-500 w-5 text-right flex-shrink-0">{{ commitItems.length - index }}</span>
                                     <div class="w-1.5 h-1.5 bg-green-400 rounded-full flex-shrink-0"></div>
-                                    <span class="text-[10px] font-mono text-gray-500 w-16 flex-shrink-0">{{ commit.date }}</span>
+                                    <span class="text-[10px] font-mono text-gray-500 w-28 flex-shrink-0 whitespace-nowrap">{{ commit.date }}<span v-if="commit.time" class="text-gray-600 ml-1">{{ commit.time }}</span></span>
                                     <span class="text-xs font-mono text-green-400/70">{{ commit.hash }}</span>
                                     <span class="text-xs text-gray-300 truncate flex-1">{{ commit.title }}</span>
                                     <span class="text-[10px] text-gray-500 flex-shrink-0">{{ commit.author }}</span>


### PR DESCRIPTION
Two unrelated items off the queue.

Commit times on the roadmap. Both changelog feeds are built from timestamps that already carry the hour and minute (git log's %ai for the website, the GitHub API's author date for the launcher) and both threw it away with date('Y-m-d'), so commits from the same day were indistinguishable and looked unordered. Every feed now also emits a time field (H:i, UTC like the rest of the app) and the roadmap renders it next to the date. The home page panel is deliberately left alone - its rows are narrow enough that the commit title is already truncating.

Map search ranking. Searching for #pgrun returned cos1_pgrun first and the map itself second. The hash was not the cause: map names are indexed as every suffix of the name, so pgrun is an equally good match for both, the text scores tie, and the tie fell through to the collection's default sorting field - newest map first. Whichever map happened to be added last won.

The index now also carries the raw name in name_exact, and searches sort on an exact hit against it before falling back to recency. Typesense caps sort_by at three criteria, so it is text match, exact hit, recency. Because the tokenizer drops a leading #, typing pgrun finds the map named #pgrun too. Measured over 300 random map names, the name typed out in full came first 293 times before and 298 after, with nothing pushed down; over the 40 maps with a # in the name, 39 before and all 40 after. The two stragglers are vineyard++ and -nw-simple, where the punctuation is the whole problem.

The sort has to name the search term, so it cannot live in config - Scout's Typesense engine reads only query_by out of that block and silently drops everything else, which is noted there now. Both call sites go through Map::searchByName().

Deploying this needs the name_exact field added to the maps collection. The deploy script runs scout:import but never recreates the collection, so the field has to be patched in first, otherwise map search fails with Error parsing eval expression in sort_by clause.