### PR TITLE
Fix comps entries refused before their demo was read

### DIFF
--- a/app/Filament/Resources/CompSubmissionResource.php
+++ b/app/Filament/Resources/CompSubmissionResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\CompSubmissionResource\Pages;
+use App\Filament\Resources\UserResource;
 use App\Models\CompSubmission;
 use App\Services\Comps\ResultsCalculator;
 use Filament\Forms;
@@ -45,37 +46,59 @@ class CompSubmissionResource extends Resource
     {
         return $table
             ->defaultSort('created_at', 'desc')
+            ->striped()
             ->columns([
+                // Round and category on one line. As a column plus a
+                // description it was two lines tall, and that alone set the
+                // height of every row in the table.
                 Tables\Columns\TextColumn::make('round.comp.title')
                     ->label('Comp')
-                    ->description(fn (CompSubmission $s) => $s->round?->category)
+                    ->formatStateUsing(fn ($state, CompSubmission $s) => trim($state . ($s->round?->category ? ' · ' . $s->round->category : '')))
+                    ->size('xs')
                     ->sortable(),
 
+                // The nick as the player wrote it. Stored with Quake's own
+                // colour codes, so `^3Flasch^1-B.I.E.R-` is the raw form and
+                // needs the same rendering the rest of the admin uses.
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Player')
                     ->searchable()
-                    ->weight('bold'),
+                    ->weight('bold')
+                    ->size('xs')
+                    ->formatStateUsing(fn (?string $state): string => $state ? UserResource::q3tohtml($state) : '-')
+                    ->html(),
 
                 Tables\Columns\TextColumn::make('physics')
                     ->badge()
+                    ->size('xs')
                     ->formatStateUsing(fn ($state) => $state ? strtoupper($state) : '-'),
 
                 Tables\Columns\TextColumn::make('time')
+                    ->size('xs')
                     ->formatStateUsing(fn ($state) => $state
                         ? gmdate('i:s', intdiv($state, 1000)) . '.' . str_pad($state % 1000, 3, '0', STR_PAD_LEFT)
                         : '-')
                     ->sortable(),
 
-                Tables\Columns\IconColumn::make('is_highlight')
-                    ->label('Highlight')
-                    ->boolean(),
+                // Two boolean columns of mostly-red crosses cost two column
+                // widths to say nothing. One column names only what is true.
+                Tables\Columns\TextColumn::make('is_highlight')
+                    ->label('Flags')
+                    ->size('xs')
+                    ->badge()
+                    ->color('gray')
+                    ->formatStateUsing(function (CompSubmission $s): string {
+                        $flags = array_filter([
+                            $s->is_highlight ? 'highlight' : null,
+                            $s->is_online ? 'online' : null,
+                        ]);
 
-                Tables\Columns\IconColumn::make('is_online')
-                    ->label('Online')
-                    ->boolean(),
+                        return $flags ? implode(', ', $flags) : '-';
+                    }),
 
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
+                    ->size('xs')
                     ->color(fn (string $state) => match ($state) {
                         'valid' => 'success',
                         'pending' => 'warning',
@@ -85,15 +108,32 @@ class CompSubmissionResource extends Resource
                     // `invalid` and want telling apart at a glance.
                     ->formatStateUsing(fn (CompSubmission $s) => $s->wasRemovedByAdmin() ? 'removed' : $s->status),
 
+                // Not wrapped: a long refusal used to grow its row to three
+                // lines. The whole sentence is in the tooltip.
                 Tables\Columns\TextColumn::make('invalid_reason')
                     ->label('Reason')
-                    ->limit(50)
-                    ->wrap()
+                    ->size('xs')
+                    ->limit(40)
                     ->tooltip(fn (CompSubmission $s) => $s->invalid_reason)
+                    ->toggleable(),
+
+                // How the run got here, which is the first thing asked when
+                // somebody says they never entered: `auto` means the guard
+                // took the demo in on its own, and the route is where the file
+                // itself came from. `web` on a row older than 18 Aug 2026 only
+                // means nothing wrote a route - see UploadedDemo::SOURCE_WEB.
+                Tables\Columns\TextColumn::make('demo.source')
+                    ->label('Via')
+                    ->size('xs')
+                    ->badge()
+                    ->color('gray')
+                    ->formatStateUsing(fn (?string $state, CompSubmission $s): string =>
+                        ($s->auto_entered ? 'auto' : 'entered') . ' / ' . ($state ?: '?'))
                     ->toggleable(),
 
                 Tables\Columns\TextColumn::make('created_at')
                     ->label('Uploaded')
+                    ->size('xs')
                     ->dateTime('d.m.Y H:i')
                     ->sortable(),
             ])
@@ -116,7 +156,10 @@ class CompSubmissionResource extends Resource
                 Tables\Filters\TernaryFilter::make('is_highlight')
                     ->label('Highlight'),
             ])
+            // Collapsed into one menu: three buttons on every row is a
+            // column of its own, and only one of them is ever pressed.
             ->actions([
+                Tables\Actions\ActionGroup::make([
                 Tables\Actions\Action::make('download')
                     ->label('Demo')
                     ->icon('heroicon-o-arrow-down-tray')
@@ -173,6 +216,7 @@ class CompSubmissionResource extends Resource
 
                         Notification::make()->title('Run restored')->success()->send();
                     }),
+                ]),
             ])
             ->emptyStateHeading('No entries')
             ->emptyStateDescription('Nobody has uploaded a run to comps yet.');
