### PR TITLE
Name the round that is about to start, not what happened to the vote

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4201,12 +4201,12 @@
     "votes": "hlasů",
     "Choose a demo": "Vybrat demo",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Když něco nevypadá správně, napiš prosím <a href=:url>adminovi</a>.",
-    "Next week's maps are decided": "Mapy na příští týden jsou rozhodnuté",
     "Next week's vote will be :category": "Příští týden se bude hlasovat o kategorii :category",
     "your timezone": "tvoje časové pásmo",
     "Playing for": "Hraje se o",
     "Starts in": "Začíná za",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Hlasování skončilo. Tohle jsou mapy na příští týden a kolo začne, až doběhne odpočet.",
     "Playing next week": "Příští týden se hraje",
-    "Final votes": "Konečné hlasy"
+    "Final votes": "Konečné hlasy",
+    "Up next: :comp": "Na řadě je :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Hlasování skončilo. Tohle jsou mapy a kolo začne, až doběhne odpočet."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4201,12 +4201,12 @@
     "votes": "Stimmen",
     "Choose a demo": "Demo wählen",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Wenn etwas nicht stimmt, wende dich bitte an <a href=:url>den Admin</a>.",
-    "Next week's maps are decided": "Die Karten für nächste Woche stehen fest",
     "Next week's vote will be :category": "Nächste Woche wird über :category abgestimmt",
     "your timezone": "deine Zeitzone",
     "Playing for": "Es geht um",
     "Starts in": "Startet in",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Die Abstimmung ist vorbei. Das sind die Karten für nächste Woche, und die Runde startet, wenn der Countdown abläuft.",
     "Playing next week": "Nächste Woche gespielt",
-    "Final votes": "Endergebnis der Abstimmung"
+    "Final votes": "Endergebnis der Abstimmung",
+    "Up next: :comp": "Als Nächstes: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Die Abstimmung ist vorbei. Das sind die Karten, und die Runde startet, wenn der Countdown abläuft."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4201,12 +4201,12 @@
     "votes": "votos",
     "Choose a demo": "Elegir demo",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Si algo no cuadra, escribe al <a href=:url>admin</a>.",
-    "Next week's maps are decided": "Los mapas de la próxima semana están decididos",
     "Next week's vote will be :category": "La próxima semana se votará :category",
     "your timezone": "tu zona horaria",
     "Playing for": "Se juega por",
     "Starts in": "Empieza en",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "La votación ha terminado. Estos son los mapas de la próxima semana, y la ronda empieza cuando acabe la cuenta atrás.",
     "Playing next week": "Se juega la próxima semana",
-    "Final votes": "Votos finales"
+    "Final votes": "Votos finales",
+    "Up next: :comp": "A continuación: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "La votación ha terminado. Estos son los mapas, y la ronda empieza cuando acabe la cuenta atrás."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4201,12 +4201,12 @@
     "votes": "votes",
     "Choose a demo": "Choisir une démo",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Si quelque chose ne va pas, contacte <a href=:url>l'admin</a>.",
-    "Next week's maps are decided": "Les maps de la semaine prochaine sont décidées",
     "Next week's vote will be :category": "La semaine prochaine, le vote portera sur :category",
     "your timezone": "ton fuseau horaire",
     "Playing for": "On joue pour",
     "Starts in": "Démarre dans",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Le vote est terminé. Voici les maps de la semaine prochaine, et le tour démarre à la fin du compte à rebours.",
     "Playing next week": "Au programme la semaine prochaine",
-    "Final votes": "Votes finaux"
+    "Final votes": "Votes finaux",
+    "Up next: :comp": "À suivre : :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Le vote est terminé. Voici les maps, et le tour démarre à la fin du compte à rebours."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4201,12 +4201,12 @@
     "votes": "stemmen",
     "Choose a demo": "Kies een demo",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Klopt er iets niet, neem dan contact op met <a href=:url>de admin</a>.",
-    "Next week's maps are decided": "De maps voor volgende week liggen vast",
     "Next week's vote will be :category": "Volgende week wordt er gestemd over :category",
     "your timezone": "jouw tijdzone",
     "Playing for": "Gespeeld om",
     "Starts in": "Begint over",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "De stemming is voorbij. Dit zijn de maps voor volgende week, en de ronde begint als de aftelklok afloopt.",
     "Playing next week": "Volgende week gespeeld",
-    "Final votes": "Eindstand van de stemming"
+    "Final votes": "Eindstand van de stemming",
+    "Up next: :comp": "Hierna: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "De stemming is voorbij. Dit zijn de maps, en de ronde begint als de aftelklok afloopt."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4201,12 +4201,12 @@
     "votes": "głosów",
     "Choose a demo": "Wybierz demo",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Jeśli coś nie wygląda dobrze, napisz do <a href=:url>admina</a>.",
-    "Next week's maps are decided": "Mapy na przyszły tydzień są wybrane",
     "Next week's vote will be :category": "W przyszłym tygodniu głosowanie będzie o kategorii :category",
     "your timezone": "twoja strefa czasowa",
     "Playing for": "Gra się o",
     "Starts in": "Zaczyna się za",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Głosowanie się skończyło. To są mapy na przyszły tydzień, a runda zacznie się, gdy odliczanie dobiegnie końca.",
     "Playing next week": "W przyszłym tygodniu gramy",
