### PR TITLE
Repair the doubled cvar note in stored filenames

### DIFF
--- a/app/Console/Commands/RetryFailedDemos.php
+++ b/app/Console/Commands/RetryFailedDemos.php
@@ -84,7 +84,7 @@ class RetryFailedDemos extends Command
                 }
 
                 $workDir = storage_path('app/demos/temp/' . $demo->id);
-                $demoFile = $this->stage($source, $workDir, $demo->original_filename);
+                $demoFile = $this->stage($source, $workDir, $demo->original_filename, $demo->id);
 
                 if (! $demoFile) {
                     $noSource++;
@@ -92,7 +92,7 @@ class RetryFailedDemos extends Command
                     continue;
                 }
 
-                $metadata = $this->readMetadata($demoFile);
+                $metadata = $this->readMetadata($demoFile, $demo->id);
 
                 if (! $metadata) {
                     $stillUnreadable++;
@@ -181,7 +181,7 @@ class RetryFailedDemos extends Command
     /**
      * Put an uncompressed copy in the work directory and hand back its path.
      */
-    private function stage(string $source, string $workDir, string $originalFilename): ?string
+    private function stage(string $source, string $workDir, string $originalFilename, int $demoId): ?string
     {
         $this->cleanup($workDir);
 
@@ -197,7 +197,7 @@ class RetryFailedDemos extends Command
 
         $process = new Process(['7z', 'e', '-y', '-o' . $workDir, $source]);
 
-        if (! $this->runOrGiveUp($process, basename($source))) {
+        if (! $this->runOrGiveUp($process, basename($source), $demoId)) {
             return null;
         }
 
@@ -218,13 +218,13 @@ class RetryFailedDemos extends Command
      * What the current parser makes of the file, or null if it still cannot
      * read it.
      */
-    private function readMetadata(string $demoFile): ?array
+    private function readMetadata(string $demoFile, int $demoId): ?array
     {
         $script = base_path('app/Services/DemoProcessor/bin/process_single_demo.py');
 
         $process = new Process(['python3', $script, $demoFile, '--json']);
 
-        if (! $this->runOrGiveUp($process, basename($demoFile))) {
+        if (! $this->runOrGiveUp($process, basename($demoFile), $demoId)) {
             return null;
         }
 
@@ -244,7 +244,7 @@ class RetryFailedDemos extends Command
      * gitignored and only exists on dev boxes), so it is a good deal slower and
      * hits the ceiling on files a dev box gets through.
      */
-    private function runOrGiveUp(Process $process, string $what): bool
+    private function runOrGiveUp(Process $process, string $what, int $demoId): bool
     {
         $process->setTimeout(max(1, (int) $this->option('timeout')));
 
@@ -252,7 +252,9 @@ class RetryFailedDemos extends Command
             $process->run();
         } catch (\Throwable $e) {
             $this->tooSlow++;
-            $this->line('  gave up on ' . $what . ' after ' . $this->option('timeout') . 's');
+            // Id first, like every other line, so a second pass over just the
+            // slow ones can be built straight out of the log.
+            $this->line('  ' . $demoId . '  gave up after ' . $this->option('timeout') . 's on ' . $what);
 
             return false;
         }


### PR DESCRIPTION
The renamer appends a note like {sv_cheats=1} when a demo was recorded with a cvar it should not have been, and checks first whether the name already carries one so it does not add a second. PHP's cast of the parser's float gives "1.0" where the older names say "1", so that check never recognised its own note and appended anyway, leaving {sv_cheats=1{sv_cheats=1.0} - two notes, one of them never closed. The cause was fixed in the parser; the names already written were not.

demos:fix-cvar-note reports by default and only writes with --apply, dumping every old name to storage/logs/cvar-note-fix-*.json before the first update so an interrupted run stays recoverable. Production has 3090 affected rows: 1516 with the note doubled, 1574 with a single note left open.

Only damage is touched. A properly closed {sv_cheats=1.0} is left exactly as it is - there are thousands of those, they are not broken, and the value is simply how it was written at the time. A brace anywhere else is left alone too, because plenty of players call themselves things like {oss or DOSIA{Andre; the first draft of the rule would have rewritten 5500 names including theirs. Three edge cases where the two notes name different cvars, or where the first key was truncated (sv_chea next to sv_cheats), are folded by keeping the key that is spelled out.

Nothing on storage is touched and nothing needs to be. A demo is found by file_path; processed_filename is only the name offered to the browser on download, what the lists show, and what search matches against. Verified locally on three rows and then put back from the journal.

Also included: a demo that ran out of time during a retry pass was reported by filename while every other line starts with the id, so a second pass over just the slow ones could not be built from the log the way the rest of the pass could. Both child processes now know which demo they are working on and say so.