### PR TITLE
Store an empty pk3 for stock maps, not null

### DIFF
--- a/app/Console/Commands/ImportMissingMaps.php
+++ b/app/Console/Commands/ImportMissingMaps.php
@@ -232,9 +232,11 @@ class ImportMissingMaps extends Command
         // size of the whole game, which is a statement of where the map comes
         // from rather than a file anyone can fetch. Left in, the download button
         // would point at dl.defrag.racing for a pk3 that was never there.
+        // Empty rather than null: the column does not take null, and the
+        // download button hides on either.
         if (stripos((string) ($details['pk3'] ?? ''), 'quake iii') !== false) {
-            $details['pk3'] = null;
-            $details['pk3_size'] = null;
+            $details['pk3'] = '';
+            $details['pk3_size'] = 0;
         }
 
         $map = new Map();


### PR DESCRIPTION
The column does not take null, so blanking the pk3 of a map that ships with the game - which was right, since "Quake III: Arena.pk3" is a statement of origin and not a file anyone can download - failed the insert on the very first map and ended the import before it had added anything.

Empty string and zero instead. The download button hides on either, since it tests the value rather than comparing it to null.

Verified by importing q3dm17 (stock, empty pk3) and lick_fs-2b (real pk3, 1 MB) together; both rows complete with levelshots, then removed.