### PR TITLE
Stop putting a demo download link in YouTube descriptions

### DIFF
--- a/app/Services/VideoMetadataService.php
+++ b/app/Services/VideoMetadataService.php
@@ -128,9 +128,10 @@ class VideoMetadataService
         }
 
         $desc .= "\n";
-        if ($video->demo_id) {
-            $desc .= "Demo download: https://defrag.racing/demos/{$video->demo_id}/download\n";
-        }
+        // No link to the demo file. A URL ending in /download next to an id is
+        // what a spam or malware post looks like to YouTube's classifier, and it
+        // started hiding these videos and putting the channel at risk. The map
+        // page below carries the same demo, one click further in.
         // Skip the map-page URL when the map name itself contains a blocked
         // term — surfacing the raw name as a clickable URL would defeat the
         // censoring above.


### PR DESCRIPTION
Every rendered video carried "Demo download: https://defrag.racing/demos/<id>/ download". A URL ending in /download next to a numeric id is what a spam or malware post looks like to YouTube's classifier, and it started hiding these videos and putting the channel at risk.

The line is gone. The map page stays and carries the same demo one click further in, so nothing is actually lost.

This fixes what is generated from now on. The 10027 videos already up were uploaded with the link in their description and only change when demome pushes metadata again.