### PR TITLE
Say that voting has closed, and when the round actually starts

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Mapy na příští týden jsou rozhodnuté",
     "Next week's vote will be :category": "Příští týden se bude hlasovat o kategorii :category",
     "your timezone": "tvoje časové pásmo",
-    "Playing for": "Hraje se o"
+    "Playing for": "Hraje se o",
+    "Starts in": "Začíná za",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Hlasování skončilo. Tohle jsou mapy na příští týden a kolo začne, až doběhne odpočet.",
+    "Playing next week": "Příští týden se hraje",
+    "Final votes": "Konečné hlasy"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Die Karten für nächste Woche stehen fest",
     "Next week's vote will be :category": "Nächste Woche wird über :category abgestimmt",
     "your timezone": "deine Zeitzone",
-    "Playing for": "Es geht um"
+    "Playing for": "Es geht um",
+    "Starts in": "Startet in",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Die Abstimmung ist vorbei. Das sind die Karten für nächste Woche, und die Runde startet, wenn der Countdown abläuft.",
+    "Playing next week": "Nächste Woche gespielt",
+    "Final votes": "Endergebnis der Abstimmung"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Los mapas de la próxima semana están decididos",
     "Next week's vote will be :category": "La próxima semana se votará :category",
     "your timezone": "tu zona horaria",
-    "Playing for": "Se juega por"
+    "Playing for": "Se juega por",
+    "Starts in": "Empieza en",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "La votación ha terminado. Estos son los mapas de la próxima semana, y la ronda empieza cuando acabe la cuenta atrás.",
+    "Playing next week": "Se juega la próxima semana",
+    "Final votes": "Votos finales"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Les maps de la semaine prochaine sont décidées",
     "Next week's vote will be :category": "La semaine prochaine, le vote portera sur :category",
     "your timezone": "ton fuseau horaire",
-    "Playing for": "On joue pour"
+    "Playing for": "On joue pour",
+    "Starts in": "Démarre dans",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Le vote est terminé. Voici les maps de la semaine prochaine, et le tour démarre à la fin du compte à rebours.",
+    "Playing next week": "Au programme la semaine prochaine",
+    "Final votes": "Votes finaux"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "De maps voor volgende week liggen vast",
     "Next week's vote will be :category": "Volgende week wordt er gestemd over :category",
     "your timezone": "jouw tijdzone",
-    "Playing for": "Gespeeld om"
+    "Playing for": "Gespeeld om",
+    "Starts in": "Begint over",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "De stemming is voorbij. Dit zijn de maps voor volgende week, en de ronde begint als de aftelklok afloopt.",
+    "Playing next week": "Volgende week gespeeld",
+    "Final votes": "Eindstand van de stemming"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Mapy na przyszły tydzień są wybrane",
     "Next week's vote will be :category": "W przyszłym tygodniu głosowanie będzie o kategorii :category",
     "your timezone": "twoja strefa czasowa",
-    "Playing for": "Gra się o"
+    "Playing for": "Gra się o",
+    "Starts in": "Zaczyna się za",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Głosowanie się skończyło. To są mapy na przyszły tydzień, a runda zacznie się, gdy odliczanie dobiegnie końca.",
+    "Playing next week": "W przyszłym tygodniu gramy",
+    "Final votes": "Ostateczne głosy"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Карты на следующую неделю определены",
     "Next week's vote will be :category": "На следующей неделе голосование будет за :category",
     "your timezone": "твой часовой пояс",
-    "Playing for": "Разыгрывается"
+    "Playing for": "Разыгрывается",
+    "Starts in": "Начнётся через",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Голосование завершено. Это карты на следующую неделю, и раунд начнётся, когда истечёт обратный отсчёт.",
+    "Playing next week": "На следующей неделе играем",
+    "Final votes": "Итоги голосования"
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Nästa veckas banor är bestämda",
     "Next week's vote will be :category": "Nästa vecka röstas det om :category",
     "your timezone": "din tidszon",
-    "Playing for": "Spelas om"
+    "Playing for": "Spelas om",
+    "Starts in": "Startar om",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Omröstningen är över. Det här är banorna för nästa vecka, och rundan startar när nedräkningen tar slut.",
+    "Playing next week": "Spelas nästa vecka",
+    "Final votes": "Slutgiltiga röster"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4204,5 +4204,9 @@
     "Next week's maps are decided": "Карти на наступний тиждень визначені",
     "Next week's vote will be :category": "Наступного тижня голосування буде за :category",
     "your timezone": "твій часовий пояс",
