### PR TITLE
Donation points, one machine per SFTP account, favourite servers, upload integrity, and a comps feed with maps in it

### DIFF
--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -17,6 +17,7 @@ use App\Services\ServerListService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -50,12 +51,37 @@ class LauncherController extends Controller
         // leave this method, so seeing the row gives nothing else away.
         $demo = UploadedDemo::withUnreleasedComps()
             ->where('file_hash', strtolower($data['hash']))
-            ->first(['id']);
+            ->first(['id', 'file_path', 'record_id', 'comps_hidden_until']);
+
+        // A row whose file never arrived is not a backup, and answering "yes"
+        // for it is how a demo gets lost for good: the launcher writes the
+        // file off as already backed up and never offers it again.
+        if ($demo && self::isAbandoned($demo)) {
+            $demo = null;
+        }
 
         return response()->json([
             'exists' => $demo !== null,
             'demo_id' => $demo?->id,
         ]);
+    }
+
+    /**
+     * A row that claims a hash but holds no file.
+     *
+     * It happens when an upload dies between the INSERT and the file landing
+     * on disk - the write below is now one transaction, but rows from before
+     * that are still in the table (2087 of them from March 2026), and
+     * file_hash is unique, so each one blocks its demo from ever being sent
+     * again. Nothing is lost by letting the file back in: there are no bytes
+     * behind these rows on any disk, and one that carries a record or a comps
+     * entry is left alone regardless.
+     */
+    private static function isAbandoned(UploadedDemo $demo): bool
+    {
+        return $demo->file_path === ''
+            && $demo->record_id === null
+            && ! $demo->isHeldForComps();
     }
 
     /**
@@ -86,10 +112,13 @@ class LauncherController extends Controller
      *
      * Expected multipart body:
      *   demo     (file, .dm_68/.dm_69 etc.)
-     *   hash     (optional md5; if omitted we compute it server-side)
+     *   hash     (optional md5 the launcher already computed; the stored hash
+     *             is always taken from the bytes that arrived, and this one is
+     *             only compared against it for the log)
      *
      * Response 200: { "demo_id": int, "status": "uploaded" }
      * Response 409: { "error": "duplicate", "demo_id": int }
+     * Response 500: { "error": <sentence> }  - nothing was written, send again
      */
     public function uploadDemo(Request $request)
     {
@@ -121,7 +150,24 @@ class LauncherController extends Controller
             ], 422);
         }
 
-        $hash = strtolower($request->input('hash') ?: md5_file($file->getPathname()));
+        // The hash is computed from the bytes that arrived, not taken from the
+        // launcher's word for them. It is the identity of the file everywhere
+        // on the site - the duplicate check, the render request, the match to a
+        // record - and a stored hash that is not the hash of the stored file is
+        // a row that lies quietly for as long as nobody hashes it again. The
+        // launcher's claim is still read, only to say so in the log when the
+        // two disagree.
+        $claimed = strtolower((string) $request->input('hash'));
+        $hash = strtolower(md5_file($file->getPathname()));
+
+        if ($claimed !== '' && $claimed !== $hash) {
+            Log::warning('Launcher upload hash mismatch', [
+                'user_id' => $user->id,
+                'claimed' => $claimed,
+                'actual' => $hash,
+                'filename' => $originalName,
+            ]);
+        }
 
         // Short-circuit: if the hash is already in the DB, treat as duplicate.
         // Returning 409 so the launcher can skip + mark local demo as "already backed up".
@@ -132,8 +178,14 @@ class LauncherController extends Controller
         // after we had already decided to publish the user's own comps run.
         $existing = UploadedDemo::withUnreleasedComps()
             ->where('file_hash', $hash)
