### PR TITLE
Put the comps and contest prize pools on the servers page

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -1148,6 +1148,60 @@ class DemomeController extends Controller
     }
 
     /**
+     * Every row whose rendered mp4 could still be sitting on the demome PC.
+     *
+     * The mp4 is only deleted after an upload AND YouTube-side processing both
+     * confirm, so anything that failed on either half leaves its file behind -
+     * and nothing on this side knows the file is there. Only the bot can see
+     * the disk, and it derives the mp4 name from `demo_filename`, so the match
+     * has to happen there: this endpoint just hands over the rows cheaply and
+     * the bot keeps the ones it can find a file for.
+     *
+     * Both halves are needed. A `failed` row means the video never landed and
+     * the file is worth re-uploading; a `completed` row whose upload timed out
+     * waiting for YouTube means the video IS up and the file is pure waste.
+     */
+    public function localFileCandidates(Request $request)
+    {
+        $since = $request->input('since');
+        $sinceDate = $since ? Carbon::parse($since) : now()->subDays(365);
+        // Newest first, so a collection that hits the ceiling loses its oldest
+        // rows - the ones least likely to still have a file - and says so
+        // instead of quietly answering "nothing here" for the rest.
+        $limit = 20000;
+
+        $videos = RenderedVideo::query()
+            ->toBase()
+            ->whereNotNull('demo_filename')
+            ->where('demo_filename', '!=', '')
+            ->whereIn('status', ['failed', 'upload_pending', 'completed'])
+            // Failed rows are few and a file can outlive the window it was
+            // rendered in, so they come whatever their age. Completed rows are
+            // ten thousand and only the recent ones can still have a file.
+            ->where(fn ($query) => $query
+                ->whereIn('status', ['failed', 'upload_pending'])
+                ->orWhere('updated_at', '>=', $sinceDate))
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get(['id', 'demo_filename', 'status', 'source', 'youtube_video_id', 'updated_at'])
+            ->map(fn ($item) => [
+                'id' => $item->id,
+                'demo_filename' => $item->demo_filename,
+                'status' => $item->status,
+                'source' => $item->source,
+                'youtube_video_id' => $item->youtube_video_id,
+                'updated_at' => $item->updated_at,
+            ]);
+
+        return response()->json([
+            'since' => $sinceDate->toIso8601String(),
+            'count' => $videos->count(),
+            'capped' => $videos->count() >= $limit,
+            'videos' => $videos,
+        ]);
+    }
+
+    /**
      * Get video metadata (title, description, tags) for a specific video.
      * Used by bot to get correct metadata before upload.
      */

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -173,7 +173,55 @@ class HandleInertiaRequests extends Middleware
                     'ends_at' => $contest->ends_at?->toIso8601String(),
                 ] : null;
             }),
+            'compsBanner'               =>      Cache::remember('comps:banner', 60, fn () => $this->compsBanner()),
         ]);
+    }
+
+    /**
+     * What the weekly is doing right now, small enough to ride along with every
+     * page: what is being played or voted on, and what it pays.
+     *
+     * There is money on the table every week and the servers page is where
+     * people actually are, so it has somewhere to say so. Cached with the
+     * contest for the same reason - this rides on every render and the answer
+     * changes twice a week.
+     */
+    private function compsBanner(): ?array
+    {
+        $round = $this->weeklyRound('active') ?? $this->weeklyRound('voting');
+
+        if (! $round) {
+            return null;
+        }
+
+        $eur = round(app(\App\Services\Comps\PrizeFunding::class)->forRound($round), 2);
+
+        return [
+            'round_id' => $round->id,
+            'number' => (int) ($round->comp?->number ?? 0),
+            'state' => $round->status,
+            'per_physics' => $eur,
+            // Both physics are paid, so the week is worth twice the per-physics
+            // figure - the same total the comps page leads with.
+            'total' => round($eur * count(\App\Services\Comps\BallotResolver::PHYSICS), 2),
+            // A round being played runs out; a ballot closes and the round it
+            // decides starts at that moment. Two different columns, one
+            // countdown on the card.
+            'until' => ($round->isVoting() ? $round->voting_closes_at : $round->ends_at)?->toIso8601String(),
+            'maps' => $round->isVoting()
+                ? []
+                : $round->maps->mapWithKeys(fn ($m) => [$m->physics => $m->map?->name])->filter()->all(),
+        ];
+    }
+
+    /** The one weekly round in the given state, if there is one. */
+    private function weeklyRound(string $status): ?\App\Models\CompRound
+    {
+        return \App\Models\CompRound::where('status', $status)
+            ->whereHas('comp', fn ($q) => $q->where('type', \App\Models\Comp::WEEKLY))
+            ->with(['comp:id,number', 'maps.map:id,name'])
+            ->orderBy('starts_at')
+            ->first();
     }
 
     private function getAvailableBadges($user): array

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Co se hraje",
     "Add to favorites": "Přidat do oblíbených",
     "Remove from favorites": "Odebrat z oblíbených",
