### PR TITLE
Guard the day between the ballot closing and the round starting

### DIFF
--- a/app/Console/Commands/CompsReguard.php
+++ b/app/Console/Commands/CompsReguard.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Comp;
+use App\Models\CompRound;
+use App\Models\UploadedDemo;
+use App\Services\Comps\UploadGuard;
+use Illuminate\Console\Command;
+
+/**
+ * Re-run the comps upload guard over demos of the maps a round has decided.
+ *
+ * Written for the day the guard only looked at rounds already being played:
+ * the ballot closes a day before play starts, and every run uploaded in that
+ * day went public - listed on the map, in the records, and queued for a
+ * YouTube render. The guard covers that window now, but the demos that came
+ * through it while it did not are already sitting in the open, and nothing
+ * re-reads a demo once the parser is done with it.
+ *
+ * Safe to run at any time: it only ever looks at demos of a map a `locked` or
+ * `active` round has decided, and hands each one to the same guard the parser
+ * calls, which decides on the demo's own contents.
+ */
+class CompsReguard extends Command
+{
+    protected $signature = 'comps:reguard {--dry-run : List what would be held, change nothing}';
+
+    protected $description = 'Re-apply the comps hold to demos of maps a decided or running round is using';
+
+    public function handle(UploadGuard $guard): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        $rounds = CompRound::whereIn('status', ['locked', 'active'])
+            ->where('ends_at', '>', now())
+            ->whereHas('comp', fn ($q) => $q->where('type', Comp::WEEKLY))
+            ->with('maps.map')
+            ->get();
+
+        if ($rounds->isEmpty()) {
+            $this->info('No decided or running round right now, nothing to guard.');
+
+            return self::SUCCESS;
+        }
+
+        $held = 0;
+
+        foreach ($rounds as $round) {
+            foreach ($round->maps as $roundMap) {
+                if (! $roundMap->map) {
+                    continue;
+                }
+
+                $name = trim($roundMap->map->name);
+
+                // Only the ones that are visible: a demo already held needs
+                // nothing, and the guard would leave it alone anyway.
+                $demos = UploadedDemo::withUnreleasedComps()
+                    ->where(fn ($q) => $q->whereNull('comps_hidden_until')
+                        ->orWhere('comps_hidden_until', '<=', now()))
+                    ->whereRaw('LOWER(map_name) = ?', [mb_strtolower($name)])
+                    ->where('created_at', '>=', $round->voting_opens_at ?? $round->created_at)
+                    ->get();
+
+                foreach ($demos as $demo) {
+                    $this->line(sprintf(
+                        '  demo %d  %s  (%s, round %d %s)',
+                        $demo->id,
+                        $demo->original_filename ?: $name,
+                        $roundMap->physics,
+                        $round->id,
+                        $round->status,
+                    ));
+
+                    if ($dryRun) {
+                        continue;
+                    }
+
+                    $guard->apply($demo->fresh());
+
+                    if ($demo->fresh()->comps_hidden_until?->isFuture()) {
+                        $held++;
+                    }
+                }
+            }
+        }
+
+        $this->info($dryRun
+            ? 'Dry run - nothing changed.'
+            : "Held {$held} demo(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -43,11 +43,26 @@ class DemomeController extends Controller
             ];
         };
 
+        // A demo comps is holding must never reach the render queue. Rendering
+        // publishes the run on YouTube, which is the same route into the open
+        // the hold exists to close - and it is worse than the site listing it,
+        // because a video outlives the round. Written as a NOT EXISTS rather
+        // than through the relation on purpose: `uploaded_demos` hides held
+        // rows by global scope, so a `whereHas` here would quietly mean the
+        // opposite of what it reads like.
+        $notHeldForComps = fn ($query) => $query->whereNotExists(fn ($sub) => $sub
+            ->selectRaw('1')
+            ->from('uploaded_demos')
+            ->whereColumn('uploaded_demos.id', 'rendered_videos.demo_id')
+            ->whereNotNull('uploaded_demos.comps_hidden_until')
+            ->where('uploaded_demos.comps_hidden_until', '>', now()));
+
         // Force-render queue: always served, ignores `paused`. Items land
         // here when admin clicks the Filament "Force render" action, which
         // sets priority=-1. Bot processes this list unconditionally.
         $forceRender = RenderedVideo::where('status', 'pending')
             ->where('priority', -1)