-            ->first(['id', 'status']);
-        if ($existing) {
+            ->first();
+
+        // An abandoned row is taken over rather than replaced: file_hash is
+        // unique, so a second row for the same demo is impossible, and the id
+        // is what anything already pointing at it would be pointing at.
+        $abandoned = $existing !== null && self::isAbandoned($existing);
+
+        if ($existing && ! $abandoned) {
             return response()->json([
                 'error' => 'duplicate',
                 'demo_id' => $existing->id,
@@ -141,23 +193,56 @@ class LauncherController extends Controller
             ], 409);
         }
 
-        $demo = UploadedDemo::create([
-            'original_filename' => $originalName,
-            'file_path' => '',
-            'file_size' => $file->getSize(),
-            'file_hash' => $hash,
-            'user_id' => $user->id,
-            'status' => 'uploaded',
-            'client_file_mtime' => self::clientMtime($request),
-        ]);
+        // The row and the file land together or not at all. Written the other
+        // way round - row first, file after - a failure in between (a full
+        // disk, a killed worker) left a hash in the table with nothing behind
+        // it, and because that hash then answered "already backed up", the
+        // demo was never offered again.
+        try {
+            $demo = DB::transaction(function () use ($existing, $abandoned, $file, $originalName, $hash, $user, $request) {
+                $fields = [
+                    'original_filename' => $originalName,
+                    'file_path' => '',
+                    'file_size' => $file->getSize(),
+                    'file_hash' => $hash,
+                    'user_id' => $user->id,
+                    'status' => 'uploaded',
+                    'client_file_mtime' => self::clientMtime($request),
+                ];
 
-        $directory = storage_path("app/demos/temp/{$demo->id}");
-        if (! is_dir($directory)) {
-            mkdir($directory, 0755, true);
+                if ($abandoned) {
+                    // Whatever the old attempt failed at is not this file's
+                    // history, so the note explaining it goes too.
+                    $existing->update($fields + ['processing_output' => null, 'validity' => null]);
+                    $demo = $existing;
+                } else {
+                    $demo = UploadedDemo::create($fields);
+                }
+
+                $directory = storage_path("app/demos/temp/{$demo->id}");
+                if (! is_dir($directory)) {
+                    mkdir($directory, 0755, true);
+                }
+                $file->move($directory, $originalName);
+                $demo->update(['file_path' => "demos/temp/{$demo->id}/{$originalName}"]);
+
+                return $demo;
+            });
+        } catch (\Throwable $e) {
+            Log::error('Launcher demo upload failed', [
+                'user_id' => $user->id,
+                'hash' => $hash,
+                'filename' => $originalName,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'error' => 'The upload could not be stored. Nothing was saved, so the launcher can send it again.',
+            ], 500);
         }
-        $file->move($directory, $originalName);
-        $demo->update(['file_path' => "demos/temp/{$demo->id}/{$originalName}"]);
 
+        // After the commit, never inside it: a worker fast enough to pick the
+        // job up mid-transaction would look for a row that is not there yet.
         ProcessDemoJob::dispatch($demo);
 
         Log::info('Launcher demo upload', [

--- a/app/Http/Controllers/DemosController.php
+++ b/app/Http/Controllers/DemosController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use App\Models\UploadedDemo;
@@ -833,17 +834,28 @@ class DemosController extends Controller
 
                     if ($replacedThisDemo) $replacedCount++;
 
-                    // Create DB record (catch unique constraint for same-hash files within one batch)
+                    // The row and the file are one write. Separately, a failure
+                    // in between (a full disk, a killed process) leaves a hash
+                    // in the table with no file behind it - and because
+                    // file_hash is unique and 'uploaded' is not a status this
+                    // page will replace, that demo can never be uploaded again.
+                    // (catch unique constraint for same-hash files within one batch)
                     try {
-                        $demo = UploadedDemo::create([
-                            'original_filename' => $originalName,
-                            'file_path' => '',
-                            'file_size' => $demoFile->getSize(),
-                            'file_hash' => $fileHash,
-                            'user_id' => $userId,
-                            'status' => 'uploaded',
-                            'client_file_mtime' => $candidate['mtime'] ?? null,
-                        ]);
+                        $demo = DB::transaction(function () use ($originalName, $demoFile, $fileHash, $userId, $candidate) {
+                            $demo = UploadedDemo::create([
+                                'original_filename' => $originalName,
+                                'file_path' => '',
+                                'file_size' => $demoFile->getSize(),
+                                'file_hash' => $fileHash,
+                                'user_id' => $userId,
+                                'status' => 'uploaded',
+                                'client_file_mtime' => $candidate['mtime'] ?? null,
+                            ]);
+
+                            $demo->update(['file_path' => $this->storeUploadedDemoLocally($demoFile, $demo->id)]);
+
+                            return $demo;
+                        });
                     } catch (\Illuminate\Database\QueryException $qe) {
                         if (str_contains($qe->getMessage(), 'Duplicate entry')) {
                             $errors[] = $this->uploadError($originalName, 'duplicate', __('The same file is in this upload twice.'));
@@ -852,11 +864,8 @@ class DemosController extends Controller
                         throw $qe;
                     }
 
-                    // Store file and update path
-                    $path = $this->storeUploadedDemoLocally($demoFile, $demo->id);
-                    $demo->update(['file_path' => $path]);
-
-                    // Dispatch for processing
+                    // Dispatch for processing, after the commit: a worker that
+                    // picked the job up mid-transaction would find no row.
                     ProcessDemoJob::dispatch($demo);
 
                     $queuedDemos[] = $demo;

--- a/app/Http/Controllers/ServerHostingController.php
+++ b/app/Http/Controllers/ServerHostingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\ServerOwnerApplication;
 use App\Models\SftpCredential;
 use App\Services\StorageVpsProvisioner;
+use App\Support\HostIdentity;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -162,6 +163,27 @@ class ServerHostingController extends Controller
             ]);
         }
 
+        // Approving this application seeds ONE credential with every server
+        // listed here, and one SFTP account is one machine - so the list has
+        // to be one machine too. Somebody with two boxes applies for the
+        // first and requests a second credential once approved.
+        $hosts = collect($request->input('servers'))->pluck('ip')->map(fn ($h) => (string) $h);
+        $first = trim((string) $hosts->first());
+
+        if (HostIdentity::isUnresolvable($first)) {
+            return back()->withErrors([
+                'servers.0.ip' => "Could not resolve {$first}. Check the spelling, or enter the server's IP address instead.",
+            ]);
+        }
+
+        foreach ($hosts as $index => $host) {
+            if (! HostIdentity::sameMachine($first, trim($host))) {
+                return back()->withErrors([
+                    "servers.{$index}.ip" => "Every server in one application has to be on the same machine as the first one ({$first}). Apply for that box now - once you are approved you can request a credential for each further machine.",
+                ]);
+            }
+        }
+
         ServerOwnerApplication::create([
             'user_id'           => $user->id,
             'message'           => $request->input('message'),
@@ -204,20 +226,62 @@ class ServerHostingController extends Controller
         }
         RateLimiter::hit($rateKey, 3600);
 
-        $ip   = trim($request->input('ip'));
+        // Normalised, so a host pasted as "box.example.com:27960" or as a
+        // URL is stored the way every other row stores it - the port lives
+        // in its own column and a duplicate has to be recognisable.
+        $ip   = HostIdentity::normalize((string) $request->input('ip'));
         $port = (int) $request->input('port');
+
+        // A name nobody can resolve cannot be checked against anything, and
+        // it is a typo far more often than it is a real box.
+        if (HostIdentity::isUnresolvable($ip)) {
+            return back()->withErrors([
+                'ip' => "Could not resolve {$ip}. Check the spelling, or enter the server's IP address instead.",
+            ]);
+        }
 
         // A server can only ship demos through one credential — dedupe
         // across ALL of the user's active credentials, not just this one.
         $siblings = SftpCredential::where('user_id', $user->id)->active()->get();
         foreach ($siblings as $sibling) {
             foreach ($sibling->servers ?? [] as $existing) {
-                if (($existing['ip'] ?? null) === $ip && (int) ($existing['port'] ?? 0) === $port) {
+                $existingIp = (string) ($existing['ip'] ?? '');
+
+                if ($existingIp === $ip && (int) ($existing['port'] ?? 0) === $port) {
                     return back()->withErrors([
                         'ip' => "You already have a server registered at {$ip}:{$port}.",
                     ]);
                 }
+
+                // One box keeps one SFTP account, so a machine already
+                // declared under another credential cannot be declared
+                // again here - otherwise the same box ships demos through
+                // two accounts and neither one accounts for it.
+                if ($sibling->id !== $credential->id && HostIdentity::sameMachine($existingIp, $ip)) {
+                    $name = $sibling->label ?: $sibling->sftp_username;
+
+                    return back()->withErrors([
+                        'ip' => "That machine is already registered under \"{$name}\". Add the server there - one machine keeps one SFTP account.",
+                    ]);
+                }
             }
+        }
+
+        // One SFTP account is one machine. Somebody declared a domain and
+        // then a different server's address under the same account, which
+        // is how a box nobody approved starts shipping demos through
+        // somebody else's credential. The comparison resolves names, so a
+        // domain and the address it points at count as the same machine
+        // and a second server on the same box is still fine.
+        $declared = collect($credential->servers ?? [])
+            ->pluck('ip')
+            ->filter()
+            ->values();
+
+        if ($declared->isNotEmpty() && ! $declared->contains(fn ($host) => HostIdentity::sameMachine((string) $host, $ip))) {
+            return back()->withErrors([
+                'ip' => "This SFTP account is for {$declared->first()}. A server on a different machine needs its own credential - request one from this page and add it there.",
+            ]);
         }
 
         $servers   = $credential->servers ?? [];

--- a/app/Http/Controllers/ServersController.php
+++ b/app/Http/Controllers/ServersController.php
@@ -2,18 +2,54 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Server;
 use App\Services\ServerListService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
 class ServersController extends Controller
 {
+    /** Enough for anyone who plays, low enough that a script cannot fill the table. */
+    private const MAX_FAVORITES = 50;
+
     public function index(Request $request)
     {
         // Render the page immediately with an empty list; the Vue page
         // then fetches the live data via /api/servers/live so a slow
         // scrape query doesn't gate the initial paint.
-        return Inertia::render('Servers')->with('servers', []);
+        //
+        // The starred ids ride along with the page instead of with the
+        // live list: the list refreshes every 30 seconds, the star is
+        // toggled without a reload, and a refresh that started before
+        // the click landed would put the star back.
+        return Inertia::render('Servers')
+            ->with('servers', [])
+            ->with('favoriteServers', $request->user()
+                ? $request->user()->favoritedServers()->pluck('servers.id')
+                : []);
+    }
+
+    public function favorite(Request $request, Server $server)
+    {
+        $user = $request->user();
+
+        if ($user->favoritedServers()->count() >= self::MAX_FAVORITES
+            && ! $user->favoritedServers()->where('servers.id', $server->id)->exists()) {
+            return response()->json([
+                'message' => 'You have starred the maximum of ' . self::MAX_FAVORITES . ' servers.',
+            ], 422);
+        }
+
+        $user->favoritedServers()->syncWithoutDetaching([$server->id]);
+
+        return response()->json(['favorited' => true]);
+    }
+
+    public function unfavorite(Request $request, Server $server)
+    {
+        $request->user()->favoritedServers()->detach($server->id);
+
+        return response()->json(['favorited' => false]);
     }
 
     public function apiServers(Request $request, ServerListService $servers)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -461,6 +461,15 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
     }
 
     /**
+     * Servers the user pinned to the top of the server list.
+     */
+    public function favoritedServers()
+    {
+        return $this->belongsToMany(Server::class, 'server_favorites')
+            ->withTimestamps();
+    }
+
+    /**
      * Boot method to create "Play Later" maplist for new users
      */
     protected static function booted()

--- a/app/Services/CommunityScoreService.php
+++ b/app/Services/CommunityScoreService.php
@@ -530,29 +530,66 @@ class CommunityScoreService
 
     private function addDonations(Collection &$scores): void
     {
-        // Bulk donation calculation - group by user_id and sum per currency
+        // A donation names its donor by EMAIL, not by user id. Nothing that
+        // records a real donation fills user_id in - not the PayPal webhook,
+        // not the DefragHQ form, not the Filament admin; only a DefragLive
+        // contest prize donated back sets it. Matching on user_id therefore
+        // scored one person out of thirteen while their profiles all showed
+        // the donor badge, which has always matched by email
+        // (User::getDonorEmails). Match the same way here, and keep user_id
+        // as the stronger claim wherever it happens to be filled in.
         $donations = DB::table('site_donations')
-            ->whereNotNull('user_id')
             ->where('status', 'approved')
-            ->groupBy('user_id', 'currency')
-            ->select('user_id', 'currency', DB::raw('SUM(amount) as total'))
-            ->get()
-            ->groupBy('user_id');
+            ->groupBy('user_id', 'donor_email', 'currency')
+            ->select('user_id', 'donor_email', 'currency', DB::raw('SUM(amount) as total'))
+            ->get();
+
+        $emails = $donations->pluck('donor_email')
+            ->filter()
+            ->map(fn ($e) => mb_strtolower(trim($e)))
+            ->unique();
+
+        // Registration address first, then the extra addresses an admin
+        // listed on the profile - so a user cannot lose their own donation
+        // to somebody else's list.
+        $byEmail = [];
+        if ($emails->isNotEmpty()) {
+            foreach (DB::table('users')->whereIn('email', $emails)->get(['id', 'email']) as $user) {
+                $byEmail[mb_strtolower(trim($user->email))] = $user->id;
+            }
+            foreach (DB::table('users')->whereNotNull('donation_emails')->get(['id', 'donation_emails']) as $user) {
+                foreach (json_decode($user->donation_emails, true) ?: [] as $extra) {
+                    $key = mb_strtolower(trim((string) $extra));
+                    if ($key !== '' && ! isset($byEmail[$key])) {
+                        $byEmail[$key] = $user->id;
+                    }
+                }
+            }
+        }
 
         $rates = \Cache::get('exchange_rates_v4', [
             'EUR' => 1, 'USD' => 1.08, 'CZK' => 25.3, 'GBP' => 0.86, 'PLN' => 4.28,
         ]);
 
-        foreach ($donations as $userId => $currencyRows) {
-            $eur = 0;
-            foreach ($currencyRows as $row) {
-                if ($row->currency === 'EUR') {
-                    $eur += $row->total;
-                } elseif (isset($rates[$row->currency]) && $rates[$row->currency] > 0) {
-                    $eur += $row->total / $rates[$row->currency];
-                }
+        $totals = [];
+        foreach ($donations as $row) {
+            $userId = $row->user_id ?: ($byEmail[mb_strtolower(trim((string) $row->donor_email))] ?? null);
+            if (! $userId) {
+                continue;
             }
 
+            if ($row->currency === 'EUR') {
+                $eur = (float) $row->total;
+            } elseif (isset($rates[$row->currency]) && $rates[$row->currency] > 0) {
+                $eur = (float) $row->total / $rates[$row->currency];
+            } else {
+                continue;
+            }
+
+            $totals[$userId] = ($totals[$userId] ?? 0) + $eur;
+        }
+
+        foreach ($totals as $userId => $eur) {
             if ($eur > 0) {
                 $this->ensureUser($scores, $userId);
                 $data = $scores->get($userId);

--- a/app/Services/Comps/CompsApiPayload.php
+++ b/app/Services/Comps/CompsApiPayload.php
@@ -100,6 +100,23 @@ class CompsApiPayload
         ];
     }
 
+    /**
+     * A map as something to look at rather than a string to read: the name,
+     * who made it, and its picture.
+     *
+     * The thumbnail goes out exactly as it is stored - a `/storage`-relative
+     * path or an absolute URL - which is the same thing the server browser
+     * already sends, so the launcher has one rule for both.
+     */
+    private function mapCard(?\App\Models\Map $map): array
+    {
+        return [
+            'map' => $map?->name,
+            'author' => $map?->author ?: null,
+            'thumbnail' => $map?->thumbnail ?: null,
+        ];
+    }
+
     private function round(string $status): ?CompRound
     {
         return CompRound::where('status', $status)
@@ -129,6 +146,9 @@ class CompsApiPayload
             'ends_at' => $round->ends_at?->toIso8601String(),
             'prize_eur' => $this->funding->forRound($round),
             'maps' => $round->maps->mapWithKeys(fn ($m) => [$m->physics => $m->map?->name])->all(),
+            // The same two maps with their author and picture. Separate from
+            // `maps` above, which older launchers read as a plain name.
+            'map_cards' => $round->maps->mapWithKeys(fn ($m) => [$m->physics => $this->mapCard($m->map)])->all(),
             // A count, never a list, and never a time. It answers "is anyone
             // else in this" without answering "what do I have to beat".
             'entrants' => $this->entrantCounts($round),
@@ -202,20 +222,32 @@ class CompsApiPayload
             // somebody spending a wildcard on it. Empty while the ballot is
             // open - a map decided early by a wildcard is not announced before
             // the vote it would pre-empt.
+            //
+            // With the map's author and picture, because "vq3: sprint" is a
+            // name, and what somebody wants to know about next week is which
+            // map that is.
             'decided' => $round->isVoting()
                 ? []
                 : $round->maps->mapWithKeys(fn ($m) => [$m->physics => [
                     'map' => $m->map?->name,
                     'decided_by' => $m->decided_by,
-                ]])->all(),
+                ] + $this->mapCard($m->map)])->all(),
             // What next week pays, next to the maps it might be played on.
             // The reason to go and vote is usually that the week is worth
             // something, and the launcher is where somebody is standing when
             // they decide whether to bother.
             'prize_eur' => $this->funding->forRound($round),
+            // Names only, kept for launchers built before `candidate_maps`
+            // existed - they render this list directly, and handing them
+            // objects would print [object Object] on somebody's screen.
             'candidates' => $round->candidates()->with('map:id,name')->get()
                 ->map(fn ($c) => $c->map?->name)
                 ->filter()
+                ->values()
+                ->all(),
+            'candidate_maps' => $round->candidates()->with('map:id,name,author,thumbnail')->get()
+                ->filter(fn ($c) => $c->map !== null)
+                ->map(fn ($c) => $this->mapCard($c->map))
                 ->values()
                 ->all(),
             'next_category' => $this->selector->categoryForWeekly((int) $round->comp->number + 1),

--- a/app/Services/Comps/CompsApiPayload.php
+++ b/app/Services/Comps/CompsApiPayload.php
@@ -125,6 +125,7 @@ class CompsApiPayload
             'comp_number' => (int) $round->comp->number,
             'category' => $round->category,
             'weapon' => $round->weapon,
+            'starts_at' => $round->starts_at?->toIso8601String(),
             'ends_at' => $round->ends_at?->toIso8601String(),
             'prize_eur' => $this->funding->forRound($round),
             'maps' => $round->maps->mapWithKeys(fn ($m) => [$m->physics => $m->map?->name])->all(),
@@ -176,11 +177,15 @@ class CompsApiPayload
     }
 
     /**
-     * The open ballot, as names and nothing else.
+     * The next round: the ballot while it is open, and what came out of it
+     * once it is not.
      *
      * No preview videos and no vote counts: the launcher cannot play the
      * previews, and voting happens on the site, so a ballot here is a heads-up
-     * about what next week might be - not a voting booth.
+     * about what next week might be - not a voting booth. But once voting has
+     * closed, "closed" on its own is the least useful thing this could say, so
+     * the decided map goes out with it, along with when the week starts and
+     * what it pays. That is what somebody looking at this is asking.
      */
     private function voting(CompRound $round): array
     {
@@ -188,8 +193,21 @@ class CompsApiPayload
             'round_id' => $round->id,
             'comp_number' => (int) $round->comp->number,
             'category' => $round->category,
+            'weapon' => $round->weapon,
             'closes_at' => $round->voting_closes_at?->toIso8601String(),
+            'starts_at' => $round->starts_at?->toIso8601String(),
+            'ends_at' => $round->ends_at?->toIso8601String(),
             'is_open' => $round->isVoting() && $round->voting_closes_at?->isFuture(),
+            // What won, per physics, and whether it won by the count or by
+            // somebody spending a wildcard on it. Empty while the ballot is
+            // open - a map decided early by a wildcard is not announced before
+            // the vote it would pre-empt.
+            'decided' => $round->isVoting()
+                ? []
+                : $round->maps->mapWithKeys(fn ($m) => [$m->physics => [
+                    'map' => $m->map?->name,
+                    'decided_by' => $m->decided_by,
+                ]])->all(),
             // What next week pays, next to the maps it might be played on.
             // The reason to go and vote is usually that the week is worth
             // something, and the launcher is where somebody is standing when

--- a/app/Services/Comps/CompsApiPayload.php
+++ b/app/Services/Comps/CompsApiPayload.php
@@ -209,6 +209,10 @@ class CompsApiPayload
      */
     private function voting(CompRound $round): array
     {
+        // Fetched once: the ballot itself is built from it, and so is the vote
+        // count next to whichever map won.
+        $candidates = $round->candidates()->with('map:id,name,author,thumbnail')->get();
+
         return [
             'round_id' => $round->id,
             'comp_number' => (int) $round->comp->number,
@@ -231,6 +235,11 @@ class CompsApiPayload
                 : $round->maps->mapWithKeys(fn ($m) => [$m->physics => [
                     'map' => $m->map?->name,
                     'decided_by' => $m->decided_by,
+                    // How many votes it won that physics with. Null for a
+                    // wildcard, which is not a map anybody voted for.
+                    'votes' => $m->decided_by === 'wildcard'
+                        ? null
+                        : $candidates->firstWhere('map_id', $m->map_id)?->{"votes_{$m->physics}"},
                 ] + $this->mapCard($m->map)])->all(),
             // What next week pays, next to the maps it might be played on.
             // The reason to go and vote is usually that the week is worth
@@ -240,14 +249,21 @@ class CompsApiPayload
             // Names only, kept for launchers built before `candidate_maps`
             // existed - they render this list directly, and handing them
             // objects would print [object Object] on somebody's screen.
-            'candidates' => $round->candidates()->with('map:id,name')->get()
-                ->map(fn ($c) => $c->map?->name)
-                ->filter()
-                ->values()
-                ->all(),
-            'candidate_maps' => $round->candidates()->with('map:id,name,author,thumbnail')->get()
+            'candidates' => $candidates->map(fn ($c) => $c->map?->name)->filter()->values()->all(),
+            // The same ballot with everything worth seeing on it. Vote counts
+            // included: they are on the site's own ballot while it runs and
+            // stay there as the final count afterwards, so there is nothing
+            // here the launcher would be giving away.
+            'candidate_maps' => $candidates
                 ->filter(fn ($c) => $c->map !== null)
-                ->map(fn ($c) => $this->mapCard($c->map))
+                ->map(fn ($c) => $this->mapCard($c->map) + [
+                    'votes' => ['cpm' => (int) $c->votes_cpm, 'vq3' => (int) $c->votes_vq3],
+                    // A map can be barred from one physics - it has been
+                    // played there recently, or it is not ranked for it - and
+                    // a vote count under a physics it cannot win reads as a
+                    // race it is losing.
+                    'blocked_physics' => $c->blocked_physics,
+                ])
                 ->values()
                 ->all(),
             'next_category' => $this->selector->categoryForWeekly((int) $round->comp->number + 1),

--- a/app/Support/HostIdentity.php
+++ b/app/Support/HostIdentity.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Answers "are these two host strings the same machine?".
+ *
+ * One SFTP account is one VPS, so every server declared under it has to
+ * live on the same box. People name a box either by its address or by a
+ * domain that points at it, and the same person often uses both, so the
+ * comparison cannot be a string comparison - it has to happen on the
+ * addresses the name resolves to.
+ */
+class HostIdentity
+{
+    /** How long a resolved name is trusted. Long enough to survive a
+     *  burst of additions, short enough that a moved box is noticed. */
+    private const TTL = 600;
+
+    /**
+     * Every address the host points at. A literal address resolves to
+     * itself. An empty array means the name could not be resolved at all,
+     * which callers must treat as "unknown", never as "no match".
+     */
+    public static function addresses(string $host): array
+    {
+        $host = self::normalize($host);
+
+        if ($host === '') {
+            return [];
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return [$host];
+        }
+
+        return Cache::remember('host-addresses:' . $host, self::TTL, function () use ($host) {
+            $addresses = [];
+
+            // AAAA is only asked for when there is no A record, so a
+            // dual-stacked box is compared on its v4 address - the one
+            // people actually type into the form.
+            foreach ([DNS_A, DNS_AAAA] as $type) {
+                foreach (@dns_get_record($host, $type) ?: [] as $record) {
+                    $address = $record['ip'] ?? $record['ipv6'] ?? null;
+                    if ($address) {
+                        $addresses[] = strtolower($address);
+                    }
+                }
+
+                if ($addresses) {
+                    break;
+                }
+            }
+
+            return array_values(array_unique($addresses));
+        });
+    }
+
+    /**
+     * Same machine? The same name always is, even when DNS is down. Two
+     * different names are only the same machine when they resolve and
+     * share an address - an unresolvable name is never claimed to match.
+     */
+    public static function sameMachine(string $a, string $b): bool
+    {
+        if (self::normalize($a) === self::normalize($b) && self::normalize($a) !== '') {
+            return true;
+        }
+
+        $left  = self::addresses($a);
+        $right = self::addresses($b);
+
+        if (! $left || ! $right) {
+            return false;
+        }
+
+        return (bool) array_intersect($left, $right);
+    }
+
+    /** True when the name resolves to nothing - a typo, or dead DNS. */
+    public static function isUnresolvable(string $host): bool
+    {
+        return self::addresses($host) === [];
+    }
+
+    /**
+     * Strip what people paste around a hostname: a scheme, a trailing
+     * slash, a port, the brackets of an IPv6 literal.
+     */
+    public static function normalize(string $host): string
+    {
+        $host = strtolower(trim($host));
+        $host = preg_replace('#^[a-z][a-z0-9+.-]*://#', '', $host);
+        $host = trim($host, '/');
+
+        // An IPv6 literal is written in brackets precisely so its own
+        // colons cannot be read as a port, so unwrap it before anything
+        // else touches the colons.
+        if (preg_match('/^\[(.+)\](?::\d+)?$/', $host, $m)) {
+            return $m[1];
+        }
+
+        // A single colon is a port; several mean a bare IPv6 literal,
+        // which keeps every one of them.
+        if (substr_count($host, ':') === 1) {
+            $host = explode(':', $host)[0];
+        }
+
+        return $host;
+    }
+}

--- a/database/migrations/2026_08_16_090000_create_server_favorites_table.php
+++ b/database/migrations/2026_08_16_090000_create_server_favorites_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('server_favorites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('server_id')->constrained('servers')->onDelete('cascade');
+            $table->timestamps();
+
+            // One star per person per server, and the server list asks
+            // "which of these did this user star" on every page load.
+            $table->unique(['user_id', 'server_id']);
+            $table->index('server_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('server_favorites');
+    }
+};

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Konečné hlasy",
     "Up next: :comp": "Na řadě je :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Hlasování skončilo. Tohle jsou mapy a kolo začne, až doběhne odpočet.",
-    "What gets played": "Co se hraje"
+    "What gets played": "Co se hraje",
+    "Add to favorites": "Přidat do oblíbených",
+    "Remove from favorites": "Odebrat z oblíbených",
+    "Click the star on a server to keep it at the top of this page.": "Klikni na hvězdičku u serveru a zůstane ti nahoře na téhle stránce."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Endergebnis der Abstimmung",
     "Up next: :comp": "Als Nächstes: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Die Abstimmung ist vorbei. Das sind die Karten, und die Runde startet, wenn der Countdown abläuft.",
-    "What gets played": "Was gespielt wird"
+    "What gets played": "Was gespielt wird",
+    "Add to favorites": "Zu Favoriten hinzufügen",
+    "Remove from favorites": "Aus Favoriten entfernen",
+    "Click the star on a server to keep it at the top of this page.": "Klick bei einem Server auf den Stern, dann bleibt er oben auf dieser Seite."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Votos finales",
     "Up next: :comp": "A continuación: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "La votación ha terminado. Estos son los mapas, y la ronda empieza cuando acabe la cuenta atrás.",
-    "What gets played": "Lo que se juega"
+    "What gets played": "Lo que se juega",
+    "Add to favorites": "Añadir a favoritos",
+    "Remove from favorites": "Quitar de favoritos",
+    "Click the star on a server to keep it at the top of this page.": "Pulsa la estrella de un servidor y se quedará arriba en esta página."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Votes finaux",
     "Up next: :comp": "À suivre : :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Le vote est terminé. Voici les maps, et le tour démarre à la fin du compte à rebours.",
-    "What gets played": "Ce qui sera joué"
+    "What gets played": "Ce qui sera joué",
+    "Add to favorites": "Ajouter aux favoris",
+    "Remove from favorites": "Retirer des favoris",
+    "Click the star on a server to keep it at the top of this page.": "Clique sur l'étoile d'un serveur et il restera en haut de cette page."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Eindstand van de stemming",
     "Up next: :comp": "Hierna: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "De stemming is voorbij. Dit zijn de maps, en de ronde begint als de aftelklok afloopt.",
-    "What gets played": "Wat er gespeeld wordt"
+    "What gets played": "Wat er gespeeld wordt",
+    "Add to favorites": "Aan favorieten toevoegen",
+    "Remove from favorites": "Uit favorieten verwijderen",
+    "Click the star on a server to keep it at the top of this page.": "Klik op de ster bij een server, dan blijft hij bovenaan deze pagina."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Ostateczne głosy",
     "Up next: :comp": "Następnie: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Głosowanie się skończyło. To są mapy, a runda zacznie się, gdy odliczanie dobiegnie końca.",
-    "What gets played": "Co się gra"
+    "What gets played": "Co się gra",
+    "Add to favorites": "Dodaj do ulubionych",
+    "Remove from favorites": "Usuń z ulubionych",
+    "Click the star on a server to keep it at the top of this page.": "Kliknij gwiazdkę przy serwerze, a zostanie na górze tej strony."
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Итоги голосования",
     "Up next: :comp": "Дальше: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосование завершено. Это карты, и раунд начнётся, когда истечёт обратный отсчёт.",
-    "What gets played": "Что играем"
+    "What gets played": "Что играем",
+    "Add to favorites": "Добавить в избранное",
+    "Remove from favorites": "Убрать из избранного",
+    "Click the star on a server to keep it at the top of this page.": "Нажми на звёздочку у сервера, и он останется наверху этой страницы."
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Slutgiltiga röster",
     "Up next: :comp": "Härnäst: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Omröstningen är över. Det här är banorna, och rundan startar när nedräkningen tar slut.",
-    "What gets played": "Det som spelas"
+    "What gets played": "Det som spelas",
+    "Add to favorites": "Lägg till i favoriter",
+    "Remove from favorites": "Ta bort från favoriter",
+    "Click the star on a server to keep it at the top of this page.": "Klicka på stjärnan vid en server, så stannar den högst upp på sidan."
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4208,5 +4208,8 @@
     "Final votes": "Підсумки голосування",
     "Up next: :comp": "Далі: :comp",
     "Voting is over. These are the maps, and the round starts when the countdown runs out.": "Голосування завершено. Це карти, і раунд почнеться, коли добіжить зворотний відлік.",
-    "What gets played": "Що граємо"
+    "What gets played": "Що граємо",
+    "Add to favorites": "Додати в обране",
+    "Remove from favorites": "Прибрати з обраного",
+    "Click the star on a server to keep it at the top of this page.": "Натисни зірочку біля сервера, і він лишиться вгорі цієї сторінки."
 }

--- a/resources/js/Components/FavoriteStar.vue
+++ b/resources/js/Components/FavoriteStar.vue
@@ -1,0 +1,48 @@
+<script setup>
+    // The star that pins a server to the top of the list. The same button
+    // in all three server views, so switching layout does not move it into
+    // a different shape.
+    //
+    // A star that is not set stays out of the way until the pointer is on
+    // the card - forty faint stars would compete with everything the card
+    // is actually for. On a phone there is no hover, so there it is always
+    // faintly visible.
+    defineProps({
+        active: { type: Boolean, default: false },
+        // 'sm' for the two card layouts, 'xs' for the dense compact rows.
+        size: { type: String, default: 'sm' },
+    });
+
+    defineEmits(['toggle']);
+</script>
+
+<template>
+    <button
+        type="button"
+        :title="active ? $t('Remove from favorites') : $t('Add to favorites')"
+        :aria-label="active ? $t('Remove from favorites') : $t('Add to favorites')"
+        :aria-pressed="active"
+        :class="[
+            'flex-shrink-0 rounded transition-all duration-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-amber-300/70',
+            active
+                ? 'text-amber-300 hover:text-amber-200 drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)]'
+                : 'text-gray-400 hover:text-amber-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-70',
+        ]"
+        @click.stop.prevent="$emit('toggle')"
+    >
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            :fill="active ? 'currentColor' : 'none'"
+            stroke="currentColor"
+            stroke-width="2"
+            :class="size === 'xs' ? 'w-4 h-4' : 'w-5 h-5'"
+        >
+            <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M11.48 3.5a.56.56 0 0 1 1.04 0l2.13 5.11c.09.2.28.35.5.36l5.52.44c.5.04.7.67.32 1l-4.2 3.6a.56.56 0 0 0-.19.59l1.28 5.39c.12.49-.41.88-.84.62l-4.73-2.89a.56.56 0 0 0-.58 0l-4.73 2.89c-.43.26-.96-.13-.84-.62l1.28-5.39a.56.56 0 0 0-.19-.59l-4.2-3.6c-.38-.33-.18-.96.32-1l5.52-.44c.22-.01.41-.16.5-.36l2.13-5.11Z"
+            />
+        </svg>
+    </button>
+</template>

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -6,6 +6,7 @@ import OnlinePlayer from '@/Components/OnlinePlayer.vue';
 import CopyButton from '@/Components/Basic/CopyButton.vue';
 import LauncherBanner from '@/Components/LauncherBanner.vue';
 import CheatsBanner from '@/Components/CheatsBanner.vue';
+import FavoriteStar from '@/Components/FavoriteStar.vue';
 import { t } from '@/utils/i18n';
 import { getWeaponIcon, getWeaponName, getItemIcon, getItemName, getFunctionIcon, getFunctionName } from '@/utils/gameItems';
 const AddToMaplistModal = defineAsyncComponent(() => import('@/Components/Maplists/AddToMaplistModal.vue'));
@@ -19,7 +20,51 @@ const props = defineProps({
         type: Array,
         default: () => []
     },
+    // Ids the signed-in user starred. Sent once with the page, then kept
+    // here - the list itself reloads every 30 seconds and would otherwise
+    // undo a click whose request is still in flight.
+    favoriteServers: {
+        type: Array,
+        default: () => []
+    },
 });
+
+const favorites = ref(new Set(props.favoriteServers ?? []));
+const isFavorite = (server) => favorites.value.has(server.id);
+
+// Starring is per account, so it follows the person to every machine they
+// play from. Signed out the star still shows - it is how you find out the
+// feature exists - and asks for a login when clicked.
+const toggleFavorite = async (server) => {
+    if (! page.props.auth.user) {
+        router.visit('/login');
+        return;
+    }
+
+    const wasFavorite = favorites.value.has(server.id);
+
+    // Optimistic: the star answers the click, not the round trip.
+    const next = new Set(favorites.value);
+    wasFavorite ? next.delete(server.id) : next.add(server.id);
+    favorites.value = next;
+
+    try {
+        await (wasFavorite
+            ? window.axios.delete(`/servers/${server.id}/favorite`)
+            : window.axios.post(`/servers/${server.id}/favorite`));
+    } catch (error) {
+        // Put it back where it was, so the page never claims something
+        // the account does not actually hold.
+        const reverted = new Set(favorites.value);
+        wasFavorite ? reverted.add(server.id) : reverted.delete(server.id);
+        favorites.value = reverted;
+
+        const message = error?.response?.data?.message;
+        if (message) {
+            alert(message);
+        }
+    }
+};
 
 const localServers = ref([]);
 const serversLoading = ref(true);
@@ -78,13 +123,15 @@ const filters = ref({
     physics: 'all', // all, cpm, vq3
     hideEmpty: savedFilters.hideEmpty || false,
     showDetails: savedFilters.showDetails !== undefined ? savedFilters.showDetails : true,
+    favoritesOnly: savedFilters.favoritesOnly || false,
 });
 
 // Persist filter changes to localStorage
-watch(() => [filters.value.hideEmpty, filters.value.showDetails], () => {
+watch(() => [filters.value.hideEmpty, filters.value.showDetails, filters.value.favoritesOnly], () => {
     localStorage.setItem('servers_filters', JSON.stringify({
         hideEmpty: filters.value.hideEmpty,
         showDetails: filters.value.showDetails,
+        favoritesOnly: filters.value.favoritesOnly,
     }));
 });
 
@@ -264,14 +311,27 @@ const filteredAndSortedServers = computed(() => {
         });
     }
 
-    // Hide empty servers
+    // Only the starred ones
+    if (filters.value.favoritesOnly) {
+        result = result.filter(server => isFavorite(server));
+    }
+
+    // Hide empty servers. A starred server stays: the empty one you are
+    // about to join is the whole reason somebody starred it.
     if (filters.value.hideEmpty) {
-        result = result.filter(server => server.online_players.length > 0);
+        result = result.filter(server => server.online_players.length > 0 || isFavorite(server));
     }
 
 
     // Sort
     result.sort((a, b) => {
+        // Starred servers sit above the rest whatever the sort is, and
+        // sort among themselves by the same rule as everything else.
+        const starred = (isFavorite(b) ? 1 : 0) - (isFavorite(a) ? 1 : 0);
+        if (starred !== 0) {
+            return starred;
+        }
+
         let comparison = 0;
 
         if (sorting.value === 'popularity') {
@@ -405,6 +465,22 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                     </div>
 
                     <div class="flex flex-wrap items-center gap-2">
+                        <!-- Starred servers. Its own switch rather than a
+                             third button under "Hide", because it is the one
+                             filter somebody flips several times in a sitting
+                             and it names what it shows, not what it drops. -->
+                        <button
+                            @click="filters.favoritesOnly = !filters.favoritesOnly"
+                            :class="filters.favoritesOnly ? 'bg-amber-500/40 text-white border-amber-400/50' : 'bg-amber-500/[0.07] text-gray-400 hover:bg-white/5 border-amber-400/25'"
+                            class="flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-bold transition-colors whitespace-nowrap"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" :fill="filters.favoritesOnly ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="2" class="w-4 h-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.5a.56.56 0 0 1 1.04 0l2.13 5.11c.09.2.28.35.5.36l5.52.44c.5.04.7.67.32 1l-4.2 3.6a.56.56 0 0 0-.19.59l1.28 5.39c.12.49-.41.88-.84.62l-4.73-2.89a.56.56 0 0 0-.58 0l-4.73 2.89c-.43.26-.96-.13-.84-.62l1.28-5.39a.56.56 0 0 0-.19-.59l-4.2-3.6c-.38-.33-.18-.96.32-1l5.52-.44c.22-.01.41-.16.5-.36l2.13-5.11Z" />
+                            </svg>
+                            {{ $t('Favorites') }}
+                            <span v-if="favorites.size" class="px-1.5 rounded bg-black/30 text-amber-200">{{ favorites.size }}</span>
+                        </button>
+
                         <!-- Sort Options -->
                         <div class="flex flex-wrap items-stretch rounded-lg border border-emerald-400/25 bg-emerald-500/[0.07] overflow-hidden">
                             <span class="flex items-center px-2.5 py-1.5 bg-emerald-500/10 text-[11px] font-bold text-emerald-300/80 uppercase whitespace-nowrap">{{ $t('Sort:') }}</span>
@@ -478,7 +554,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
 
             <!-- Large Card Layout -->
             <div v-else-if="layout === 'large'" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <div v-for="server in filteredAndSortedServers" :key="server.id" :class="['group relative cursor-default bg-black/40 backdrop-blur-sm rounded-2xl border transition-all duration-300 hover:shadow-2xl overflow-hidden player-list-hover-group', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 hover:shadow-red-500/20' : 'border-white/10 hover:border-white/20 hover:shadow-blue-500/20']">
+                <div v-for="server in filteredAndSortedServers" :key="server.id" :class="['group relative cursor-default bg-black/40 backdrop-blur-sm rounded-2xl border transition-all duration-300 hover:shadow-2xl overflow-hidden player-list-hover-group', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 hover:shadow-red-500/20' : 'border-white/10 hover:border-white/20 hover:shadow-blue-500/20', isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
                     <CheatsBanner :cheats="server.cheats" :subdued="cheatsAreExpected(server)" />
                     <!-- Background Image - FIXED SIZE, never changes, keeps aspect ratio -->
                     <div class="absolute top-0 left-0 right-0 h-[450px] rounded-t-2xl pointer-events-none">
@@ -522,6 +598,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                                 <img :src="`/images/flags/${server.location}.png`" class="w-5 h-3.5 rounded" style="filter: drop-shadow(0 2px 4px rgba(0,0,0,1)) drop-shadow(0 0 8px rgba(0,0,0,0.8));" :title="server.location" @error="$event.target.style.display='none'">
                                 <h3 class="text-xl font-bold text-white flex-1" style="text-shadow: 0 2px 8px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1), 0 0 12px rgba(0,0,0,0.8);" v-html="q3tohtml(server.name)"></h3>
                                 <CopyButton :text="server.ip + ':' + server.port" size="sm" :label="$t('Copy IP')" />
+                                <FavoriteStar :active="isFavorite(server)" @toggle="toggleFavorite(server)" />
                             </div>
 
                             <!-- Map Info with hover group -->
@@ -694,7 +771,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                         </div>
                     </div>
 
-                    <div v-for="server in filteredAndSortedServers.filter(s => !s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 pt-4' : ['border-white/10 hover:border-blue-500/50', server.cheats ? 'pt-4' : '']]">
+                    <div v-for="server in filteredAndSortedServers.filter(s => !s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 pt-4' : ['border-white/10 hover:border-blue-500/50', server.cheats ? 'pt-4' : ''], isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
                         <CheatsBanner :cheats="server.cheats" compact :subdued="cheatsAreExpected(server)" />
                         <!-- Background Map Thumbnail -->
                         <div v-if="server.mapdata?.thumbnail" class="absolute inset-0 transition-all duration-500">
@@ -714,6 +791,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                             <div class="flex items-center justify-between gap-2">
                                 <!-- Left: Flag and Server Info -->
                                 <div class="flex items-center gap-2 flex-1 min-w-0">
+                                    <FavoriteStar :active="isFavorite(server)" size="xs" @toggle="toggleFavorite(server)" />
                                     <img :src="`/images/flags/${server.location}.png`" class="w-5 h-3.5 rounded shadow-md flex-shrink-0" :title="server.location" @error="$event.target.style.display='none'">
 
                                     <div class="inline-flex flex-col bg-black/40  px-2 py-1 rounded border border-white/20">
@@ -806,7 +884,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                         </div>
                     </div>
 
-                    <div v-for="server in filteredAndSortedServers.filter(s => s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 pt-4' : ['border-white/10 hover:border-purple-500/50', server.cheats ? 'pt-4' : '']]">
+                    <div v-for="server in filteredAndSortedServers.filter(s => s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 pt-4' : ['border-white/10 hover:border-purple-500/50', server.cheats ? 'pt-4' : ''], isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
                         <CheatsBanner :cheats="server.cheats" compact :subdued="cheatsAreExpected(server)" />
                         <!-- Background Map Thumbnail -->
                         <div v-if="server.mapdata?.thumbnail" class="absolute inset-0 transition-all duration-500">
@@ -825,6 +903,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                             <div class="flex items-center justify-between gap-2">
                                 <!-- Left: Flag and Server Info -->
                                 <div class="flex items-center gap-2 flex-1 min-w-0">
+                                    <FavoriteStar :active="isFavorite(server)" size="xs" @toggle="toggleFavorite(server)" />
                                     <img :src="`/images/flags/${server.location}.png`" class="w-5 h-3.5 rounded shadow-md flex-shrink-0" :title="server.location" @error="$event.target.style.display='none'">
 
                                     <div class="inline-flex flex-col bg-black/40  px-2 py-1 rounded border border-white/20">
@@ -920,15 +999,17 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                  room to spare. -->
             <div v-else-if="layout === 'oldschool'" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
                 <div v-for="server in filteredAndSortedServers" :key="server.id"
-                     :class="['rounded-xl border bg-black/40 backdrop-blur-sm p-3',
-                              server.cheats && !cheatsAreExpected(server) ? 'border-red-500/50' : 'border-white/10']">
+                     :class="['group rounded-xl border bg-black/40 backdrop-blur-sm p-3',
+                              server.cheats && !cheatsAreExpected(server) ? 'border-red-500/50' : 'border-white/10',
+                              isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
 
                     <CheatsBanner :cheats="server.cheats" :subdued="cheatsAreExpected(server)" />
 
                     <div class="flex items-center gap-2 mb-3">
                         <img v-if="server.location" :src="`/images/flags/${server.location}.png`" :title="server.location"
                              class="w-5 h-3.5 rounded shrink-0" @error="$event.target.style.display='none'" />
-                        <h3 class="font-bold text-sm truncate" v-html="q3tohtml(server.name)"></h3>
+                        <h3 class="font-bold text-sm truncate flex-1" v-html="q3tohtml(server.name)"></h3>
+                        <FavoriteStar :active="isFavorite(server)" size="xs" @toggle="toggleFavorite(server)" />
                     </div>
 
                     <div class="flex gap-3">
@@ -1014,7 +1095,8 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
                     </svg>
                     <h3 class="text-xl font-bold text-white mb-2">{{ $t('No servers found') }}</h3>
-                    <p class="text-gray-400">{{ $t('Try adjusting your filters') }}</p>
+                    <p v-if="filters.favoritesOnly && favorites.size === 0" class="text-gray-400">{{ $t('Click the star on a server to keep it at the top of this page.') }}</p>
+                    <p v-else class="text-gray-400">{{ $t('Try adjusting your filters') }}</p>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -434,6 +434,10 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/user/api-tokens', [\App\Http\Controllers\ApiTokenController::class, 'store'])->name('api-tokens.store');
     Route::delete('/user/api-tokens/{tokenId}', [\App\Http\Controllers\ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
 
+    // Starred servers, pinned to the top of the server list
+    Route::post('/servers/{server}/favorite', [ServersController::class, 'favorite'])->name('servers.favorite');
+    Route::delete('/servers/{server}/favorite', [ServersController::class, 'unfavorite'])->name('servers.unfavorite');
+
     // Server hosting (SFTP serverdemo credentials)
     Route::get('/server-hosting', [\App\Http\Controllers\ServerHostingController::class, 'index'])->name('server-hosting.index');
     Route::post('/server-hosting/apply', [\App\Http\Controllers\ServerHostingController::class, 'apply'])->name('server-hosting.apply');


### PR DESCRIPTION
Seven commits, four areas.

**Community score** - donation points were looked up by `site_donations.user_id`,
which nobody fills in, so almost nobody got them. Donors are matched by e-mail now,
the same way the profile badge already did it. 1 person with points becomes 14.

**Server hosting** - one SFTP account is one machine. Adding a server and applying
for one both resolve the address first, so a domain and its own IP count as the same
box and a second, unrelated one is refused.

**Favourite servers** - a star in all three views, favourites pinned above the sort,
"hide empty" does not apply to them. Needs `php artisan migrate`.

**Demo uploads** - the row used to be written before the file. A failure in between
left a hash with no file behind it, and since file_hash is unique and lookup-by-hash
answered "already backed up", that demo could never be sent again. 2087 rows are in
that state. Row, file and path are one transaction now, the stored hash is computed
from the bytes that arrived instead of taken from the launcher's word for them, and a
row with no file reports as missing and is taken over on re-upload.

**Comps feed for the launcher** - it named maps and nothing else, and after a vote it
could only say "closed". It now carries the map that won per physics with the votes it
won by, the ballot with authors, thumbnails and vote counts, and `starts_at` / `ends_at`
so the launcher can say when the week begins. `maps` and `candidates` keep their old
string shape beside the new fields, because launchers already installed read those
lists directly.

Deploy: `php artisan migrate`. Optionally `php artisan community:calculate-scores` to
recompute the donation points straight away.