@@ -193,7 +237,16 @@ class CompSubmissionResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()->with(['user', 'round.comp']);
+        // The demo relation without the global scope. Every entry in a
+        // round still being played is held, which is exactly what that scope
+        // hides - eager loading it plainly returns null for the rows an admin
+        // most needs to look at. Same reason SubmissionValidator::reject does
+        // not go through $submission->demo.
+        return parent::getEloquentQuery()->with([
+            'user',
+            'round.comp',
+            'demo' => fn ($q) => $q->withUnreleasedComps(),
+        ]);
     }
 
     public static function getPages(): array

--- a/app/Http/Controllers/Api/DemomeController.php
+++ b/app/Http/Controllers/Api/DemomeController.php
@@ -725,7 +725,7 @@ class DemomeController extends Controller
             'file_size' => $file->getSize(),
             'file_hash' => $hash,
             'status' => 'uploaded',
-            'source' => 'demome',
+            'source' => UploadedDemo::SOURCE_DEMOME,
             'client_file_mtime' => $mtime,
         ]);
 

--- a/app/Http/Controllers/Api/LauncherController.php
+++ b/app/Http/Controllers/Api/LauncherController.php
@@ -207,6 +207,7 @@ class LauncherController extends Controller
                     'file_hash' => $hash,
                     'user_id' => $user->id,
                     'status' => 'uploaded',
+                    'source' => UploadedDemo::SOURCE_LAUNCHER,
                     'client_file_mtime' => self::clientMtime($request),
                 ];
 

--- a/app/Http/Controllers/DemosController.php
+++ b/app/Http/Controllers/DemosController.php
@@ -849,6 +849,7 @@ class DemosController extends Controller
                                 'file_hash' => $fileHash,
                                 'user_id' => $userId,
                                 'status' => 'uploaded',
+                                'source' => UploadedDemo::SOURCE_WEB,
                                 'client_file_mtime' => $candidate['mtime'] ?? null,
                             ]);
 

--- a/app/Jobs/ExtractAndQueueArchiveJob.php
+++ b/app/Jobs/ExtractAndQueueArchiveJob.php
@@ -89,6 +89,7 @@ class ExtractAndQueueArchiveJob implements ShouldQueue
                     'file_hash' => $fileHash,
                     'user_id' => $this->userId,
                     'status' => 'uploaded',
