### PR TITLE
Never guess which of two players with the same nick was watched

### DIFF
--- a/app/Services/DefragliveWatchService.php
+++ b/app/Services/DefragliveWatchService.php
@@ -212,13 +212,18 @@ class DefragliveWatchService
             }
         }
 
-        // 2) Clean-name match against the live player map.
-        if (! $mddId && $clean !== '') {
-            $op = OnlinePlayer::whereNotNull('mdd_id')
+        // 2) Clean-name match against the live player map, and only when the
+        //    whole map answers with one account. Nicks are not unique - two
+        //    people playing as "kali" at the same time is not hypothetical -
+        //    and the second-best guess is somebody else's watch time.
+        if (! $mddId && $clean !== '' && ! $this->isDefaultName($clean)) {
+            $live = OnlinePlayer::whereNotNull('mdd_id')
                 ->get(['name', 'mdd_id'])
-                ->first(fn ($p) => $this->cleanName((string) $p->name) === $clean);
-            if ($op && $op->mdd_id) {
-                $mddId = (int) $op->mdd_id;
+                ->filter(fn ($p) => $this->cleanName((string) $p->name) === $clean)
+                ->pluck('mdd_id')
+                ->unique();
+            if ($live->count() === 1) {
+                $mddId = (int) $live->first();
             }
         }
 
@@ -517,18 +522,42 @@ class DefragliveWatchService
      * is stored with no id at all, and then counts as a separate contestant with
      * their own row. Reading the answer back off the sessions that did resolve
      * repairs the rest without asking anything else.
+     *
+     * Only a nick the game has answered the same way every time is used. Twelve
+     * of the nicks watched so far have been reported as two different accounts -
+     * two people really do play as "kali" - and there is no way to tell which of
+     * them the unresolved session belongs to, so it stays its own contestant.
+     * The engine default is skipped outright: nearly two hundred accounts have
+     * been seen as UnnamedPlayer, so it identifies nobody.
      */
     private function mddByCleanName($rows): array
     {
-        $known = [];
+        $seen = [];
 
         foreach ($rows as $r) {
-            if ($r->mdd_id && $r->player_name_clean) {
-                $known[$r->player_name_clean] = (int) $r->mdd_id;
+            if ($r->mdd_id && $r->player_name_clean && ! $this->isDefaultName($r->player_name_clean)) {
+                $seen[$r->player_name_clean][(int) $r->mdd_id] = true;
+            }
+        }
+
+        $known = [];
+
+        foreach ($seen as $clean => $accounts) {
+            if (count($accounts) === 1) {
+                $known[$clean] = (int) array_key_first($accounts);
             }
         }
 
         return $known;
+    }
+
+    /**
+     * A name the engine hands out rather than one a player chose, so it says
+     * nothing about who is behind it.
+     */
+    private function isDefaultName(string $clean): bool
+    {
+        return in_array($clean, ['unnamedplayer', 'player', 'unknownplayer'], true);
     }
 
     /**


### PR DESCRIPTION
Nicks are not unique, and the watch data says so: twelve of the 144 nicks spectated so far have been reported by the game as two different accounts, and nearly two hundred accounts have been seen as UnnamedPlayer. Both places that answer "who is this" from a nick took the first answer they found.

The live-list match now resolves only when every logged-in player carrying that nick is the same account, and the identity read back off earlier sessions only uses a nick the game has answered the same way every time. Anything else stays unresolved and counts as its own contestant, which is the honest reading. The engine's own default names identify nobody and are skipped outright.