### PR TITLE
Let the metadata backfill walk newest videos first

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -1127,8 +1127,16 @@ class DemomeController extends Controller
         $videos = RenderedVideo::where('status', 'completed')
             ->whereNotNull('youtube_video_id')
             ->whereNotNull('youtube_url')
-            ->where('id', '>', $lastId)
-            ->orderBy('id', 'asc')
+            // Newest first when before_id is given (0 = start at the newest).
+            // A backfill costs API quota per video and there are ten thousand
+            // of them, so it has to reach the ones people actually watch first;
+            // walking up from id 1 spends days on videos nobody opens.
+            ->when($request->has('before_id'), function ($query) use ($request) {
+                $beforeId = (int) $request->input('before_id');
+
+                return $query->when($beforeId > 0, fn ($q) => $q->where('id', '<', $beforeId))
+                    ->orderBy('id', 'desc');
+            }, fn ($query) => $query->where('id', '>', $lastId)->orderBy('id', 'asc'))
             ->limit($limit)
             ->get()
             ->map(function ($video) {


### PR DESCRIPTION
Rewriting the descriptions already on YouTube costs API quota per video and there are 10027 of them. Walking up from id 1, as the endpoint has always done, would spend its first days on videos from years ago that nobody opens, while the ones carrying the channel keep the download link that got them hidden.

before_id pages the same list downwards (0 starts at the newest). after_id is untouched, so the bot's own polling pass keeps its ascending walk and its stored position.