### PR TITLE
Open the notification instead of just ticking it off

### DIFF
--- a/app/Console/Commands/ScrapeMaps.php
+++ b/app/Console/Commands/ScrapeMaps.php
@@ -53,12 +53,12 @@ class ScrapeMaps extends Command
             }
         }
 
-        // One notification for the whole run, not one per map - Worldspawn
-        // publishes in bursts and the scrape above picks a burst up whole.
+        // One notification per map per recipient, so every one of them can name
+        // and link the map it is about.
         if ($inserted->isNotEmpty()) {
             $sent = app(NewMapNotifier::class)->notify($inserted);
 
-            $this->info("Notified {$sent} users about {$inserted->count()} new map(s)");
+            $this->info("Wrote {$sent} notification(s) for {$inserted->count()} new map(s)");
         }
     }
 

--- a/app/Services/NewMapNotifier.php
+++ b/app/Services/NewMapNotifier.php
@@ -9,20 +9,24 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
- * Tells everyone who wants to know that a map was released.
+ * Tells everyone who wants to know that a map was released - one notification
+ * per map, whatever the scrape run brought in.
  *
- * Worldspawn publishes in bursts - 55 maps landed on one day in July - and the
- * scraper picks a whole burst up in a single run, so a batch becomes ONE
- * notification listing it instead of one per map. That is the difference
- * between roughly one row per user every other day and someone coming back
- * from a holiday to two hundred unread lines.
+ * A run that found several maps used to fold them into a single summary row
+ * ("5 maps"), which could only point at the map list: it named at most three
+ * of them and none of them was clickable. A notification that cannot say which
+ * map it is about is not worth the line it takes up.
  */
 class NewMapNotifier
 {
     public const TYPE = 'new_map';
 
-    /** How many map names the summary spells out before it counts the rest. */
-    private const NAMES_IN_SUMMARY = 3;
+    /**
+     * Rows per INSERT. Worldspawn publishes in bursts - 55 maps landed on one
+     * day in July - and a burst is multiplied by every recipient, so the fan
+     * out has to be handed to the database in bounded pieces.
+     */
+    private const INSERT_CHUNK = 1000;
 
     /**
      * @param  Collection<int, Map>  $maps  The maps one scrape run inserted.
@@ -36,24 +40,32 @@ class NewMapNotifier
             return 0;
         }
 
-        $payload = $this->payload($maps);
+        $payloads = $maps->map(fn (Map $map) => $this->payload($map))->all();
         $now = now();
         $sent = 0;
 
-        // A plain insert rather than one Notification per user: the payload is
+        // A plain insert rather than one Notification per user: the payloads are
         // identical for everybody, and the announcement fan-out's
         // User::all()->each is already the slowest thing an admin can trigger.
         User::where('map_news', true)
             ->select('id')
             ->orderBy('id')
-            ->chunkById(500, function (Collection $users) use ($payload, $now, &$sent) {
-                $rows = $users->map(fn (User $user) => $payload + [
-                    'user_id' => $user->id,
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ])->all();
+            ->chunkById(500, function (Collection $users) use ($payloads, $now, &$sent) {
+                $rows = [];
 
-                DB::table('notifications')->insert($rows);
+                foreach ($users as $user) {
+                    foreach ($payloads as $payload) {
+                        $rows[] = $payload + [
+                            'user_id' => $user->id,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+                    }
+                }
+
+                foreach (array_chunk($rows, self::INSERT_CHUNK) as $chunk) {
+                    DB::table('notifications')->insert($chunk);
+                }
 
                 $sent += count($rows);
             });
@@ -62,41 +74,24 @@ class NewMapNotifier
     }
 
     /**
-     * The notification body, shared by every recipient. The frontend renders
-     * `before`, then `headline` as the link, then `after`.
+     * The notification body for one map, shared by every recipient. The
+     * frontend renders `before`, then `headline` as the link, then `after`.
      */
-    private function payload(Collection $maps): array
+    private function payload(Map $map): array
     {
-        $common = [
+        return [
             'read' => false,
             'type' => self::TYPE,
-            'image' => $maps->first()->thumbnail,
-        ];
-
-        if ($maps->count() === 1) {
-            $map = $maps->first();
-
-            return $common + [
-                // The label leads and the map name is the headline, so the
-                // header banner reads "New map: mapname" - it prints the
-                // headline and nothing else.
-                'before' => 'New map:',
-                'headline' => Str::limit($map->name, 200, ''),
-                'after' => $map->author ? Str::limit('by ' . $map->author, 200, '') : '',
-                'url' => '/maps/' . $map->name,
-            ];
-        }
-
-        $names = $maps->take(self::NAMES_IN_SUMMARY)->pluck('name')->implode(', ');
-        $rest = $maps->count() - self::NAMES_IN_SUMMARY;
-
-        return $common + [
-            'before' => 'New maps:',
-            'headline' => $maps->count() . ' maps',
-            'after' => Str::limit($rest > 0 ? $names . ' and ' . $rest . ' more' : $names, 200, ''),
-            // /maps is ordered by date_added DESC, so the front page of it is
-            // exactly the batch that was just announced.
-            'url' => '/maps',
+            'image' => $map->thumbnail,
+            // The label leads and the map name is the headline, so the header
+            // banner reads "New map: mapname" - it prints the headline and
+            // nothing else.
+            'before' => 'New map:',
+            'headline' => Str::limit($map->name, 200, ''),
+            'after' => $map->author ? Str::limit('by ' . $map->author, 200, '') : '',
+            // Encoded, because 33 maps carry a "#" in the name and an unescaped
+            // one turns the rest of the link into a fragment.
+            'url' => '/maps/' . rawurlencode($map->name),
         ];
     }
 }

--- a/resources/js/Layouts/MainLayout.vue
+++ b/resources/js/Layouts/MainLayout.vue
@@ -402,8 +402,22 @@
 
         // Mark as read via API, then navigate if requested
         axios.post(route('notifications.system.toggle', notification.id)).finally(() => {
-            if (navigate) {
+            if (!navigate) {
+                return;
+            }
+
+            // Straight to what the banner is about - the map, the announcement,
+            // the video. It used to drop the user on the notification list with
+            // the row highlighted, so the thing itself was still a click away
+            // and the banner for a new map led everywhere except to the map.
+            const url = notification.url;
+
+            if (!url) {
                 router.visit(route('notifications.system.index', { highlight: notification.id }));
+            } else if (/^https?:\/\//i.test(url)) {
+                window.open(url, '_blank', 'noopener');
+            } else {
+                router.visit(url);
             }
         });
     };

--- a/resources/js/Pages/NotificationsView.vue
+++ b/resources/js/Pages/NotificationsView.vue
@@ -112,6 +112,32 @@
         });
     };
 