-    "Final votes": "Ostateczne głosy"
+    "Final votes": "Ostateczne głosy",
+    "Up next: :comp": "Następnie: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Głosowanie się skończyło. To są mapy, a runda zacznie się, gdy odliczanie dobiegnie końca."
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4201,12 +4201,12 @@
     "votes": "голосов",
     "Choose a demo": "Выбрать демо",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Если что-то выглядит не так, напиши <a href=:url>админу</a>.",
-    "Next week's maps are decided": "Карты на следующую неделю определены",
     "Next week's vote will be :category": "На следующей неделе голосование будет за :category",
     "your timezone": "твой часовой пояс",
     "Playing for": "Разыгрывается",
     "Starts in": "Начнётся через",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Голосование завершено. Это карты на следующую неделю, и раунд начнётся, когда истечёт обратный отсчёт.",
     "Playing next week": "На следующей неделе играем",
-    "Final votes": "Итоги голосования"
+    "Final votes": "Итоги голосования",
+    "Up next: :comp": "Дальше: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосование завершено. Это карты, и раунд начнётся, когда истечёт обратный отсчёт."
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4201,12 +4201,12 @@
     "votes": "röster",
     "Choose a demo": "Välj demo",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Om något inte ser rätt ut, kontakta <a href=:url>adminen</a>.",
-    "Next week's maps are decided": "Nästa veckas banor är bestämda",
     "Next week's vote will be :category": "Nästa vecka röstas det om :category",
     "your timezone": "din tidszon",
     "Playing for": "Spelas om",
     "Starts in": "Startar om",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Omröstningen är över. Det här är banorna för nästa vecka, och rundan startar när nedräkningen tar slut.",
     "Playing next week": "Spelas nästa vecka",
-    "Final votes": "Slutgiltiga röster"
+    "Final votes": "Slutgiltiga röster",
+    "Up next: :comp": "Härnäst: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Omröstningen är över. Det här är banorna, och rundan startar när nedräkningen tar slut."
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4201,12 +4201,12 @@
     "votes": "голосів",
     "Choose a demo": "Обрати демо",
     "If something does not look right, please contact <a href=:url>admin</a>.": "Якщо щось виглядає не так, напиши <a href=:url>адміну</a>.",
-    "Next week's maps are decided": "Карти на наступний тиждень визначені",
     "Next week's vote will be :category": "Наступного тижня голосування буде за :category",
     "your timezone": "твій часовий пояс",
     "Playing for": "Розігрується",
     "Starts in": "Почнеться через",
-    "Voting is over. These are the maps for next week, and the round starts when the countdown runs out.": "Голосування завершено. Це карти на наступний тиждень, і раунд почнеться, коли добіжить зворотний відлік.",
     "Playing next week": "Наступного тижня граємо",
-    "Final votes": "Підсумки голосування"
+    "Final votes": "Підсумки голосування",
+    "Up next: :comp": "Далі: :comp",
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосування завершено. Це карти, і раунд почнеться, коли добіжить зворотний відлік."
 }

--- a/resources/js/Pages/Comps/Index.vue
+++ b/resources/js/Pages/Comps/Index.vue
@@ -618,8 +618,17 @@ export default {
             <div class="border-b border-blue-400/20 bg-gradient-to-r from-blue-500/[0.12] to-white/5 backdrop-blur-sm px-5 py-3">
                 <div class="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1.5">
                     <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 min-w-0">
+                        <!-- Once the ballot has shut, the panel stops being a
+                             ballot and becomes the announcement of the round
+                             that is about to run - so it names that round
+                             instead of describing what happened to the vote.
+                             "Next week's maps are decided" said neither what
+                             was starting nor when; paired with the countdown
+                             beside it, the comp's own name answers both. -->
                         <span class="text-lg font-black text-white">
-                            {{ voting.is_open ? $t('Vote on the next map') : $t("Next week's maps are decided") }}
+                            {{ voting.is_open
+                                ? $t('Vote on the next map')
+                                : $t('Up next: :comp', { comp: voting.comp_title }) }}
                         </span>
                         <span class="text-sm font-black uppercase tracking-wider text-blue-300">
                             {{ categoryLabel(voting.category) }}<template v-if="voting.weapon"> · {{ voting.weapon }}</template>
@@ -670,7 +679,7 @@ export default {
                      caption on the first row of maps. -->
                 <p class="mt-1.5 text-sm text-gray-400">
                     <template v-if="voting.is_open">{{ $t('CPM and VQ3 vote separately, so each physics gets the map its own players picked. You have one vote in each and can move it until the deadline.') }}</template>
-                    <template v-else>{{ $t('Voting is over. These are the maps for next week, and the round starts when the countdown runs out.') }}</template>
+                    <template v-else>{{ $t('Voting is over. These are the maps, and the round starts when the countdown runs out.') }}</template>
                 </p>
             </div>
 


### PR DESCRIPTION
"Next week's maps are decided" is a sentence about the ballot, and once the ballot is shut the ballot is the least interesting thing on the panel. It said neither what was starting nor when, which left a header whose only content was that something invisible had already finished.

The panel now names the round - "Up next: Weekly #1" - and the countdown beside it says when. Between them the header answers both questions on one line, which is what it was failing to do.