-    "Playing for": "Розігрується"
+    "Playing for": "Розігрується",
+    "Starts in": "Почнеться через",
+    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Голосування завершено. Це карти на наступний тиждень, і раунд почнеться, коли добіжить зворотний відлік.",
+    "Playing next week": "Наступного тижня граємо",
+    "Final votes": "Підсумки голосування"
 }

--- a/resources/js/Pages/Comps/Index.vue
+++ b/resources/js/Pages/Comps/Index.vue
@@ -650,7 +650,18 @@ export default {
                             <span class="text-[11px] tabular-nums text-emerald-100/50">{{ $t('(:amount EUR per physics)', { amount: voting.prize.eur }) }}</span>
                         </span>
 
-                        <CompsCountdown v-if="voting.is_open" :until="voting.closes_at" :label="$t('Voting closes in')" emphasis inline />
+                        <!-- Two different clocks, because this panel lives
+                             through two states and the gap between them is a
+                             whole day. While the ballot is open the deadline
+                             is what matters; once it has closed the only
+                             question left is when the thing actually starts,
+                             and a panel that answered neither was the most
+                             confusing screen on the site: voting visibly over,
+                             nothing saying so, and no date anywhere. -->
+                        <CompsCountdown v-if="voting.is_open"
+                                        :until="voting.closes_at" :label="$t('Voting closes in')" emphasis inline />
+                        <CompsCountdown v-else
+                                        :until="voting.starts_at" :label="$t('Starts in')" emphasis inline />
                     </div>
                 </div>
 
@@ -658,7 +669,8 @@ export default {
                      panel as a whole, and sitting above the grid it read as a
                      caption on the first row of maps. -->
                 <p class="mt-1.5 text-sm text-gray-400">
-                    {{ $t('CPM and VQ3 vote separately, so each physics gets the map its own players picked. You have one vote in each and can move it until the deadline.') }}
+                    <template v-if="voting.is_open">{{ $t('CPM and VQ3 vote separately, so each physics gets the map its own players picked. You have one vote in each and can move it until the deadline.') }}</template>
+                    <template v-else>{{ $t('Voting is over. These are the maps for next week, and the round starts when the countdown runs out.') }}</template>
                 </p>
             </div>
 
@@ -675,8 +687,13 @@ export default {
                 {{ errors.wildcard }}
             </div>
 
-            <!-- Once decided, say so and by what -->
-            <div v-if="!voting.is_open" class="mb-4 grid gap-3 sm:grid-cols-2">
+            <!-- Once decided, say so and by what. Given its own heading:
+                 with the ballot closed these two boxes are the answer people
+                 came for, and unlabelled they read as another pair of cards. -->
+            <div v-if="!voting.is_open" class="mb-1.5 text-[11px] font-black uppercase tracking-widest text-blue-300/70">
+                {{ $t('Playing next week') }}
+            </div>
+            <div v-if="!voting.is_open" class="mb-5 grid gap-3 sm:grid-cols-2">
                 <div
                     v-for="physics in PHYSICS"
                     :key="physics"
@@ -691,6 +708,13 @@ export default {
                         <template v-else>{{ $t('Chosen by vote') }}</template>
                     </div>
                 </div>
+            </div>
+
+            <!-- The ballot below is history once it has closed, so it says
+                 so rather than sitting there looking like it still takes
+                 clicks. -->
+            <div v-if="!voting.is_open" class="mb-1.5 text-[11px] font-black uppercase tracking-widest text-gray-500">
+                {{ $t('Final votes') }}
             </div>
 
             <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">


### PR DESCRIPTION
Between the ballot closing on Saturday and the round starting on Sunday there is a full day in which comps deliberately does nothing. The page had no idea: it kept the voting heading's explanation of how to vote, printed no clock at all, and left the ballot cards sitting there as though they still took clicks. Somebody looking at it could see the voting was over and find nothing on the page admitting it, let alone saying when the thing they had voted for would begin.

So the panel now carries the clock that matters in each state. While the ballot is open that is the deadline; once it has closed it is a countdown to the start, with the wall clock underneath as everywhere else. The sentence under the heading swaps too, from how voting works to the fact that it is finished.

The two decided maps get a heading of their own - with the ballot closed they are the answer people came for, and unlabelled they read as another pair of cards - and the ballot below them is marked as final votes rather than being left to look interactive.

Nothing about the scheduler changed. It was doing exactly what it was written to do; only the page was silent about it.