+    // The whole row opens what the notification is about and marks it read on
+    // the way out. Reading one is the same gesture as acting on it, and the
+    // headline alone was a two-word target; the toggle keeps its own button so
+    // a row can still be flipped back without opening anything.
+    const markSystemRead = (notification) => {
+        if (!notification.read) {
+            toggleSystemNotificationRead(notification.id);
+        }
+    };
+
+    const openSystemNotification = (notification) => {
+        markSystemRead(notification);
+
+        if (!notification.url) {
+            return;
+        }
+
+        // render_completed points at YouTube, everything else at one of our
+        // own pages.
+        if (/^https?:\/\//i.test(notification.url)) {
+            window.open(notification.url, '_blank', 'noopener');
+        } else {
+            router.visit(notification.url);
+        }
+    };
+
     const markAllSystemAsRead = () => {
         axios.post(route('notifications.system.clear')).then(() => {
             props.systemNotificationsPage.data.forEach(n => n.read = true);
@@ -482,11 +508,14 @@
 
                                 <!-- Read/Unread Toggle -->
                                 <button @click.stop="toggleNotificationRead(notification.id)" class="shrink-0 p-1 rounded hover:bg-white/5 transition-all" :title="notification.read ? 'Mark as unread' : 'Mark as read'">
-                                    <svg v-if="!notification.read" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-green-400">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                                    <!-- A sealed envelope is unread and asks to be opened; an opened one
+                                         is read. The old check mark read as "approve" and the crossed-out
+                                         bell as "mute", neither of which is what this button does. -->
+                                    <svg v-if="!notification.read" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-blue-400">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
                                     </svg>
-                                    <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-yellow-400">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
+                                    <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-gray-500">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 9v.906a2.25 2.25 0 0 1-1.183 1.981l-6.478 3.488M2.25 9v.906a2.25 2.25 0 0 0 1.183 1.981l6.478 3.488m8.839 2.51-4.66-2.51m0 0-1.023-.55a2.25 2.25 0 0 0-2.134 0l-1.022.55m0 0-4.661 2.51m16.5 1.615a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V8.844a2.25 2.25 0 0 1 1.183-1.981l7.5-4.039a2.25 2.25 0 0 1 2.134 0l7.5 4.039a2.25 2.25 0 0 1 1.183 1.98V19.5Z" />
                                     </svg>
                                 </button>
                             </div>
@@ -671,7 +700,7 @@
 
                     <!-- Filtered Notifications -->
                     <div class="divide-y divide-white/5">
-                        <div v-for="notification in filteredSystemNotifications" :key="notification.id" :id="'notification-' + notification.id" @click="toggleSystemNotificationRead(notification.id)" class="group px-2 py-1 hover:bg-white/10 hover:!opacity-100 transition-all cursor-pointer" :class="{'opacity-40': notification.read && highlightId !== notification.id, 'ring-2 ring-blue-500/50 bg-blue-500/10 rounded-lg': highlightId === notification.id}">
+                        <div v-for="notification in filteredSystemNotifications" :key="notification.id" :id="'notification-' + notification.id" @click="openSystemNotification(notification)" class="group px-2 py-1 hover:bg-white/10 hover:!opacity-100 transition-all cursor-pointer" :class="{'opacity-40': notification.read && highlightId !== notification.id, 'ring-2 ring-blue-500/50 bg-blue-500/10 rounded-lg': highlightId === notification.id}">
                             <div class="flex items-center gap-2">
                                 <!-- Icon -->
                                 <div class="shrink-0">
@@ -686,11 +715,11 @@
                                 <div class="flex-1 min-w-0 text-sm text-gray-300">
                                     <template v-if="notification.type === 'announcement'">
                                         <span class="text-gray-400">Announcement:</span>
-                                        <Link @click.stop class="ml-1.5 text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
+                                        <span class="ml-1.5 text-blue-400 group-hover:text-blue-300 group-hover:underline font-bold transition-colors" v-html="q3tohtml(notification.headline)"></span>
                                     </template>
                                     <template v-else-if="notification.type === 'render_completed'">
                                         <span class="text-gray-400">Render:</span>
-                                        <Link v-if="notification.subheadline" @click.stop class="ml-1.5 inline-flex items-center gap-1 align-middle text-emerald-300 hover:text-emerald-200 hover:underline font-bold transition-colors" :href="notification.subheadline">
+                                        <Link v-if="notification.subheadline" @click.stop="markSystemRead(notification)" class="ml-1.5 inline-flex items-center gap-1 align-middle text-emerald-300 hover:text-emerald-200 hover:underline font-bold transition-colors" :href="notification.subheadline">
                                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 shrink-0">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z" />
                                             </svg>
@@ -698,7 +727,7 @@
                                         </Link>
                                         <span v-else class="ml-1.5" v-html="q3tohtml(notification.before)"></span>
                                         <span class="mx-1.5 text-gray-500">-</span>
-                                        <a @click.stop class="inline-flex items-center gap-1 align-middle text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" target="_blank" rel="noopener noreferrer">
+                                        <a @click.stop="markSystemRead(notification)" class="inline-flex items-center gap-1 align-middle text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" target="_blank" rel="noopener noreferrer">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4 shrink-0 text-red-500">
                                                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
                                             </svg>
@@ -708,10 +737,10 @@
                                     <template v-else>
                                         <span v-if="getNotificationPrefix(notification.type)" class="text-gray-400 mr-1.5">{{ getNotificationPrefix(notification.type) }}</span>
                                         <span v-if="notification.before" class="text-gray-400" v-html="q3tohtml(notification.before)"></span>
-                                        <Link @click.stop class="mx-1.5 text-blue-400 hover:text-blue-300 hover:underline font-bold transition-colors" :href="notification.url" v-html="q3tohtml(notification.headline)"></Link>
+                                        <span class="mx-1.5 text-blue-400 group-hover:text-blue-300 group-hover:underline font-bold transition-colors" v-html="q3tohtml(notification.headline)"></span>
                                         <span v-if="notification.after" class="text-gray-400" v-html="q3tohtml(notification.after)"></span>
                                         <template v-if="notification.type === 'alias_suggestion'">
-                                            <Link @click.stop class="ml-1.5 inline-flex items-center gap-1 align-middle text-yellow-400 hover:text-yellow-300 hover:underline transition-colors" :href="notification.url">
+                                            <Link @click.stop="markSystemRead(notification)" class="ml-1.5 inline-flex items-center gap-1 align-middle text-yellow-400 hover:text-yellow-300 hover:underline transition-colors" :href="notification.url">
                                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 shrink-0">
                                                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                                                 </svg>
@@ -723,11 +752,14 @@
 
                                 <!-- Read/Unread Toggle -->
                                 <button @click.stop="toggleSystemNotificationRead(notification.id)" class="shrink-0 p-1 rounded hover:bg-white/5 transition-all" :title="notification.read ? 'Mark as unread' : 'Mark as read'">
-                                    <svg v-if="!notification.read" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-green-400">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                                    <!-- A sealed envelope is unread and asks to be opened; an opened one
+                                         is read. The old check mark read as "approve" and the crossed-out
+                                         bell as "mute", neither of which is what this button does. -->
+                                    <svg v-if="!notification.read" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-blue-400">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
                                     </svg>
-                                    <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-yellow-400">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a24.248 24.248 0 0 0 3.844.148m-3.844-.148a23.856 23.856 0 0 1-5.455-1.31 8.964 8.964 0 0 0 2.3-5.542m3.155 6.852a3 3 0 0 0 5.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 0 0 3.536-1.003A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
+                                    <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-gray-500">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 9v.906a2.25 2.25 0 0 1-1.183 1.981l-6.478 3.488M2.25 9v.906a2.25 2.25 0 0 0 1.183 1.981l6.478 3.488m8.839 2.51-4.66-2.51m0 0-1.023-.55a2.25 2.25 0 0 0-2.134 0l-1.022.55m0 0-4.661 2.51m16.5 1.615a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V8.844a2.25 2.25 0 0 1 1.183-1.981l7.5-4.039a2.25 2.25 0 0 1 2.134 0l7.5 4.039a2.25 2.25 0 0 1 1.183 1.98V19.5Z" />
                                     </svg>
                                 </button>
                             </div>


### PR DESCRIPTION
Clicking a system notification row toggled read and nothing else. The only thing that went anywhere was the headline, a two-word target with a click handler that stopped the row's, so the usual outcome of aiming at an announcement was marking it read. The whole row is the link now and it marks itself read on the way out; the toggle keeps its own button, so a row can still be flipped back without opening anything. The chips that lead somewhere else - the demo behind a render, approve/reject on an alias - mark it read too and keep their own target.

The header banner had the same hole, and worse: it dropped the user on the notification list with the row highlighted, so whatever it announced was still a click away. A new map announced there led everywhere except to the map. It goes to the notification's own url now, external ones in a new tab, and falls back to the list only when there is nothing to open.

Read state was drawn as a check mark for unread and a crossed-out bell for read, which read as approve and mute. It is a sealed and an opened envelope.

New maps are one notification each. A run that found several folded them into a summary row that could only point at the map list: it spelled out three names, the rest was "and 6 more", and none of them was clickable. Worldspawn publishes in bursts, so the fan-out is now a burst times every recipient and the insert is chunked to match - 5 maps across 762 recipients is 3810 rows in 100ms. Map names go through rawurlencode, because 33 of them carry a "#" and an unescaped one turns the rest of the link into a fragment.