### PR TITLE
Label the decided maps, do not date them

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4205,8 +4205,8 @@
     "your timezone": "tvoje časové pásmo",
     "Playing for": "Hraje se o",
     "Starts in": "Začíná za",
-    "Playing next week": "Příští týden se hraje",
     "Final votes": "Konečné hlasy",
     "Up next: :comp": "Na řadě je :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Hlasování skončilo. Tohle jsou mapy a kolo začne, až doběhne odpočet."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Hlasování skončilo. Tohle jsou mapy a kolo začne, až doběhne odpočet.",
+    "What gets played": "Co se hraje"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4205,8 +4205,8 @@
     "your timezone": "deine Zeitzone",
     "Playing for": "Es geht um",
     "Starts in": "Startet in",
-    "Playing next week": "Nächste Woche gespielt",
     "Final votes": "Endergebnis der Abstimmung",
     "Up next: :comp": "Als Nächstes: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Die Abstimmung ist vorbei. Das sind die Karten, und die Runde startet, wenn der Countdown abläuft."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Die Abstimmung ist vorbei. Das sind die Karten, und die Runde startet, wenn der Countdown abläuft.",
+    "What gets played": "Was gespielt wird"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4205,8 +4205,8 @@
     "your timezone": "tu zona horaria",
     "Playing for": "Se juega por",
     "Starts in": "Empieza en",
-    "Playing next week": "Se juega la próxima semana",
     "Final votes": "Votos finales",
     "Up next: :comp": "A continuación: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "La votación ha terminado. Estos son los mapas, y la ronda empieza cuando acabe la cuenta atrás."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "La votación ha terminado. Estos son los mapas, y la ronda empieza cuando acabe la cuenta atrás.",
+    "What gets played": "Lo que se juega"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4205,8 +4205,8 @@
     "your timezone": "ton fuseau horaire",
     "Playing for": "On joue pour",
     "Starts in": "Démarre dans",
-    "Playing next week": "Au programme la semaine prochaine",
     "Final votes": "Votes finaux",
     "Up next: :comp": "À suivre : :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Le vote est terminé. Voici les maps, et le tour démarre à la fin du compte à rebours."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Le vote est terminé. Voici les maps, et le tour démarre à la fin du compte à rebours.",
+    "What gets played": "Ce qui sera joué"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4205,8 +4205,8 @@
     "your timezone": "jouw tijdzone",
     "Playing for": "Gespeeld om",
     "Starts in": "Begint over",
-    "Playing next week": "Volgende week gespeeld",
     "Final votes": "Eindstand van de stemming",
     "Up next: :comp": "Hierna: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "De stemming is voorbij. Dit zijn de maps, en de ronde begint als de aftelklok afloopt."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "De stemming is voorbij. Dit zijn de maps, en de ronde begint als de aftelklok afloopt.",
+    "What gets played": "Wat er gespeeld wordt"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4205,8 +4205,8 @@
     "your timezone": "twoja strefa czasowa",
     "Playing for": "Gra się o",
     "Starts in": "Zaczyna się za",
-    "Playing next week": "W przyszłym tygodniu gramy",
     "Final votes": "Ostateczne głosy",
     "Up next: :comp": "Następnie: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Głosowanie się skończyło. To są mapy, a runda zacznie się, gdy odliczanie dobiegnie końca."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Głosowanie się skończyło. To są mapy, a runda zacznie się, gdy odliczanie dobiegnie końca.",
+    "What gets played": "Co się gra"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4205,8 +4205,8 @@
     "your timezone": "твой часовой пояс",
     "Playing for": "Разыгрывается",
     "Starts in": "Начнётся через",
-    "Playing next week": "На следующей неделе играем",
     "Final votes": "Итоги голосования",
     "Up next: :comp": "Дальше: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосование завершено. Это карты, и раунд начнётся, когда истечёт обратный отсчёт."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосование завершено. Это карты, и раунд начнётся, когда истечёт обратный отсчёт.",
+    "What gets played": "Что играем"
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4205,8 +4205,8 @@
     "your timezone": "din tidszon",
     "Playing for": "Spelas om",
     "Starts in": "Startar om",
-    "Playing next week": "Spelas nästa vecka",
     "Final votes": "Slutgiltiga röster",
     "Up next: :comp": "Härnäst: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Omröstningen är över. Det här är banorna, och rundan startar när nedräkningen tar slut."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Omröstningen är över. Det här är banorna, och rundan startar när nedräkningen tar slut.",
+    "What gets played": "Det som spelas"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4205,8 +4205,8 @@
     "your timezone": "твій часовий пояс",
     "Playing for": "Розігрується",
     "Starts in": "Почнеться через",
-    "Playing next week": "Наступного тижня граємо",
     "Final votes": "Підсумки голосування",
     "Up next: :comp": "Далі: :comp",
-    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосування завершено. Це карти, і раунд почнеться, коли добіжить зворотний відлік."
+    "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосування завершено. Це карти, і раунд почнеться, коли добіжить зворотний відлік.",
+    "What gets played": "Що граємо"
 }

--- a/resources/js/Pages/Comps/Index.vue
+++ b/resources/js/Pages/Comps/Index.vue
@@ -698,9 +698,14 @@ export default {
 
             <!-- Once decided, say so and by what. Given its own heading:
                  with the ballot closed these two boxes are the answer people
-                 came for, and unlabelled they read as another pair of cards. -->
+                 came for, and unlabelled they read as another pair of cards.
+                 It labels, it does not date - the countdown above already says
+                 when, and "next week" reads as a contradiction next to a clock
+                 counting down to tomorrow evening. The pairing with "final
+                 votes" below is the point: two maps that get played, five that
+                 were on the ballot. -->
             <div v-if="!voting.is_open" class="mb-1.5 text-[11px] font-black uppercase tracking-widest text-blue-300/70">
-                {{ $t('Playing next week') }}
+                {{ $t('What gets played') }}
             </div>
             <div v-if="!voting.is_open" class="mb-5 grid gap-3 sm:grid-cols-2">
                 <div


### PR DESCRIPTION
"Playing next week" sat directly under a countdown reading twenty hours, which made the panel argue with itself. The heading exists to separate the two maps that get played from the five that were on the ballot, and the clock beside it already answers when - so it says what they are and leaves the timing alone.