-    "Click the star on a server to keep it at the top of this page.": "Klikni na hvězdičku u serveru a zůstane ti nahoře na téhle stránce."
+    "Click the star on a server to keep it at the top of this page.": "Klikni na hvězdičku u serveru a zůstane ti nahoře na téhle stránce.",
+    "Weekly comps": "Týdenní comps",
+    "Vote now ->": "Hlasuj ->",
+    "Most watched player wins": "Nejsledovanější hráč bere"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Was gespielt wird",
     "Add to favorites": "Zu Favoriten hinzufügen",
     "Remove from favorites": "Aus Favoriten entfernen",
-    "Click the star on a server to keep it at the top of this page.": "Klick bei einem Server auf den Stern, dann bleibt er oben auf dieser Seite."
+    "Click the star on a server to keep it at the top of this page.": "Klick bei einem Server auf den Stern, dann bleibt er oben auf dieser Seite.",
+    "Weekly comps": "Wöchentliche Comps",
+    "Vote now ->": "Jetzt abstimmen ->",
+    "Most watched player wins": "Meistgesehener Spieler gewinnt"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Lo que se juega",
     "Add to favorites": "Añadir a favoritos",
     "Remove from favorites": "Quitar de favoritos",
-    "Click the star on a server to keep it at the top of this page.": "Pulsa la estrella de un servidor y se quedará arriba en esta página."
+    "Click the star on a server to keep it at the top of this page.": "Pulsa la estrella de un servidor y se quedará arriba en esta página.",
+    "Weekly comps": "Comps semanales",
+    "Vote now ->": "Vota ahora ->",
+    "Most watched player wins": "El jugador más visto gana"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Ce qui sera joué",
     "Add to favorites": "Ajouter aux favoris",
     "Remove from favorites": "Retirer des favoris",
-    "Click the star on a server to keep it at the top of this page.": "Clique sur l'étoile d'un serveur et il restera en haut de cette page."
+    "Click the star on a server to keep it at the top of this page.": "Clique sur l'étoile d'un serveur et il restera en haut de cette page.",
+    "Weekly comps": "Comps hebdomadaires",
+    "Vote now ->": "Voter maintenant ->",
+    "Most watched player wins": "Le joueur le plus regardé gagne"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Wat er gespeeld wordt",
     "Add to favorites": "Aan favorieten toevoegen",
     "Remove from favorites": "Uit favorieten verwijderen",
-    "Click the star on a server to keep it at the top of this page.": "Klik op de ster bij een server, dan blijft hij bovenaan deze pagina."
+    "Click the star on a server to keep it at the top of this page.": "Klik op de ster bij een server, dan blijft hij bovenaan deze pagina.",
+    "Weekly comps": "Wekelijkse comps",
+    "Vote now ->": "Stem nu ->",
+    "Most watched player wins": "Meest bekeken speler wint"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Co się gra",
     "Add to favorites": "Dodaj do ulubionych",
     "Remove from favorites": "Usuń z ulubionych",