+                    'source' => UploadedDemo::SOURCE_ARCHIVE,
                     'client_file_mtime' => $this->archivedMtime($demoFile['mtime'] ?? null),
                 ]);
 

--- a/app/Models/UploadedDemo.php
+++ b/app/Models/UploadedDemo.php
@@ -35,6 +35,25 @@ class UploadedDemo extends Model
         static::deleted($clearCache);
     }
 
+    /**
+     * Which route put this file on the site.
+     *
+     * The column has existed since March 2026 with a default of `web`, but
+     * only demome ever wrote to it, so every other route landed on the
+     * default and the four of them were indistinguishable. That mattered the
+     * first time somebody asked how a demo of theirs had reached comps: the
+     * honest answer was that the database could not say.
+     *
+     * `WEB` keeps its old meaning, so rows written before 18 Aug 2026 read
+     * the same as they always did - which for those rows means "the /demos
+     * form, the launcher, an archive or comps", not "the /demos form".
+     */
+    public const SOURCE_WEB = 'web';
+    public const SOURCE_LAUNCHER = 'launcher';
+    public const SOURCE_COMPS = 'comps';
+    public const SOURCE_ARCHIVE = 'archive';
+    public const SOURCE_DEMOME = 'demome';
+
     protected $fillable = [
         'original_filename',
         'processed_filename',

--- a/app/Services/Comps/SubmissionIntake.php
+++ b/app/Services/Comps/SubmissionIntake.php
@@ -131,6 +131,7 @@ class SubmissionIntake
                 'file_hash' => $hash,
                 'user_id' => $user->id,
                 'status' => 'uploaded',
+                'source' => UploadedDemo::SOURCE_COMPS,
                 // Out of /demos, the map page, profiles and the launcher until
                 // the round is over. The demo is the route.
                 'comps_hidden_until' => $round->ends_at,

--- a/app/Services/Comps/SubmissionValidator.php
+++ b/app/Services/Comps/SubmissionValidator.php
@@ -32,6 +32,21 @@ class SubmissionValidator
     public const PARSED = ['processed', 'assigned', 'fallback-assigned'];
 
     /**
+     * Outcomes that are not outcomes yet: the parser has the file and has not
+     * finished with it.
+     *
+     * Load-bearing. `ProcessDemoJob` sets `processing` before it reads a byte,
+     * and that write is a status change, so the observer lands here with an
+     * entry that is still waiting and a demo that looks unreadable only
+     * because nothing has read it yet. Without this every entry made through
+     * the comps form was refused with "The demo could not be read" seconds
+     * after it was made, and `settleFor` only ever revisits `pending` rows -
+     * so the real verdict, which arrived moments later, found nothing left to
+     * correct. 12 entries in the first week, every single manual one.
+     */
+    private const IN_FLIGHT = ['uploaded', 'processing'];
+
+    /**
      * Settle every pending entry hanging off a finished upload.
      */
     public function settleFor(UploadedDemo $demo): void
@@ -48,6 +63,12 @@ class SubmissionValidator
 
     public function settle(CompSubmission $submission, UploadedDemo $demo): void
     {
+        // Still being read. Say nothing and stay pending; the parser's own
+        // finish will bring us back here with something to judge.
+        if (in_array($demo->status, self::IN_FLIGHT, true)) {
+            return;
+        }
+
         if (! in_array($demo->status, self::PARSED, true)) {
             $this->reject($submission, __('The demo could not be read.'), releasable: true);
 


### PR DESCRIPTION
Every entry made through the comps upload form was refused with "The demo could not be read" within seconds of being made. 12 entries, all of them manual; the 56 the guard made were fine.

ProcessDemoJob writes status `processing` before it opens the file, and the observer read that as a parser that had failed. settle() now waits on `uploaded` and `processing` instead of judging them.

Also here: every upload route now records itself in `source` (only demome did), and the entries table in the admin fits on a screen with nicks in their real colours.

After deploy, re-settle the 12 rows - they are all good runs.
