### PR TITLE
Fix comps refusals, stale Demos Top rows and the cheats card

### DIFF
--- a/app/Models/UploadedDemo.php
+++ b/app/Models/UploadedDemo.php
@@ -33,6 +33,43 @@ class UploadedDemo extends Model
 
         static::saved($clearCache);
         static::deleted($clearCache);
+
+        // Which record a demo belongs to decides whether Demos Top shows it as
+        // a row of its own or folds it into the main record's cluster - so the
+        // moment it moves, the cached Demos Top for that map is wrong.
+        //
+        // Here rather than at the callers. Five places move a demo between
+        // records: two assign endpoints, two unassign paths and the admin's
+        // reassignment action. Exactly one of them remembered to bump the
+        // counter, so a demo assigned to an existing record stayed on screen
+        // twice - once folded into the record it now belongs to, once as the
+        // orphan row the hour-old cache still believed in. Anywhere but the
+        // model, the sixth caller forgets again.
+        //
+        // `wasChanged` keeps it to the writes that matter: a download counter
+        // or an assignment note leaves the cache alone.
+        static::saved(function ($demo) {
+            if (! $demo->wasChanged('record_id')) {
+                return;
+            }
+
+            // The map as it was before this write, when the write cleared it.
+            // Reprocessing a demo nulls map_name and record_id together, and
+            // the stale row to clear is filed under the OLD map - reading the
+            // new value there finds null and silently skips the bump.
+            $map = $demo->map_name ?: $demo->getOriginal('map_name');
+
+            if ($map) {
+                Cache::increment('demostop_gen:' . $map);
+            }
+        });
+
+        // A deleted demo leaves the same stale row behind.
+        static::deleted(function ($demo) {
+            if ($demo->map_name && $demo->record_id) {
+                Cache::increment('demostop_gen:' . $demo->map_name);
+            }
+        });
     }
 
     /**

--- a/resources/js/Components/CheatsBanner.vue
+++ b/resources/js/Components/CheatsBanner.vue
@@ -5,6 +5,13 @@
 // badge: a time set where cheats are enabled is worth nothing, and somebody
 // scanning the list should not have to hunt for that.
 //
+// Full width, but not full brightness. At bg-red-600/90 with a red-500/60
+// border on the card as well, a cheats server pulled the eye harder than any
+// normal one and read as the most important thing on the page - which is
+// backwards, since it is the server whose times do not count. Toned down
+// 18 Aug 2026 on a player's report; the warning still reads at a glance and
+// no longer outranks everything around it.
+//
 // Renders nothing for false OR null. Null means the server never told us -
 // only an engine new enough to put sv_cheats in its getdfstatus reply does,
 // because the cvar is systeminfo and never reaches a server browser otherwise.
@@ -29,7 +36,7 @@ defineProps({
             'absolute top-0 inset-x-0 z-20 flex items-center justify-center gap-2 backdrop-blur-sm pointer-events-none',
             subdued
                 ? 'bg-gray-900/70 border-b border-white/10 py-0.5'
-                : ['bg-red-600/90 border-b border-red-300/40', compact ? 'py-0.5' : 'py-1.5'],
+                : ['bg-red-800/85 border-b border-red-400/25', compact ? 'py-0.5' : 'py-1.5'],
         ]"
         :title="subdued
             ? $t('This server runs with sv_cheats enabled. It is a freestyle server, so nothing here is a timed result anyway.')

--- a/resources/js/Pages/Servers.vue
+++ b/resources/js/Pages/Servers.vue
@@ -561,7 +561,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
 
             <!-- Large Card Layout -->
             <div v-else-if="layout === 'large'" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <div v-for="server in filteredAndSortedServers" :key="server.id" :class="['group relative cursor-default bg-black/40 backdrop-blur-sm rounded-2xl border transition-all duration-300 hover:shadow-2xl overflow-hidden player-list-hover-group', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 hover:shadow-red-500/20' : 'border-white/10 hover:border-white/20 hover:shadow-blue-500/20', isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
+                <div v-for="server in filteredAndSortedServers" :key="server.id" :class="['group relative cursor-default bg-black/40 backdrop-blur-sm rounded-2xl border transition-all duration-300 hover:shadow-2xl overflow-hidden player-list-hover-group', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/25 hover:border-red-400/45 hover:shadow-red-500/10' : 'border-white/10 hover:border-white/20 hover:shadow-blue-500/20', isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
                     <CheatsBanner :cheats="server.cheats" :subdued="cheatsAreExpected(server)" />
                     <!-- Background Image - FIXED SIZE, never changes, keeps aspect ratio -->
                     <div class="absolute top-0 left-0 right-0 h-[450px] rounded-t-2xl pointer-events-none">
@@ -778,7 +778,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                         </div>
                     </div>
 
-                    <div v-for="server in filteredAndSortedServers.filter(s => !s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 pt-4' : ['border-white/10 hover:border-blue-500/50', server.cheats ? 'pt-4' : ''], isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
+                    <div v-for="server in filteredAndSortedServers.filter(s => !s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/25 hover:border-red-400/45 pt-4' : ['border-white/10 hover:border-blue-500/50', server.cheats ? 'pt-4' : ''], isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
                         <CheatsBanner :cheats="server.cheats" compact :subdued="cheatsAreExpected(server)" />
                         <!-- Background Map Thumbnail -->
                         <div v-if="server.mapdata?.thumbnail" class="absolute inset-0 transition-all duration-500">
@@ -891,7 +891,7 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                         </div>
                     </div>
 
-                    <div v-for="server in filteredAndSortedServers.filter(s => s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/60 hover:border-red-400/80 pt-4' : ['border-white/10 hover:border-purple-500/50', server.cheats ? 'pt-4' : ''], isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
+                    <div v-for="server in filteredAndSortedServers.filter(s => s.defrag.toLowerCase().includes('cpm'))" :key="server.id" :class="['group relative overflow-hidden rounded-xl border transition-all duration-300', server.cheats && !cheatsAreExpected(server) ? 'border-red-500/25 hover:border-red-400/45 pt-4' : ['border-white/10 hover:border-purple-500/50', server.cheats ? 'pt-4' : ''], isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
                         <CheatsBanner :cheats="server.cheats" compact :subdued="cheatsAreExpected(server)" />
                         <!-- Background Map Thumbnail -->
                         <div v-if="server.mapdata?.thumbnail" class="absolute inset-0 transition-all duration-500">
@@ -1005,12 +1005,22 @@ const serverCount = computed(() => filteredAndSortedServers.value.length);
                  40px short however small the thumbnail is made. At four it has
                  room to spare. -->
             <div v-else-if="layout === 'oldschool'" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+                <!-- `relative` and the extra top padding are what the other
+                     three card layouts already have and this one did not, so
+                     the banner - which is absolutely positioned at top-0 -
+                     had nothing to anchor to and lay across the server name.
+                     Padding only when there is a banner to make room for, and
+                     keyed on `cheats` alone: a subdued banner is still drawn. -->
                 <div v-for="server in filteredAndSortedServers" :key="server.id"
-                     :class="['group rounded-xl border bg-black/40 backdrop-blur-sm p-3',
-                              server.cheats && !cheatsAreExpected(server) ? 'border-red-500/50' : 'border-white/10',
+                     :class="['group relative rounded-xl border bg-black/40 backdrop-blur-sm p-3',
+                              server.cheats && !cheatsAreExpected(server) ? 'border-red-500/25' : 'border-white/10',
+                              server.cheats ? 'pt-6' : '',
                               isFavorite(server) ? 'ring-1 ring-amber-400/50' : '']">
 
-                    <CheatsBanner :cheats="server.cheats" :subdued="cheatsAreExpected(server)" />
+                    <!-- compact, like the two column layouts. The full-height
+                         banner is for the big cards, where it sits over a
+                         450px thumbnail rather than over the card's first row. -->
+                    <CheatsBanner :cheats="server.cheats" compact :subdued="cheatsAreExpected(server)" />
 
                     <div class="flex items-center gap-2 mb-3">
                         <img v-if="server.location" :src="`/images/flags/${server.location}.png`" :title="server.location"


### PR DESCRIPTION
Five things, all found by players in one evening.

Comps refused every entry made through its own upload form with "The demo could not be read". ProcessDemoJob writes status `processing` before it opens the file and the observer read that as a failed parse. 12 entries, all manual; the 56 the guard made were fine. Re-settle those rows after deploy.

Moving a demo between records left the map page half stale: the record updates live, the Demos Top row comes from an hour-long cache. Assigning showed the demo twice, unassigning made it vanish. Five call sites move a demo, one bumped the generation counter; the bump is now in the model.

Also: every upload route records itself in `source` (only demome did), the cheats banner no longer covers the server name in the oldschool card layout and its red is toned down, and the comps entries table in the admin fits on a screen with nicks in their real colours.