-    "Click the star on a server to keep it at the top of this page.": "Kliknij gwiazdkę przy serwerze, a zostanie na górze tej strony."
+    "Click the star on a server to keep it at the top of this page.": "Kliknij gwiazdkę przy serwerze, a zostanie na górze tej strony.",
+    "Weekly comps": "Cotygodniowe comps",
+    "Vote now ->": "Zagłosuj teraz ->",
+    "Most watched player wins": "Najczęściej oglądany gracz wygrywa"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Что играем",
     "Add to favorites": "Добавить в избранное",
     "Remove from favorites": "Убрать из избранного",
-    "Click the star on a server to keep it at the top of this page.": "Нажми на звёздочку у сервера, и он останется наверху этой страницы."
+    "Click the star on a server to keep it at the top of this page.": "Нажми на звёздочку у сервера, и он останется наверху этой страницы.",
+    "Weekly comps": "Еженедельные comps",
+    "Vote now ->": "Голосовать ->",
+    "Most watched player wins": "Самый просматриваемый игрок получает"
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Det som spelas",
     "Add to favorites": "Lägg till i favoriter",
     "Remove from favorites": "Ta bort från favoriter",
-    "Click the star on a server to keep it at the top of this page.": "Klicka på stjärnan vid en server, så stannar den högst upp på sidan."
+    "Click the star on a server to keep it at the top of this page.": "Klicka på stjärnan vid en server, så stannar den högst upp på sidan.",
+    "Weekly comps": "Veckans comps",
+    "Vote now ->": "Rösta nu ->",
+    "Most watched player wins": "Spelaren med flest tittartimmar vinner"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4211,5 +4211,8 @@
     "What gets played": "Що граємо",
     "Add to favorites": "Додати в обране",
     "Remove from favorites": "Прибрати з обраного",
-    "Click the star on a server to keep it at the top of this page.": "Натисни зірочку біля сервера, і він лишиться вгорі цієї сторінки."
+    "Click the star on a server to keep it at the top of this page.": "Натисни зірочку біля сервера, і він лишиться вгорі цієї сторінки.",
+    "Weekly comps": "Щотижневі comps",
+    "Vote now ->": "Голосувати ->",
+    "Most watched player wins": "Гравець, за яким спостерігали найбільше, отримує"
 }

--- a/resources/js/Components/PromoRail.vue
+++ b/resources/js/Components/PromoRail.vue
@@ -20,19 +20,34 @@ const contest = computed(() => page.props.defragliveContest || null);
 const now = ref(Date.now());
 let timer = null;
 
+// The cross means "not now", not "never again". A round runs for the better
+// part of a week and a contest for a fortnight, so a permanent dismissal would
+// hide the prize for the whole thing over one click at the wrong moment - and
+// the money is the point. It holds for three days; a new round or contest
+// brings the card straight back anyway, because the key carries the id.
+const DISMISS_DAYS = 3;
+
 // Both start hidden and are let through on mount, so somebody who dismissed a
 // card does not watch it flash up and vanish on every page load.
 const dismissedComps = ref(true);
 const dismissedContest = ref(true);
 
 const compsKey = computed(() => comps.value ? `promo_comps_dismissed_${comps.value.round_id}` : null);
-// The same key the sitewide contest banner uses: dismissing this contest is one
-// decision, not one per place it happens to be shown.
-const contestKey = computed(() => contest.value ? `dl_contest_banner_dismissed_${contest.value.id}` : null);
+const contestKey = computed(() => contest.value ? `promo_contest_dismissed_${contest.value.id}` : null);
+
+// When it was dismissed, not that it was. Anything unreadable - including the
+// bare "1" the older sitewide banner wrote - simply counts as not dismissed.
+const isDismissed = (key) => {
+    if (!key) return false;
+
+    const at = Number(localStorage.getItem(key));
+
+    return at > 0 && Date.now() - at < DISMISS_DAYS * 86400000;
+};
 
 onMounted(() => {
-    dismissedComps.value = compsKey.value ? localStorage.getItem(compsKey.value) === '1' : false;
-    dismissedContest.value = contestKey.value ? localStorage.getItem(contestKey.value) === '1' : false;
+    dismissedComps.value = isDismissed(compsKey.value);
+    dismissedContest.value = isDismissed(contestKey.value);
 
     timer = setInterval(() => { now.value = Date.now(); }, 1000);
 });
