### PR TITLE
Let a donated contest prize go straight into the comps pool

### DIFF
--- a/app/Filament/Resources/DefragliveContestResource.php
+++ b/app/Filament/Resources/DefragliveContestResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\DefragliveContestResource\Pages;
 use App\Models\DefragliveContest;
+use App\Services\Comps\PrizeFunding;
 use App\Services\DefragliveWatchService;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -168,7 +169,67 @@ class DefragliveContestResource extends Resource
                             ->label('Create a site donation record in the winner\'s name')
                             ->helperText('Shows up immediately in the site donations progress as approved.')
                             ->default(true)
+                            ->live()
                             ->visible(fn (Forms\Get $get) => $get('resolution') === DefragliveContest::STATUS_DONATED),
+
+                        // A winner who gives the prize back does not always
+                        // mean "put it towards the hosting bill" - most of them
+                        // say comps. That used to mean creating the donation
+                        // here and then opening it in the donations resource to
+                        // fill in three more columns by hand, which is exactly
+                        // the kind of second step that gets forgotten.
+                        Forms\Components\Radio::make('donation_target')
+                            ->label('Where does it go?')
+                            ->options([
+                                'site' => 'Site upkeep',
+                                'comps' => 'Comps prize pool',
+                            ])
+                            ->descriptions([
+                                'comps' => 'Earmarked for comps, so it funds a weekly prize instead of counting towards the hosting goal.',
+                            ])
+                            ->default('site')
+                            ->required()
+                            ->live()
+                            ->visible(fn (Forms\Get $get) => $get('resolution') === DefragliveContest::STATUS_DONATED
+                                && $get('create_donation')),
+
+                        Forms\Components\TextInput::make('comps_start_comp')
+                            ->label('Funds weekly number')
+                            ->numeric()
+                            ->minValue(1)
+                            ->required()
+                            // The first weekly nothing else pays for. Pointing
+                            // it at a week that is already funded would stack
+                            // on top of that week rather than extend the pool.
+                            ->default(fn () => app(PrizeFunding::class)->nextFundableComp())
+                            ->helperText(fn () => 'The pool is currently paid up through weekly '
+                                . (app(PrizeFunding::class)->fundedThroughComp() ?? 'nothing') . '.')
+                            ->visible(fn (Forms\Get $get) => $get('resolution') === DefragliveContest::STATUS_DONATED
+                                && $get('create_donation')
+                                && $get('donation_target') === 'comps'),
+
+                        Forms\Components\TextInput::make('comps_weeks')
+                            ->label('Spread over how many weeklies')
+                            ->numeric()
+                            ->minValue(1)
+                            ->default(1)
+                            ->required()
+                            ->visible(fn (Forms\Get $get) => $get('resolution') === DefragliveContest::STATUS_DONATED
+                                && $get('create_donation')
+                                && $get('donation_target') === 'comps'),
+
+                        // The comps pool has no currency logic at all: it sums
+                        // the earmarked column as euro. Worth saying out loud
+                        // rather than converting behind the admin's back.
+                        Forms\Components\Placeholder::make('currency_warning')
+                            ->hiddenLabel()
+                            ->content(fn (DefragliveContest $record) => 'The comps pool is counted in EUR, but this prize is in '
+                                . $record->prize_currency . '. It will be added to the pool as '
+                                . $record->prize_amount . ' EUR.')
+                            ->visible(fn (Forms\Get $get, DefragliveContest $record) => $record->prize_currency !== 'EUR'
+                                && $get('resolution') === DefragliveContest::STATUS_DONATED
+                                && $get('create_donation')
+                                && $get('donation_target') === 'comps'),
                     ])
                     ->visible(fn (DefragliveContest $r) => $r->winner_name !== null
                         && ! in_array($r->status, DefragliveContest::RESOLVED_STATUSES, true))
@@ -184,6 +245,9 @@ class DefragliveContestResource extends Resource
 
                                 return;
                             }
+                            $toComps = ($data['donation_target'] ?? 'site') === 'comps';
+                            $contestUrl = url('/defraglive/contest');
+
                             // Credit the prize back as a real site donation so it
                             // shows up in the donations progress right away.
                             // donor_email matters: isDonor()/getDonationTotal()
@@ -198,11 +262,32 @@ class DefragliveContestResource extends Resource
                                 'currency' => $record->prize_currency,
                                 'donation_date' => now()->toDateString(),
                                 'note' => "DefragLive contest prize donated back ({$record->title}) - "
-                                    . url('/defraglive/contest'),
+                                    . $contestUrl,
                                 'status' => 'approved',
+                                // The earmark. Left null for an ordinary
+                                // donation, because PrizeFunding only counts
+                                // rows where all three are filled in - a
+                                // half-filled one would sit in neither pot.
+                                'comps_amount' => $toComps ? $record->prize_amount : null,
+                                'comps_weeks' => $toComps ? (int) $data['comps_weeks'] : null,
+                                'comps_start_comp' => $toComps ? (int) $data['comps_start_comp'] : null,
+                                // Public, printed under the donor's name on the
+                                // comps page. The URL is written into the
+                                // sentence rather than stored beside it; the
+                                // page pulls it back out and makes the note
+                                // itself the link.
+                                'comps_note' => $toComps
+                                    ? 'Donated winnings from the DefragLive contest - ' . $contestUrl
+                                    : null,
                             ]);
+
+                            $where = $toComps
+                                ? "the comps prize pool, funding weekly {$data['comps_start_comp']}"
+                                    . ((int) $data['comps_weeks'] > 1 ? " for {$data['comps_weeks']} weeklies" : '')
+                                : 'the site upkeep';
+
                             Notification::make()->title('Marked as donated')
