### PR TITLE
Say why a map has no download instead of hiding the button

### DIFF
--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -15,6 +15,17 @@ class Map extends Model
     use HasFactory;
     use Searchable;
 
+    /**
+     * Sent with every map so the download button knows which of the two
+     * reasons for having no pk3 applies - see App\Support\StockMaps.
+     */
+    protected $appends = ['is_stock'];
+
+    public function getIsStockAttribute(): bool
+    {
+        return \App\Support\StockMaps::has($this->name);
+    }
+
     protected static function boot()
     {
         parent::boot();

--- a/app/Support/StockMaps.php
+++ b/app/Support/StockMaps.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * The maps that come with Quake III Arena itself.
+ *
+ * Read off the .bsp files in pak0 through pak8 of a stock install - pak0 holds
+ * the game's own maps, pak2 adds q3tourney6_ctf, and pak6 the four pro- recuts
+ * from the 1.32 point release. Fixed since 2001, so a list rather than
+ * something to detect at runtime.
+ *
+ * These have no pk3 of their own to offer: Worldspawn describes them as
+ * "Quake III: Arena.pk3" at the size of the whole game, which says where the
+ * map comes from rather than naming a file anyone can download. Telling them
+ * apart from a map that is simply lost matters, because the two deserve very
+ * different things said about them.
+ */
+class StockMaps
+{
+    public const NAMES = [
+        'pro-q3dm13', 'pro-q3dm6', 'pro-q3tourney2', 'pro-q3tourney4',
+        'q3ctf1', 'q3ctf2', 'q3ctf3', 'q3ctf4',
+        'q3dm0', 'q3dm1', 'q3dm2', 'q3dm3', 'q3dm4', 'q3dm5', 'q3dm6', 'q3dm7',
+        'q3dm8', 'q3dm9', 'q3dm10', 'q3dm11', 'q3dm12', 'q3dm13', 'q3dm14',
+        'q3dm15', 'q3dm16', 'q3dm17', 'q3dm18', 'q3dm19',
+        'q3tourney1', 'q3tourney2', 'q3tourney3', 'q3tourney4', 'q3tourney5',
+        'q3tourney6', 'q3tourney6_ctf',
+        'test_bigbox',
+    ];
+
+    public static function has(?string $name): bool
+    {
+        return $name !== null && in_array(mb_strtolower($name), self::NAMES, true);
+    }
+}

--- a/resources/js/Components/MapCardLine.vue
+++ b/resources/js/Components/MapCardLine.vue
@@ -153,7 +153,19 @@
                     <div v-for="func in functionsList" :title="func" :class="`sprite-items sprite-${func} w-5 h-5 mr-1 flex-shrink-0 mb-1`"></div>
                 </div>
     
-                <a target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
+                <!-- A map with no pk3 is either one of the maps Quake III ships
+                     with, which has nothing to download, or one whose file we
+                     could not find anywhere and would like back. -->
+                <div v-if="!map?.pk3 && map?.is_stock" class="flex justify-center text-gray-500 bg-blackop-50 py-1 px-2 rounded-md text-sm">
+                    Comes with Quake III Arena
+                </div>
+
+                <div v-else-if="!map?.pk3" class="text-gray-500 bg-blackop-50 py-1 px-2 rounded-md text-sm text-center">
+                    This map's pk3 could not be found anywhere.<br>
+                    If you have it, send it to <span class="text-gray-400">neyo</span> and it will be added.
+                </div>
+
+                <a v-else target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
                     <div class="flex justify-center text-gray-400 bg-blackop-50 hover:bg-blackop-80 py-1 px-2 rounded-md cursor-pointer" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" />

--- a/resources/js/Components/MapCardLineSmall.vue
+++ b/resources/js/Components/MapCardLineSmall.vue
@@ -118,9 +118,19 @@
                     <div v-for="func in functionsList" :title="func" :class="`sprite-items sprite-${func} w-5 h-5 mr-1 flex-shrink-0 mb-1`"></div>
                 </div>
     
-                <!-- No pk3 means the map ships with the game, so there is
-                     nothing to download. -->
-                <a v-if="map?.pk3" target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
+                <!-- Same two cases as MapCardLine: a map that ships with the
+                     game has nothing to download, a map with no pk3 anywhere is
+                     one we would like back. -->
+                <div v-if="!map?.pk3 && map?.is_stock" class="flex justify-center text-gray-500 bg-blackop-50 py-1 px-2 rounded-md text-sm">
+                    Comes with Quake III Arena
+                </div>
+
+                <div v-else-if="!map?.pk3" class="text-gray-500 bg-blackop-50 py-1 px-2 rounded-md text-sm text-center">
+                    This map's pk3 could not be found anywhere.<br>
+                    If you have it, send it to <span class="text-gray-400">neyo</span> and it will be added.
+                </div>
+
+                <a v-else target="_blank" :href="'https://dl.defrag.racing/downloads/maps/' + encodeURIComponent(map?.pk3?.split('/').pop() ?? '')">
                     <div class="flex justify-center text-gray-400 bg-blackop-50 hover:bg-blackop-80 py-1 px-2 rounded-md cursor-pointer" title="Download">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" />


### PR DESCRIPTION
A map with no pk3 is one of two very different things, and the map page said nothing about either. Either it is one of the 36 maps Quake III ships with - Worldspawn describes those as "Quake III: Arena.pk3" at the size of the whole game, which names an origin rather than a file - or it is a map whose pk3 we could not find anywhere, which is worth asking about rather than passing over in silence.

App\Support\StockMaps is the list, read off pak0, pak2 and pak6 of a stock install and unchanged since 2001, so a list rather than runtime detection. The Map model appends is_stock, and the detail card now shows "Comes with Quake III Arena" for those, and for the rest that the pk3 could not be found anywhere and to send it to neyo if you have it. A map with a pk3 keeps its download button untouched.

Both the wide and the narrow detail card carry it, since the map page swaps between them by screen size. The grid tiles in the map list keep hiding the button - there is no room there for a sentence, and the detail page is one click away.

Checked that the list matches case-insensitively: Q3DM6 resolves as stock, lick_fs-2b and thirdperson do not.