### PR TITLE
Clear the old failure when a render completes

### DIFF
--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -151,6 +151,11 @@ class DemomeController extends Controller
 
         $renderedVideo->update([
             'status' => 'completed',
+            // Whatever it failed with last time is no longer true, and a row
+            // reading "completed" while still carrying "no space left on
+            // device" sends whoever opens it looking for a problem that was
+            // fixed by the upload it is showing.
+            'failure_reason' => null,
             'youtube_url' => $validated['youtube_url'],
             'youtube_video_id' => $validated['youtube_video_id'],
             'render_duration_seconds' => $validated['render_duration_seconds'] ?? null,


### PR DESCRIPTION
A row that has been uploaded still carried whatever it failed with the last time round, so the admin panel showed "completed" next to "no space left on device" and sent whoever opened it looking for a problem the upload it is showing had already fixed.