-                                ->body("Site donation of {$record->prize_amount} {$record->prize_currency} recorded for {$plainWinner}.")
+                                ->body("Site donation of {$record->prize_amount} {$record->prize_currency} recorded for {$plainWinner}, towards {$where}.")
                                 ->success()->send();
 
                             return;

--- a/app/Services/Comps/PrizeFunding.php
+++ b/app/Services/Comps/PrizeFunding.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Comps;
 
+use App\Models\Comp;
 use App\Models\CompRound;
 use App\Models\SiteDonation;
 use Illuminate\Support\Collection;
@@ -99,7 +100,8 @@ class PrizeFunding
                 'per_physics' => $d->compsPerPhysics(),
                 'from_comp' => (int) $d->comps_start_comp,
                 'to_comp' => $d->compsEndComp(),
-                'note' => $d->comps_note,
+                'note' => $this->noteText($d->comps_note),
+                'note_url' => $this->noteUrl($d->comps_note),
             ])
             ->all();
     }
@@ -141,6 +143,61 @@ class PrizeFunding
         $ends = $this->all()->map(fn (SiteDonation $d) => $d->compsEndComp())->filter();
 
         return $ends->isEmpty() ? null : (int) $ends->max();
+    }
+
+    /**
+     * The earliest weekly a donation made right now could still pay for.
+     *
+     * Normally that is simply the week after the pool runs out: funding is
+     * paid up through weekly 15, so the next euro goes on 16. Two things stop
+     * that being the whole answer. Funding that lapsed years ago would send
+     * the money to a week already played, so it never goes earlier than the
+     * first round that has not started - a round that has started keeps the
+     * figure its players were told. And with nothing funded at all there is no
+     * "after", so it falls through to the first weekly still to be created.
+     */
+    public function nextFundableComp(): int
+    {
+        $firstOpen = CompRound::query()
+            ->whereHas('comp', fn ($q) => $q->weekly())
+            ->where('starts_at', '>', now())
+            ->with('comp:id,number')
+            ->orderBy('starts_at')
+            ->first()?->comp?->number;
+
+        $earliest = (int) ($firstOpen ?? ((int) Comp::weekly()->max('number') + 1));
+
+        return max($earliest, (int) $this->fundedThroughComp() + 1);
+    }
+
+    /**
+     * A link written into a comps note, so the page can make the note itself
+     * clickable.
+     *
+     * Notes are free text and there is no column for a URL, which is fine:
+     * somebody explaining where money came from writes the link into the
+     * sentence anyway. Only http(s) is picked up - a note is admin-entered but
+     * it is rendered into an anchor on a public page.
+     */
+    private function noteUrl(?string $note): ?string
+    {
+        if (! $note || ! preg_match('~https?://\S+~i', $note, $m)) {
+            return null;
+        }
+
+        return rtrim($m[0], '.,;)');
+    }
+
+    /** The same note with the URL taken back out, and no dangling separator. */
+    private function noteText(?string $note): ?string
+    {
+        if (! $note) {
+            return null;
+        }
+
+        $text = trim((string) preg_replace('~https?://\S+~i', '', $note));
+
+        return trim((string) preg_replace('/\s*[-:]\s*$/', '', $text)) ?: null;
     }
 
     /**

--- a/resources/js/Components/Comps/CompsDonors.vue
+++ b/resources/js/Components/Comps/CompsDonors.vue
@@ -52,7 +52,16 @@
                         {{ $t('over :count weeklies (:from-:to)', { count: d.weeks, from: d.from_comp, to: d.to_comp }) }}
                     </span>
                 </div>
-                <p v-if="d.note" class="mt-1 text-xs text-emerald-100/70 italic leading-snug">{{ d.note }}</p>
+                <!-- A note with a link in it becomes the link. Money that came
+                     from somewhere else - a contest prize handed back, say -
+                     is worth being able to click through to, and there is no
+                     column for a URL: it is written into the sentence and the
+                     server pulls it back out. -->
+                <p v-if="d.note" class="mt-1 text-xs text-emerald-100/70 italic leading-snug">
+                    <a v-if="d.note_url" :href="d.note_url"
+                       class="underline decoration-emerald-100/30 hover:text-emerald-100">{{ d.note }}</a>
+                    <template v-else>{{ d.note }}</template>
+                </p>
             </li>
         </ul>
 


### PR DESCRIPTION
A winner handing the prize back rarely means "put it towards the hosting bill" - they say comps. Resolving one already created a real site donation in their name, but only ever an ordinary one: the three comps columns stayed empty, so PrizeFunding never saw it and the money had to be earmarked by hand in the donations resource afterwards. That second step is exactly the kind that gets forgotten, and a prize sitting in the wrong pot looks like a promise quietly dropped.

So the dialog now asks where it goes, and fills the earmark itself. The weekly it funds defaults to the first one nothing else pays for: paid up through 15 means it lands on 16. That is not simply the last funded week plus one - funding that lapsed would send the money to a week already played, so it never goes earlier than the first round that has not started, because a round that has started keeps the figure its players were told.

The note it writes is public and names where the money came from, with a link back to the contest. There is no column for a URL and this did not seem worth a migration, so the link is written into the sentence and PrizeFunding pulls it back out; the comps page then makes the note itself the anchor. Any note with an http(s) link in it now behaves that way.

The comps pool has no currency logic at all - it sums the earmarked column as euro - so a prize in anything but EUR says so in the dialog rather than being converted behind the admin's back.