### PR TITLE
Import the maps demos sit on but the map table never had

### DIFF
--- a/app/Console/Commands/ImportMissingMaps.php
+++ b/app/Console/Commands/ImportMissingMaps.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\External\WorldSpawn;
+use App\Models\Map;
+use App\Models\UploadedDemo;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Adds rows for maps that demos sit on but the maps table has never heard of.
+ *
+ * `scrape:maps` walks Worldspawn newest-first and stops at the newest map it
+ * already knows, so it only ever picks up what was published since the last
+ * run. Anything older than the first scrape stays missing forever: its page
+ * 404s, it is absent from search and from the map list, and the demos on it
+ * have nowhere to be seen. 1374 such maps carry 12362 demos.
+ *
+ * Worldspawn does not have all of them - the long tail of one-demo maps is
+ * mostly gone, and stock Quake 3 maps were never there in the first place -
+ * so whatever it cannot answer for is written out for a second pass from
+ * another source.
+ *
+ * Reports without writing unless --apply is passed.
+ */
+class ImportMissingMaps extends Command
+{
+    protected $signature = 'maps:import-missing
+        {--apply : Actually add the maps. Without this nothing is written}
+        {--limit=0 : Stop after this many maps (0 = all)}
+        {--min-demos=1 : Skip maps carrying fewer demos than this}
+        {--sleep=1 : Seconds to wait between requests to Worldspawn}';
+
+    protected $description = 'Add maps that demos reference but the maps table is missing';
+
+    public function handle(): int
+    {
+        $apply = (bool) $this->option('apply');
+        $limit = (int) $this->option('limit');
+        $minDemos = max(1, (int) $this->option('min-demos'));
+        $sleep = max(0, (int) $this->option('sleep'));
+
+        $missing = $this->missing($minDemos);
+
+        if ($missing->isEmpty()) {
+            $this->info('Every map a demo points at already has a row.');
+
+            return self::SUCCESS;
+        }
+
+        if ($limit > 0) {
+            $missing = $missing->take($limit);
+        }
+
+        $this->info(($apply ? 'Importing ' : 'Dry run over ') . $missing->count() . ' map(s), '
+            . $missing->sum('demos') . ' demo(s) between them.');
+        $this->line('One request per map with ' . $sleep . 's between them, so this takes a while.');
+        $this->newLine();
+
+        $ws = new WorldSpawn();
+        $found = 0;
+        $added = 0;
+        $absent = [];
+
+        foreach ($missing as $i => $row) {
+            if ($i > 0 && $sleep > 0) {
+                sleep($sleep);
+            }
+
+            $details = $this->lookUp($ws, $row->map_name);
+
+            if (! $details) {
+                $absent[] = $row->demos . "\t" . $row->map_name;
+                $this->line(sprintf('  %5d demos  %-34s not on Worldspawn', $row->demos, $row->map_name));
+                continue;
+            }
+
+            $found++;
+
+            if (! $apply) {
+                $this->line(sprintf(
+                    '  %5d demos  %-34s %s | %s | %s',
+                    $row->demos,
+                    $row->map_name,
+                    $details['physics'] ?: '?',
+                    $details['author'] ?: 'no author',
+                    $details['weapons'] ?: 'no weapons'
+                ));
+                continue;
+            }
+
+            $added += $this->store($ws, $details) ? 1 : 0;
+            $this->line(sprintf('  %5d demos  %-34s added', $row->demos, $row->map_name));
+        }
+
+        $this->newLine();
+        $this->info('Looked at ' . $missing->count() . ' map(s).');
+        $this->line('  Worldspawn has: ' . $found);
+        $this->line('  Worldspawn does not have: ' . count($absent));
+
+        if ($apply) {
+            $this->line('  rows added: ' . $added);
+        }
+
+        if ($absent) {
+            $list = storage_path('logs/maps-not-on-worldspawn.txt');
+            file_put_contents($list, implode("\n", $absent) . "\n");
+            $this->line('  written to ' . $list . ' for a second pass');
+        }
+
+        if (! $apply && $found > 0) {
+            $this->newLine();
+            $this->comment('Nothing was written. Add --apply to import these.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Map names carried by demos that have no row, most demos first, compared
+     * case-insensitively - `RUNDTC` is stored as `rundtc`.
+     */
+    private function missing(int $minDemos)
+    {
+        $have = Map::pluck('name')->map(fn ($n) => mb_strtolower($n))->flip();
+
+        return UploadedDemo::query()
+            ->whereNotNull('map_name')
+            ->where('map_name', '!=', '')
+            ->select('map_name', DB::raw('count(*) as demos'))
+            ->groupBy('map_name')
+            ->having('demos', '>=', $minDemos)
+            ->orderByDesc('demos')
+            ->get()
+            ->reject(fn ($row) => isset($have[mb_strtolower($row->map_name)]))
+            ->values();
+    }
+
+    /**
+     * Worldspawn's details for a map, or null. Anything that goes wrong counts
+     * as "not there": a missing map answers with a page that has none of the
+     * elements the parser reaches for, so it fails on a null rather than
+     * returning cleanly, and one absent map must not end the run.
+     */
+    private function lookUp(WorldSpawn $ws, string $name): ?array
+    {
+        try {
+            $details = $ws->getMapDetails($name);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        return is_array($details) && ! empty($details['name']) ? $details : null;
+    }
+
+    private function store(WorldSpawn $ws, array $details): bool
+    {
+        if (Map::where('name', $details['name'])->exists()) {
+            return false;
+        }
+
+        // Worldspawn answers for a stock map with "Quake III: Arena.pk3" and the
+        // size of the whole game, which is a statement of where the map comes
+        // from rather than a file anyone can fetch. Left in, the download button
+        // would point at dl.defrag.racing for a pk3 that was never there.
+        if (stripos((string) ($details['pk3'] ?? ''), 'quake iii') !== false) {
+            $details['pk3'] = null;
+            $details['pk3_size'] = null;
+        }
+
+        $map = new Map();
+        $map->fill($details);
+        $map->thumbnail = $ws->downloadImage($details['map_image']);
+        $map->visible = true;
+        $map->save();
+
+        return true;
+    }
+}

--- a/app/Console/Commands/ScrapeMaps.php
+++ b/app/Console/Commands/ScrapeMaps.php
@@ -84,20 +84,6 @@ class ScrapeMaps extends Command
     }
 
     public function downloadImage($url) {
-        $ch = curl_init($url);
-
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-
-        $data = curl_exec($ch);
-
-        curl_close($ch);
-
-        $extension = pathinfo($url, PATHINFO_EXTENSION);
-        $filename = "thumbs/" . Str::random(20) . '.' . $extension;
-
-        Storage::disk('public')->put($filename, $data);
-
-        return $filename;
+        return (new WorldSpawn())->downloadImage($url);
     }
 }

--- a/app/External/WorldSpawn.php
+++ b/app/External/WorldSpawn.php
@@ -5,6 +5,8 @@ namespace App\External;
 use \DOMDocument;
 use \DOMXPath;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class WorldSpawn {
     protected $url = "https://ws.q3df.org/maps/?show=50&page=";
@@ -135,7 +137,10 @@ class WorldSpawn {
     public function getMapDetails($map) {
         $result = [];
 
-        $xpath = $this->read_data($this->mapUrl . $map);
+        // Encoded, or a name like "#pgrun" cuts the URL short at the fragment
+        // and every map whose name starts with a hash comes back as the map
+        // list. The raw name is what goes into the result below.
+        $xpath = $this->read_data($this->mapUrl . rawurlencode($map));
 
         if (!($xpath instanceof DOMXPath)) {
             \Log::warning('WorldSpawn: Failed to fetch map details for ' . $map);
@@ -371,5 +376,34 @@ class WorldSpawn {
         }
 
         return '';
+    }
+
+    /**
+     * Pull a levelshot down to the public disk and return its stored path.
+     *
+     * Lives here rather than in a command so that everything importing a map -
+     * the nightly scrape and the backfill of maps it never reached - stores its
+     * thumbnails the same way.
+     */
+    public function downloadImage($url) {
+        $ch = curl_init($url);
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+
+        $data = curl_exec($ch);
+
+        curl_close($ch);
+
+        if ($data === false || $data === '') {
+            return null;
+        }
+
+        $extension = pathinfo($url, PATHINFO_EXTENSION);
+        $filename = 'thumbs/' . Str::random(20) . '.' . $extension;
+
+        Storage::disk('public')->put($filename, $data);
+
+        return $filename;
     }
 }

--- a/resources/js/Components/MapCard.vue
+++ b/resources/js/Components/MapCard.vue
@@ -197,8 +197,10 @@
                             <span class="text-[9px] font-semibold">Save</span>
                         </button>
 
-                        <!-- Download Button -->
+                        <!-- Download Button. Hidden for maps that ship with the
+                             game, which have no pk3 of their own to fetch. -->
                         <a
+                            v-if="map?.pk3"
                             @click.stop
                             target="_blank"
                             :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')"

--- a/resources/js/Components/MapCardLineSmall.vue
+++ b/resources/js/Components/MapCardLineSmall.vue
@@ -118,7 +118,9 @@
                     <div v-for="func in functionsList" :title="func" :class="`sprite-items sprite-${func} w-5 h-5 mr-1 flex-shrink-0 mb-1`"></div>
                 </div>
     
-                <a target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
+                <!-- No pk3 means the map ships with the game, so there is
+                     nothing to download. -->
+                <a v-if="map?.pk3" target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
                     <div class="flex justify-center text-gray-400 bg-blackop-50 hover:bg-blackop-80 py-1 px-2 rounded-md cursor-pointer" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" />


### PR DESCRIPTION
scrape:maps walks Worldspawn newest-first and stops at the newest map it already knows, so it only ever picks up what was published since the last run. Anything older than the first scrape was never imported and never will be: the map page 404s, the map is absent from search and from the list, and the demos recorded on it have nowhere to be seen. That is 1374 maps carrying 12362 demos, q3dm17 alone with 936.

maps:import-missing takes the map names demos point at, compares them against the map table case-insensitively (RUNDTC is stored rundtc), and asks Worldspawn for each in turn, most demos first. It reports by default and writes only with --apply. Worldspawn's own details give the physics, author, description, date, pk3 and - as asked for - the weapons, items, functions and levelshot, so an imported map is furnished exactly like a scraped one.

Coverage is far better weighted by demos than by map: of the thirty largest, 28 are on Worldspawn, covering 95% of their demos, while a random sample across all 1374 finds only a quarter. The long tail of maps with one or two demos is largely gone from there, so every name Worldspawn cannot answer for is written to storage/logs/maps-not-on-worldspawn.txt for a second pass from another source.

Two things found on the way:

- A map name starting with # cut the request URL short at the fragment, so Worldspawn answered with the map list instead of the map. The name is encoded now and kept raw in the result.
- Worldspawn describes a stock map's pk3 as "Quake III: Arena.pk3" at the size of the whole game, which is a statement of origin, not a file. It is not stored, and the download button now hides itself when a map has no pk3 rather than linking to something that was never on dl.defrag.racing.

Thumbnail downloading moved to the Worldspawn client so both importers store levelshots the same way; scrape:maps keeps its method and delegates.

Verified locally by importing q3dm17 end to end - row complete with author, The Longest Yard, weapons, items, functions and an 11 kB levelshot - then removed along with its thumbnail.