### PR TITLE
Find maps published under a name the demos never saw

### DIFF
--- a/app/Console/Commands/ImportMissingMaps.php
+++ b/app/Console/Commands/ImportMissingMaps.php
@@ -30,7 +30,9 @@ class ImportMissingMaps extends Command
         {--apply : Actually add the maps. Without this nothing is written}
         {--limit=0 : Stop after this many maps (0 = all)}
         {--min-demos=1 : Skip maps carrying fewer demos than this}
-        {--sleep=1 : Seconds to wait between requests to Worldspawn}';
+        {--sleep=1 : Seconds to wait between requests to Worldspawn}
+        {--only=* : Only these map names, instead of everything missing}
+        {--via-search : Also import maps only a search could find, under the name the demos use}';
 
     protected $description = 'Add maps that demos reference but the maps table is missing';
 
@@ -42,6 +44,11 @@ class ImportMissingMaps extends Command
         $sleep = max(0, (int) $this->option('sleep'));
 
         $missing = $this->missing($minDemos);
+
+        if ($only = $this->option('only')) {
+            $wanted = array_map('mb_strtolower', $only);
+            $missing = $missing->filter(fn ($row) => in_array(mb_strtolower($row->map_name), $wanted, true))->values();
+        }
 
         if ($missing->isEmpty()) {
             $this->info('Every map a demo points at already has a row.');
@@ -62,6 +69,7 @@ class ImportMissingMaps extends Command
         $found = 0;
         $added = 0;
         $absent = [];
+        $candidates = [];
 
         foreach ($missing as $i => $row) {
             if ($i > 0 && $sleep > 0) {
@@ -69,11 +77,37 @@ class ImportMissingMaps extends Command
             }
 
             $details = $this->lookUp($ws, $row->map_name);
+            $viaSearch = null;
+
+            if (! $details) {
+                $viaSearch = $this->searchFor($ws, $row->map_name);
+
+                if ($viaSearch) {
+                    $details = $this->lookUp($ws, $viaSearch);
+                }
+            }
 
             if (! $details) {
                 $absent[] = $row->demos . "\t" . $row->map_name;
                 $this->line(sprintf('  %5d demos  %-34s not on Worldspawn', $row->demos, $row->map_name));
                 continue;
+            }
+
+            if ($viaSearch) {
+                // Published under a different name than the .bsp the demos
+                // recorded. The row has to carry the name the demos use or they
+                // still will not find it, so everything else comes from the
+                // release page while the name does not.
+                $candidates[] = $row->demos . "\t" . $row->map_name . "\t" . $viaSearch;
+                $details['name'] = $row->map_name;
+
+                if (! $this->option('via-search')) {
+                    $this->line(sprintf(
+                        '  %5d demos  %-34s only via search -> %s (skipped)',
+                        $row->demos, $row->map_name, $viaSearch
+                    ));
+                    continue;
+                }
             }
 
             $found++;
@@ -101,6 +135,15 @@ class ImportMissingMaps extends Command
 
         if ($apply) {
             $this->line('  rows added: ' . $added);
+        }
+
+        if ($candidates) {
+            $this->line('  found only by search: ' . count($candidates)
+                . ($this->option('via-search') ? ' (imported)' : ' (skipped, pass --via-search to take them)'));
+
+            $list = storage_path('logs/maps-found-by-search.txt');
+            file_put_contents($list, implode("\n", $candidates) . "\n");
+            $this->line('  listed in ' . $list . ' as demos, name used, name on Worldspawn');
         }
 
         if ($absent) {
@@ -152,6 +195,31 @@ class ImportMissingMaps extends Command
         }
 
         return is_array($details) && ! empty($details['name']) ? $details : null;
+    }
+
+    /**
+     * The one map a search turns up for a name, or null.
+     *
+     * Worldspawn names its pages after the release, which is usually but not
+     * always the .bsp inside - the demos on "thirdperson" belong to the map
+     * published as "teamrun-thirdperson". A search finds it, but a search also
+     * matches on substrings, so this only answers when exactly one result
+     * carries the name looked for. Anything less certain is left for a human.
+     */
+    private function searchFor(WorldSpawn $ws, string $name): ?string
+    {
+        try {
+            $hits = $ws->searchMaps($name);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        $hits = array_values(array_filter(
+            $hits,
+            fn ($hit) => str_contains(mb_strtolower($hit), mb_strtolower($name))
+        ));
+
+        return count($hits) === 1 ? $hits[0] : null;
     }
 
     private function store(WorldSpawn $ws, array $details): bool

--- a/app/External/WorldSpawn.php
+++ b/app/External/WorldSpawn.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 
 class WorldSpawn {
     protected $url = "https://ws.q3df.org/maps/?show=50&page=";
+    protected $searchUrl = "https://ws.q3df.org/maps/?show=50&map=";
     protected $mapUrl = "https://ws.q3df.org/map/";
     protected $wsUrl = "https://ws.q3df.org";
     protected $xpath;
@@ -132,6 +133,34 @@ class WorldSpawn {
             'found' =>  $found,
             'maps'  =>  $maps
         ];
+    }
+
+    /**
+     * Map names Worldspawn lists for a search.
+     *
+     * Its pages are named after the release, which is usually but not always
+     * the name of the .bsp inside - "thirdperson" is published as
+     * "teamrun-thirdperson" - so a lookup by the name a demo recorded can miss
+     * a map that is very much there.
+     */
+    public function searchMaps($name) {
+        $xpath = $this->read_data($this->searchUrl . rawurlencode($name));
+
+        if (!($xpath instanceof DOMXPath)) {
+            return [];
+        }
+
+        $table = $xpath->query("//table[@id='maps_table']")->item(0);
+
+        if (! $table) {
+            return [];
+        }
+
+        try {
+            return $this->getMaps($table)['maps'];
+        } catch (\Throwable $e) {
+            return [];
+        }
     }
 
     public function getMapDetails($map) {


### PR DESCRIPTION
Worldspawn names its pages after the release, which is usually the .bsp inside it but not always: the 219 demos recorded on "thirdperson" belong to a map published as "teamrun-thirdperson". A lookup by the name a demo carries misses those entirely, and they came back as "not on Worldspawn" when they are very much there.

A miss now falls back to Worldspawn's search. Because that matches substrings - "q3dm6" returns twenty maps - the result is only taken when exactly one hit carries the name looked for; anything less certain is left alone. Such a map is reported and listed in storage/logs/maps-found-by-search.txt but NOT imported unless --via-search says so, because the row has to be stored under the name the demos use for them to find it, and quietly assuming two differently named maps are the same is not something to do a thousand times unattended.

--only takes specific map names, so an odd one out can be dealt with deliberately rather than by loosening the rule for everything.

Verified locally: 'thirdperson' resolves to teamrun-thirdperson and imports with the name the demos use, the real pk3 to download, weapons, items, functions and a 52 kB levelshot; a search for 'q3dm6' is correctly refused as ambiguous. Test row removed afterwards.