### PR TITLE
Build the huffman extension on deploy

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -70,6 +70,18 @@ def pipeline_cmds(name):
         f"rm -rdf {PROJECT_PATH}/releases/{name}/storage",
         f"ln -s {PROJECT_PATH}/deploy/storage {PROJECT_PATH}/releases/{name}/storage",
         "./build-rust.sh",
+        # The huffman decoder the demo parser leans on, built from the C source
+        # that is in the repo. Only the compiled object is gitignored, so every
+        # release starts without it and huffman.py silently falls back to the
+        # pure-Python reader - correct, but several times slower, and on a big
+        # demo slow enough to run into the parser's own timeout. Nothing breaks
+        # if the build fails (that fallback is exactly what we had until now),
+        # so it must never stop a deploy - but say so in the log.
+        'echo "==> Building the demo parser huffman extension..."',
+        "cd app/Services/DemoProcessor/bin/demoparser "
+        "&& python3 setup.py build_ext --inplace "
+        "&& python3 -c \"import _q3huff; print('    huffman extension ready')\" "
+        "|| echo '!!! build failed - demos will be parsed in pure Python (slow but correct)'",
         "php artisan storage:link",
         "php artisan migrate --force",
         "php artisan filament:assets",


### PR DESCRIPTION
The demo parser ships a C huffman decoder and falls back to a pure-Python reader when it cannot import it. Only the compiled object is gitignored - the C source and setup.py are both in the repo - so production had everything it needed and simply never ran the build. Every release therefore started without the extension and quietly took the slow path.

On a small 300 kB demo that is 0.13s against 0.7s, and the gap widens with the file, which is how a dry run over the failed pile hit the parser's 120 second ceiling on a demo a dev box reads without noticing. It also means every upload has been parsed the slow way in production this whole time.

The build cannot break a deploy: if it fails the fallback is exactly the behaviour we had until now, so it only prints a line saying demos will be parsed in Python. Needs gcc and the Python headers on the box.

Clean build verified in the container: compiles and imports.