### PR TITLE
Index for search after the workers restart, not before

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -84,8 +84,6 @@ def pipeline_cmds(name):
         "php artisan route:cache",
         "php artisan view:cache",
         "php artisan icons:cache",
-        "php artisan scout:import 'App\\Models\\Demo'",
-        "php artisan scout:import 'App\\Models\\Map'",
         # Link public assets from deploy directory
         f"rm -rf {PROJECT_PATH}/releases/{name}/public/baseq3",
         f"ln -s {PROJECT_PATH}/deploy/baseq3 {PROJECT_PATH}/releases/{name}/public/baseq3",
@@ -138,6 +136,15 @@ else
     fi
 fi
 exit 0""",
+        # Search indexing, and it has to be down here rather than up with the
+        # other cache rebuilds. SCOUT_QUEUE is on, so `scout:import` only
+        # dispatches jobs - and run before the restarts above, those jobs get
+        # picked up by the workers of the *previous* release, which build each
+        # document with the old toSearchableArray(). Any newly indexed field
+        # silently never lands, which is how the map search shipped without its
+        # name_exact and had to be re-imported by hand after the deploy.
+        "php artisan scout:import 'App\\Models\\Demo'",
+        "php artisan scout:import 'App\\Models\\Map'",
         # Warm the rest of the public-page caches by triggering the
         # Cache::remember blocks inside the controllers (homepage
         # totals, ranking prebuilt pages, records, community


### PR DESCRIPTION
SCOUT_QUEUE is on, so scout:import does not index anything itself - it dispatches a job per chunk. Sitting where it did, above the symlink swap and the worker restart, those jobs were picked up by the workers still running the previous release, which build every document with the old toSearchableArray().

A field added in the same deploy therefore never reached the index, and nothing said so: the import reported success, the collection kept its old shape, and the feature looked broken for no visible reason. That is exactly how the map search ranking went out without its name_exact and needed a manual re-import afterwards.

Moved both imports below the octane check, which also buys the restarted workers a few seconds to come up.