+            ->tap($notHeldForComps)
             ->orderBy('created_at', 'asc')
             ->limit(5)
             ->get()
@@ -62,6 +77,7 @@ class DemomeController extends Controller
         $items = ($paused
             ? RenderedVideo::where('status', 'pending')->where('priority', -1)
             : RenderedVideo::where('status', 'pending'))
+            ->tap($notHeldForComps)
             ->orderBy('priority', 'asc')
             ->orderBy('created_at', 'asc')
             ->limit(5)

--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -674,6 +674,22 @@ class LauncherController extends Controller
             : UploadedDemo::where('file_hash', strtolower($data['file_hash']))->first();
 
         if (! $demo) {
+            // A demo comps is holding is hidden from this lookup by the global
+            // scope, and answering "upload it first" would send the launcher
+            // round the loop again. Say what is actually happening instead, and
+            // do not queue: a render publishes the run on YouTube, which is the
+            // one place a held run must not appear.
+            $held = UploadedDemo::withUnreleasedComps()
+                ->when(isset($data['demo_id']), fn ($q) => $q->whereKey($data['demo_id']))
+                ->when(! isset($data['demo_id']), fn ($q) => $q->where('file_hash', strtolower($data['file_hash'])))
+                ->first(['id', 'comps_hidden_until']);
+
+            if ($held) {
+                return response()->json([
+                    'error' => 'This run is on a map comps is using. It can be rendered once the round is over.',
+                ], 409);
+            }
+
             return response()->json([
                 'error' => 'Demo not found. Upload it first via /upload-demo.',
                 'needs_upload' => true,

--- a/app/Models/CompRound.php
+++ b/app/Models/CompRound.php
@@ -94,9 +94,17 @@ class CompRound extends Model
         return $this->status === 'voting';
     }
 
+    /**
+     * `locked` counts as well as `active`: between the ballot closing and play
+     * starting the map is decided and public, and a run made in that day counts
+     * for the round the same way a run from the voting window does. Refusing it
+     * with "this round is closed" would be false - it has not started - and
+     * would only push the run onto the public site instead, which is the one
+     * thing the round cannot have.
+     */
     public function acceptsUploads(): bool
     {
-        return $this->status === 'active';
+        return in_array($this->status, ['locked', 'active'], true);
     }
 
     /**

--- a/app/Services/Comps/UploadGuard.php
+++ b/app/Services/Comps/UploadGuard.php
@@ -483,12 +483,20 @@ class UploadGuard
     }
 
     /**
-     * The round being played on this map, in any physics. Deliberately not
+     * The round this map is decided for, in any physics. Deliberately not
      * filtered by the demo's own physics - see the class docblock.
+     *
+     * `locked` as well as `active`: the ballot closes a day before play
+     * starts, and for that day the map is public knowledge with no round to
+     * guard it. Only `active` was asked for, so runs uploaded in that gap went
+     * straight onto the site, into the records and into the render queue -
+     * which is the route handed to everybody who has not played it yet. A run
+     * made then counts for the round exactly like one from the voting window,
+     * so it is held and entered the same way.
      */
     private function playedRoundFor(string $mapName): ?CompRound
     {
-        return CompRound::where('status', 'active')
+        return CompRound::whereIn('status', ['locked', 'active'])
             ->where('ends_at', '>', now())
             ->whereHas('comp', fn ($q) => $q->where('type', Comp::WEEKLY))
             ->whereHas('maps.map', fn ($q) => $q->whereRaw('LOWER(name) = ?', [mb_strtolower(trim($mapName))]))


### PR DESCRIPTION
The weekly ballot closes a day before play starts, and the upload guard only asked for a round that was already `active` - so runs uploaded in that gap went public: on the map page, in the records, and into the render queue. A run made then counts for the round like one from the voting days, so it is now held and entered the same way.

- the guard reads `locked` rounds as well as `active` ones
- a locked round accepts uploads: it has not started, so "this round is closed" was false, and refusing only pushed the run onto the public site
- the render queue skips demos comps is holding, and a render request for one is answered instead of being told to upload it first
- `comps:reguard` re-applies the hold to demos already in the open

Needs `php artisan comps:reguard` after deploy.