@@ -40,14 +55,15 @@ onMounted(() => {
 onUnmounted(() => { if (timer) clearInterval(timer); });
 
 const dismiss = (which) => {
+    const key = which === 'comps' ? compsKey.value : contestKey.value;
+
     if (which === 'comps') {
         dismissedComps.value = true;
-        if (compsKey.value) localStorage.setItem(compsKey.value, '1');
-        return;
+    } else {
+        dismissedContest.value = true;
     }
 
-    dismissedContest.value = true;
-    if (contestKey.value) localStorage.setItem(contestKey.value, '1');
+    if (key) localStorage.setItem(key, String(Date.now()));
 };
 
 // One key with the whole "3d 7h" already in it. Splitting it per unit would

--- a/resources/js/Components/PromoRail.vue
+++ b/resources/js/Components/PromoRail.vue
@@ -1,0 +1,177 @@
+<script setup>
+import { Link, usePage } from '@inertiajs/vue3';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { formatPrize } from '@/utils/currency';
+import { t } from '@/utils/i18n';
+
+// What is running right now and pays money, parked in the corner of the page
+// people actually sit on. The servers list is where somebody is when they are
+// about to play, which is the moment a weekly map or a watch contest is worth
+// knowing about - the comps page only reaches people already going there.
+//
+// Both cards are fed by shared Inertia props, so this costs the page nothing
+// and renders nothing at all when neither is on. Each is dismissed on its own
+// and comes back for the next round or contest, since the key carries the id.
+const page = usePage();
+
+const comps = computed(() => page.props.compsBanner || null);
+const contest = computed(() => page.props.defragliveContest || null);
+
+const now = ref(Date.now());
+let timer = null;
+
+// Both start hidden and are let through on mount, so somebody who dismissed a
+// card does not watch it flash up and vanish on every page load.
+const dismissedComps = ref(true);
+const dismissedContest = ref(true);
+
+const compsKey = computed(() => comps.value ? `promo_comps_dismissed_${comps.value.round_id}` : null);
+// The same key the sitewide contest banner uses: dismissing this contest is one
+// decision, not one per place it happens to be shown.
+const contestKey = computed(() => contest.value ? `dl_contest_banner_dismissed_${contest.value.id}` : null);
+
+onMounted(() => {
+    dismissedComps.value = compsKey.value ? localStorage.getItem(compsKey.value) === '1' : false;
+    dismissedContest.value = contestKey.value ? localStorage.getItem(contestKey.value) === '1' : false;
+
+    timer = setInterval(() => { now.value = Date.now(); }, 1000);
+});
+
+onUnmounted(() => { if (timer) clearInterval(timer); });
+
+const dismiss = (which) => {
+    if (which === 'comps') {
+        dismissedComps.value = true;
+        if (compsKey.value) localStorage.setItem(compsKey.value, '1');
+        return;
+    }
+
+    dismissedContest.value = true;
+    if (contestKey.value) localStorage.setItem(contestKey.value, '1');
+};
+
+// One key with the whole "3d 7h" already in it. Splitting it per unit would
+// glue the d/h/m letters onto the placeholder names, which survives t() and
+// then quietly traps whoever translates the line.
+const remaining = (iso) => {
+    if (!iso) return null;
+
+    const ms = new Date(iso).getTime() - now.value;
+    if (ms <= 0) return null;
+
+    const s = Math.floor(ms / 1000);
+    const d = Math.floor(s / 86400);
+    const h = Math.floor((s % 86400) / 3600);
+    const m = Math.floor((s % 3600) / 60);
+
+    if (d > 0) return t(':time left', { time: `${d}d ${h}h` });
+    if (h > 0) return t(':time left', { time: `${h}h ${m}m` });
+
+    return t(':time left', { time: `${m}m` });
+};
+
+const compsLeft = computed(() => remaining(comps.value?.until));
+const contestLeft = computed(() => remaining(contest.value?.ends_at));
+
+const contestPrize = computed(() => contest.value
+    ? formatPrize(contest.value.prize_amount, contest.value.prize_currency)
+    : '');
+
+// A ballot that has closed but whose round has not flipped to active yet still
+// has the voting status, and a countdown that ran out reads as broken. The card
+// stays up either way - what it pays is the point, the timer is a detail.
+const votingOpen = computed(() => comps.value?.state === 'voting' && compsLeft.value !== null);
+
+const showComps = computed(() => comps.value && !dismissedComps.value);
+const showContest = computed(() => contest.value && !dismissedContest.value);
+</script>
+
+<template>
+    <!-- Hidden below xl: a fixed card over a two-column server grid covers the
+         thing the visitor came for. -->
+    <div v-if="showComps || showContest"
+        class="hidden xl:flex fixed bottom-4 right-4 z-[150] w-[268px] flex-col gap-3">
+
+        <Transition
+            enter-active-class="transition duration-500 ease-out"
+            enter-from-class="translate-y-24 opacity-0"
+            enter-to-class="translate-y-0 opacity-100">
+            <Link v-if="showComps" href="/comps"
+                class="group relative rounded-xl border border-emerald-400/40 bg-black/70 backdrop-blur-md shadow-2xl overflow-hidden hover:border-emerald-400/80 transition-colors">
+                <div class="h-1 bg-emerald-400"></div>
+
+                <button type="button" @click.prevent.stop="dismiss('comps')"
+                    class="absolute top-2 right-2 z-10 text-gray-500 hover:text-white w-5 h-5 flex items-center justify-center rounded hover:bg-white/10"
+                    :title="$t('Dismiss')">
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
+                </button>
+
+                <div class="p-3.5">
+                    <div class="flex items-center gap-2">
+                        <span class="text-xl leading-none">🏁</span>
+                        <div class="text-[11px] uppercase tracking-widest font-bold text-emerald-300">{{ $t('Weekly comps') }}</div>
+                    </div>
+
+                    <div class="mt-1 font-black text-white leading-tight">
+                        {{ votingOpen ? $t('Vote on the next map') : $t('Playing now') }}
+                    </div>
+
+                    <div v-if="comps.total > 0" class="mt-2 flex items-baseline gap-2">
+                        <span class="text-2xl font-black tabular-nums text-emerald-300 leading-none">{{ comps.total }} EUR</span>
+                        <span class="text-[10px] text-emerald-100/50 tabular-nums">{{ $t('(:amount EUR per physics)', { amount: comps.per_physics }) }}</span>
+                    </div>
+
+                    <!-- The maps are the reason to click while a round is being
+                         played: knowing there is a comp on is not the same as
+                         knowing whether it is on a map you like. -->
+                    <div v-if="Object.keys(comps.maps || {}).length" class="mt-2 space-y-0.5">
+                        <div v-for="(map, physics) in comps.maps" :key="physics"
+                            class="flex items-center gap-1.5 text-[11px] min-w-0">
+                            <span class="uppercase font-bold text-gray-500 w-7 flex-shrink-0">{{ physics }}</span>
+                            <span class="text-gray-300 truncate">{{ map }}</span>
+                        </div>
+                    </div>
+
+                    <div class="mt-2 flex items-center justify-between gap-2 text-xs">
+                        <span v-if="compsLeft" class="text-amber-300 font-semibold">{{ compsLeft }}</span>
+                        <span class="text-emerald-300 font-semibold group-hover:underline ml-auto">
+                            {{ votingOpen ? $t('Vote now ->') : $t('Enter now ->') }}
+                        </span>
+                    </div>
+                </div>
+            </Link>
+        </Transition>
+
+        <Transition
+            enter-active-class="transition duration-500 ease-out delay-150"
+            enter-from-class="translate-y-24 opacity-0"
+            enter-to-class="translate-y-0 opacity-100">
+            <Link v-if="showContest" href="/defraglive/contest"
+                class="group relative rounded-xl border border-[#9147ff]/40 bg-black/70 backdrop-blur-md shadow-2xl overflow-hidden hover:border-[#9147ff]/80 transition-colors">
+                <div class="h-1 bg-[#9147ff]"></div>
+
+                <button type="button" @click.prevent.stop="dismiss('contest')"
+                    class="absolute top-2 right-2 z-10 text-gray-500 hover:text-white w-5 h-5 flex items-center justify-center rounded hover:bg-white/10"
+                    :title="$t('Dismiss')">
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
+                </button>
+
+                <div class="p-3.5">
+                    <div class="flex items-center gap-2">
+                        <span class="text-xl leading-none">🏆</span>
+                        <div class="text-[11px] uppercase tracking-widest font-bold text-purple-300">{{ $t('Contest live') }}</div>
+                    </div>
+
+                    <div class="mt-1 font-black text-white leading-tight">{{ $t('Most watched player wins') }}</div>
+
+                    <div class="mt-2 text-2xl font-black tabular-nums text-emerald-300 leading-none">{{ contestPrize }}</div>
+
+                    <div class="mt-2 flex items-center justify-between gap-2 text-xs">
+                        <span v-if="contestLeft" class="text-amber-300 font-semibold">{{ contestLeft }}</span>
+                        <span class="text-[#bf94ff] font-semibold group-hover:underline ml-auto">{{ $t('Enter now ->') }}</span>
+                    </div>
+                </div>
+            </Link>
+        </Transition>
+    </div>
+</template>

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -6,6 +6,7 @@ import OnlinePlayer from '@/Components/OnlinePlayer.vue';
 import CopyButton from '@/Components/Basic/CopyButton.vue';
 import LauncherBanner from '@/Components/LauncherBanner.vue';
 import CheatsBanner from '@/Components/CheatsBanner.vue';
+import PromoRail from '@/Components/PromoRail.vue';
 import FavoriteStar from '@/Components/FavoriteStar.vue';
 import { t } from '@/utils/i18n';
 import { getWeaponIcon, getWeaponName, getItemIcon, getItemName, getFunctionIcon, getFunctionName } from '@/utils/gameItems';
@@ -355,6 +356,12 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
 <template>
     <div class="">
         <Head :title="$t('Servers')" />
+
+        <!-- Whatever is running for money right now. This page is where people
+             are while deciding what to play, so it is the one place a weekly
+             map or a watch contest reaches somebody who was not already going
+             to look for it. -->
+        <PromoRail />
 
         <!-- Header Section -->
         <div class="relative bg-gradient-to-b from-black/25 via-black/10 to-transparent pt-6 pb-96 pointer-events-none">

--- a/routes/api.php
+++ b/routes/api.php
@@ -148,6 +148,7 @@ Route::prefix('demome')->middleware('demome.token')->withoutMiddleware('throttle
     Route::get('/publish-counts-today', [\App\Http\Controllers\Api\DemomeController::class, 'publishCountsToday']);
     Route::post('/auto-approve-publish', [\App\Http\Controllers\Api\DemomeController::class, 'autoApprovePublish']);
     Route::get('/video-metadata/{renderedVideo}', [\App\Http\Controllers\Api\DemomeController::class, 'videoMetadata']);
+    Route::get('/local-file-candidates', [\App\Http\Controllers\Api\DemomeController::class, 'localFileCandidates']);
     Route::get('/videos-needing-metadata-update', [\App\Http\Controllers\Api\DemomeController::class, 'videosNeedingMetadataUpdate']);
 });
 


### PR DESCRIPTION
Floating rail on /servers with the weekly comps prize pool (what it pays, which maps, or that the vote is open) and the DefragLive contest prize, both with a countdown. Hidden below xl.
Closing a card holds for three days instead of the whole round, and a new round or contest brings it back.
New compsBanner shared prop, cached 60s, next to the contest prop that was already there.
New local-file-candidates demome endpoint so the render bot can find mp4s that never left its disk.
Three new keys in all nine languages.