### PR TITLE
Comps: honest refusals, no leaked times, and a visible hold

### DIFF
--- a/app/Http/Controllers/DemosController.php
+++ b/app/Http/Controllers/DemosController.php
@@ -243,7 +243,13 @@ class DemosController extends Controller
         $demoCounts = null;
         if (Auth::check() && ($needs('userDemos') || $needs('demoCounts'))) {
             if ($isAdmin) {
-                $query = UploadedDemo::with(['record.user', 'user', 'offlineRecord', 'suggestedUser']);
+                // withUnreleasedComps() here and in the owner's branch below:
+                // these two lists are exactly the readers the comps scope was
+                // written to make an exception for. Everywhere else the demo
+                // stays hidden - the public browse further down does NOT get
+                // this, and neither does anything else on the site.
+                $query = UploadedDemo::withUnreleasedComps()
+                    ->with(['record.user', 'user', 'offlineRecord', 'suggestedUser']);
 
                 if ($filterTab === 'online') {
                     $query->where('gametype', 'LIKE', 'm%');
@@ -309,9 +315,10 @@ class DemosController extends Controller
                 }
 
                 if ($needs('userDemos')) $userDemos = $query->paginate(20, ['*'], 'userPage');
-                if ($needs('demoCounts')) $demoCounts = Cache::remember('demo_counts_admin', 60, fn () => $this->computeDemoCounts(UploadedDemo::query()));
+                if ($needs('demoCounts')) $demoCounts = Cache::remember('demo_counts_admin', 60, fn () => $this->computeDemoCounts(UploadedDemo::withUnreleasedComps()));
             } else {
-                $query = UploadedDemo::where('user_id', $currentUser->id)
+                $query = UploadedDemo::withUnreleasedComps()
+                    ->where('user_id', $currentUser->id)
                     ->with(['record.user', 'offlineRecord']);
 
                 if ($filterTab === 'online') {
@@ -354,7 +361,7 @@ class DemosController extends Controller
                 }
 
                 if ($needs('userDemos')) $userDemos = $query->paginate(20, ['*'], 'userPage');
-                if ($needs('demoCounts')) $demoCounts = Cache::remember("demo_counts_user_{$currentUser->id}", 3600, fn () => $this->computeDemoCounts(UploadedDemo::where('user_id', $currentUser->id)));
+                if ($needs('demoCounts')) $demoCounts = Cache::remember("demo_counts_user_{$currentUser->id}", 3600, fn () => $this->computeDemoCounts(UploadedDemo::withUnreleasedComps()->where('user_id', $currentUser->id)));
             }
         }
 

--- a/app/Models/UploadedDemo.php
+++ b/app/Models/UploadedDemo.php
@@ -149,6 +149,18 @@ class UploadedDemo extends Model
         'download_count',
     ];
 
+    /**
+     * Serialised with every demo so a list can say why one of them is not
+     * where its owner expects it to be.
+     *
+     * Cheap - it reads two columns already on the row - and null for the
+     * overwhelming majority, which is the point: only a demo comps is holding
+     * has anything to explain.
+     */
+    protected $appends = [
+        'comps_hold',
+    ];
+
     protected $casts = [
         'file_size' => 'integer',
         'time_ms' => 'integer',
@@ -292,6 +304,31 @@ class UploadedDemo extends Model
     }
 
     /** True while this demo is a comps entry in a round still being played. */
+    /**
+     * Why this demo is missing from the public site: `held`, `withdrawn`, or
+     * null when it is not missing at all.
+     *
+     * Somebody who uploads a run of the map comps is playing gets it taken off
+     * the site until the round ends. That is correct and it is the whole point
+     * of the hold - but it was also invisible. The demo vanished from the
+     * uploader's own list with nothing said, so the only reading available was
+     * that the upload had failed. The file was never gone: download has let
+     * the owner and an admin through from the start. There was simply nothing
+     * left to click.
+     *
+     * `withdrawn` outranks `held` because it answers the better question. A
+     * person who took their own run out of comps wants to see that they did,
+     * not to be told the site is holding it.
+     */
+    public function getCompsHoldAttribute(): ?string
+    {
+        if (! $this->isHeldForComps()) {
+            return null;
+        }
+
+        return $this->comps_withdrawn_at ? 'withdrawn' : 'held';
+    }
+
     public function isHeldForComps(): bool
     {
         return $this->comps_hidden_until !== null

--- a/app/Models/UploadedDemo.php
+++ b/app/Models/UploadedDemo.php
@@ -48,8 +48,12 @@ class UploadedDemo extends Model
         //
         // `wasChanged` keeps it to the writes that matter: a download counter
         // or an assignment note leaves the cache alone.
+        // `comps_hidden_until` moves a demo in and out of Demos Top for the
+        // same reason: a held run is kept out of the offline pool while its
+        // round is being played, so both the moment it is held and the moment
+        // the round releases it change what that map should show.
         static::saved(function ($demo) {
-            if (! $demo->wasChanged('record_id')) {
+            if (! $demo->wasChanged('record_id') && ! $demo->wasChanged('comps_hidden_until')) {
                 return;
             }
 
@@ -59,17 +63,36 @@ class UploadedDemo extends Model
             // new value there finds null and silently skips the bump.
             $map = $demo->map_name ?: $demo->getOriginal('map_name');
 
-            if ($map) {
-                Cache::increment('demostop_gen:' . $map);
-            }
+            static::forgetDemosTop($map);
         });
 
         // A deleted demo leaves the same stale row behind.
         static::deleted(function ($demo) {
-            if ($demo->map_name && $demo->record_id) {
-                Cache::increment('demostop_gen:' . $demo->map_name);
+            if ($demo->record_id || $demo->comps_hidden_until) {
+                static::forgetDemosTop($demo->map_name);
             }
         });
+    }
+
+    /**
+     * Retire the cached Demos Top for one map.
+     *
+     * A counter rather than a tagged flush: tags do not flush reliably under
+     * Redis behind Octane, and a Demos Top that survives its own invalidation
+     * is worse than no cache at all - the page then shows live records beside
+     * an hour-old cluster and every action looks half-applied.
+     *
+     * Public and static because the model's own events cannot carry this
+     * alone. The comps hold and release write with `saveQuietly()` and with
+     * query-builder `update()`, both of which skip events on purpose, so those
+     * paths call this by hand. Anything that moves a demo between records, or
+     * in or out of a comps hold, owes this map one call.
+     */
+    public static function forgetDemosTop(?string $mapName): void
+    {
+        if ($mapName) {
+            Cache::increment('demostop_gen:' . $mapName);
+        }
     }
 
     /**

--- a/app/Services/Comps/SubmissionValidator.php
+++ b/app/Services/Comps/SubmissionValidator.php
@@ -222,9 +222,18 @@ class SubmissionValidator
             // Not through `$submission->demo`: that relation runs into the
             // global scope which hides exactly the demo we are holding, so it
             // answers null and the release would silently not happen.
-            UploadedDemo::withUnreleasedComps()
-                ->whereKey($submission->uploaded_demo_id)
-                ->update(['comps_hidden_until' => null]);
+            $demo = UploadedDemo::withUnreleasedComps()->find($submission->uploaded_demo_id);
+
+            if ($demo) {
+                UploadedDemo::withUnreleasedComps()
+                    ->whereKey($demo->id)
+                    ->update(['comps_hidden_until' => null]);
+
+                // A query-builder update fires no model events, so the map's
+                // Demos Top would keep the run hidden for another hour after
+                // it was let out.
+                UploadedDemo::forgetDemosTop($demo->map_name);
+            }
 
             $submission->delete();
 

--- a/app/Services/Comps/SubmissionValidator.php
+++ b/app/Services/Comps/SubmissionValidator.php
@@ -47,6 +47,20 @@ class SubmissionValidator
     private const IN_FLIGHT = ['uploaded', 'processing'];
 
     /**
+     * The parser read the demo, and noted a cvar that was not what it should
+     * be - `pmove_fixed 0`, a timescale, an unconfirmed finish.
+     *
+     * NOT an unreadable file, however much the name suggests it. The rest of
+     * the site is explicit about this: the map page lists these demos beside
+     * the clean ones because "it deviated on some cvar" is not "it is
+     * unusable". Comps left the status out of PARSED and it fell through to
+     * the last branch, so a run whose time, map, physics and offending cvar
+     * were all known came back as "The demo could not be read." - to the one
+     * person who could have fixed their config if anybody had said which cvar.
+     */
+    public const FLAGGED = 'failed-validity';
+
+    /**
      * Settle every pending entry hanging off a finished upload.
      */
     public function settleFor(UploadedDemo $demo): void
@@ -69,7 +83,13 @@ class SubmissionValidator
             return;
         }
 
-        if (! in_array($demo->status, self::PARSED, true)) {
+        // A flagged demo goes on through the checks below rather than being
+        // refused here: its map, physics and time are all known, so it can be
+        // told exactly what was wrong with it, and the note is only the last
+        // of the reasons it does not count.
+        $flagged = $demo->status === self::FLAGGED;
+
+        if (! $flagged && ! in_array($demo->status, self::PARSED, true)) {
             $this->reject($submission, __('The demo could not be read.'), releasable: true);
 
             return;
@@ -112,6 +132,15 @@ class SubmissionValidator
             return;
         }
 
+        // A real run of this round's map, and it still does not count. Said
+        // with the cvar named, and never released: an entry somebody can read
+        // and report beats a demo that quietly went public.
+        if ($flagged) {
+            $this->reject($submission, $this->validityReason($demo));
+
+            return;
+        }
+
         if (! $demo->time_ms) {
             $this->reject($submission, __('No finish time was found in this demo.'));
 
@@ -134,6 +163,27 @@ class SubmissionValidator
         ]);
 
         Log::info("[comps] submission {$submission->id} accepted: {$physics} {$demo->time_ms}ms");
+    }
+
+    /**
+     * The refusal a flagged demo carries, naming the cvars that were noted.
+     *
+     * The note itself is not a cheating verdict - `client_finish` only says the
+     * finish was not confirmed client-side - so the sentence says what was
+     * seen, not what it means, and leaves the judgement to whoever the person
+     * reports it to.
+     *
+     * Lives here rather than on UploadGuard because both routes refuse the same
+     * demo for the same reason, and two wordings for one verdict is how the
+     * automatic path came to tell the truth while the form did not.
+     */
+    public function validityReason(UploadedDemo $demo): string
+    {
+        $flags = collect((array) $demo->validity)->keys()->implode(', ');
+
+        return $flags === ''
+            ? __('This demo did not pass the validity check, so it does not count in comps.')
+            : __('This demo carries a validity note (:flags), so it does not count in comps.', ['flags' => $flags]);
     }
 
     /**

--- a/app/Services/Comps/UploadGuard.php
+++ b/app/Services/Comps/UploadGuard.php
@@ -172,6 +172,10 @@ class UploadGuard
                 ->whereNotNull('comps_hidden_until')
                 ->whereRaw('LOWER(map_name) = ?', [mb_strtolower(trim($roundMap->map->name))])
                 ->update(['comps_hidden_until' => null]);
+
+            // A query-builder update fires no model events, and this is the
+            // moment a whole round's runs are supposed to appear at once.
+            UploadedDemo::forgetDemosTop($roundMap->map->name);
         }
 
         return $released;
@@ -458,6 +462,12 @@ class UploadGuard
         // the same demo twice before the first pass reached its own check.
         $demo->comps_hidden_until = $until;
         $demo->saveQuietly();
+
+        // saveQuietly skips the model's own events, so the map's Demos Top
+        // cache is retired here instead. Without it the run stays on the page
+        // for up to an hour after it was hidden, which for a comps map is the
+        // whole hour that mattered.
+        UploadedDemo::forgetDemosTop($demo->map_name);
     }
 
     private function alreadyEntered(UploadedDemo $demo): bool
@@ -535,6 +545,10 @@ class UploadGuard
 
         // Quietly, for the same reason holdUntil is - see the note there.
         $demo->saveQuietly();
+
+        // Same as holdUntil, in the other direction: the run has to come back
+        // to the map page, and nothing else will put it there.
+        UploadedDemo::forgetDemosTop($demo->map_name);
     }
 
     /**

--- a/app/Services/Comps/UploadGuard.php
+++ b/app/Services/Comps/UploadGuard.php
@@ -40,7 +40,7 @@ use Illuminate\Support\Facades\Log;
 class UploadGuard
 {
     /** Parser outcome for a demo it read, but which carries a cvar note. */
-    private const FLAGGED = 'failed-validity';
+    private const FLAGGED = SubmissionValidator::FLAGGED;
 
     /** Parser outcome for a demo it could not read at all. */
     private const UNREADABLE = 'failed';
@@ -147,23 +147,6 @@ class UploadGuard
         }
 
         return $adopted;
-    }
-
-    /**
-     * The refusal a flagged demo carries, naming the cvars that were noted.
-     *
-     * The note itself is not a cheating verdict - `client_finish` only says the
-     * finish was not confirmed client-side - so the sentence says what was
-     * seen, not what it means, and leaves the judgement to whoever the person
-     * reports it to.
-     */
-    private function validityReason(UploadedDemo $demo): string
-    {
-        $flags = collect((array) $demo->validity)->keys()->implode(', ');
-
-        return $flags === ''
-            ? __('This demo did not pass the validity check, so it does not count in comps.')
-            : __('This demo carries a validity note (:flags), so it does not count in comps.', ['flags' => $flags]);
     }
 
     /**
@@ -377,7 +360,7 @@ class UploadGuard
             'uploaded_demo_id' => $demo->id,
             'is_highlight' => false,
             'status' => $flagged ? 'invalid' : 'pending',
-            'invalid_reason' => $flagged ? $this->validityReason($demo) : null,
+            'invalid_reason' => $flagged ? $this->validator->validityReason($demo) : null,
             // The person did not choose this, the site did. Same flag the
             // launcher's guesses carry, and it means the same thing: if this
             // turns out not to be a run of the map, undo it rather than leave

--- a/app/Services/DemosTopService.php
+++ b/app/Services/DemosTopService.php
@@ -30,9 +30,32 @@ class DemosTopService
     public function buildReps(string $mapName, string $physicsPattern, array $mainRecordIds = [], ?DemoProfileResolver $resolver = null): Collection
     {
 
+        // Demos comps is holding on this map, so pool 1 can leave them out.
+        //
+        // offline_records is its own table and carries no comps scope, so a run
+        // held back for a running round still had a row here and the map page
+        // printed its time - the one number the round exists to keep quiet.
+        // The FILE was never at risk: the demo behind the row is scoped away,
+        // which is why there was nothing to download and why this looked
+        // harmless. But a rival only needs the number, and on lovet-fifth the
+        // target time of a live round sat on the public page for two days.
+        //
+        // Pools 2 and 3 read uploaded_demos and the global scope covers them.
+        $heldDemoIds = UploadedDemo::withUnreleasedComps()
+            ->whereRaw('LOWER(map_name) = ?', [mb_strtolower(trim($mapName))])
+            ->whereNotNull('comps_hidden_until')
+            ->where('comps_hidden_until', '>', now())
+            ->pluck('id')
+            ->all();
+
         // Pool 1: offline_records (with demo eager-loaded so we can read q3df signals)
         $offline = OfflineRecord::where('map_name', $mapName)
             ->where('physics', 'LIKE', $physicsPattern)
+            // Rows with no demo at all stay: `NOT IN` answers null for a null
+            // demo_id, which would drop every one of them instead.
+            ->when($heldDemoIds, fn ($q) => $q->where(
+                fn ($w) => $w->whereNull('demo_id')->orWhereNotIn('demo_id', $heldDemoIds)
+            ))
             ->with([
                 // Whole row, not a column list: the record chips hand this demo
                 // to the details panel, which needs physics, gametype, time,

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Klikni na hvězdičku u serveru a zůstane ti nahoře na téhle stránce.",
     "Weekly comps": "Týdenní comps",
     "Vote now ->": "Hlasuj ->",
-    "Most watched player wins": "Nejsledovanější hráč bere"
+    "Most watched player wins": "Nejsledovanější hráč bere",
+    "A comps entry. Hidden from the public until the round ends.": "Přihláška do comps. Veřejnost ji neuvidí, dokud kolo neskončí.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Odhlášeno z comps tím, kdo demo nahrál. Veřejnost ho neuvidí, dokud kolo neskončí.",
+    "comps hold": "zadrženo comps",
+    "withdrawn": "odhlášeno"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Klick bei einem Server auf den Stern, dann bleibt er oben auf dieser Seite.",
     "Weekly comps": "Wöchentliche Comps",
     "Vote now ->": "Jetzt abstimmen ->",
-    "Most watched player wins": "Meistgesehener Spieler gewinnt"
+    "Most watched player wins": "Meistgesehener Spieler gewinnt",
+    "A comps entry. Hidden from the public until the round ends.": "Ein Comps-Beitrag. Bis zum Ende der Runde nicht öffentlich sichtbar.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Vom Uploader aus den Comps genommen. Bis zum Ende der Runde nicht öffentlich sichtbar.",
+    "comps hold": "comps-sperre",
+    "withdrawn": "zurückgezogen"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Pulsa la estrella de un servidor y se quedará arriba en esta página.",
     "Weekly comps": "Comps semanales",
     "Vote now ->": "Vota ahora ->",
-    "Most watched player wins": "El jugador más visto gana"
+    "Most watched player wins": "El jugador más visto gana",
+    "A comps entry. Hidden from the public until the round ends.": "Una inscripción de comps. Oculta al público hasta que termine la ronda.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Retirado de comps por quien lo subió. Oculto al público hasta que termine la ronda.",
+    "comps hold": "retenido por comps",
+    "withdrawn": "retirado"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Clique sur l'étoile d'un serveur et il restera en haut de cette page.",
     "Weekly comps": "Comps hebdomadaires",
     "Vote now ->": "Voter maintenant ->",
-    "Most watched player wins": "Le joueur le plus regardé gagne"
+    "Most watched player wins": "Le joueur le plus regardé gagne",
+    "A comps entry. Hidden from the public until the round ends.": "Une participation aux comps. Masquée au public jusqu'à la fin de la manche.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Retiré des comps par la personne qui l'a envoyé. Masqué au public jusqu'à la fin de la manche.",
+    "comps hold": "retenu par comps",
+    "withdrawn": "retiré"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Klik op de ster bij een server, dan blijft hij bovenaan deze pagina.",
     "Weekly comps": "Wekelijkse comps",
     "Vote now ->": "Stem nu ->",
-    "Most watched player wins": "Meest bekeken speler wint"
+    "Most watched player wins": "Meest bekeken speler wint",
+    "A comps entry. Hidden from the public until the round ends.": "Een comps-inzending. Verborgen voor het publiek tot de ronde eindigt.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Uit comps gehaald door de uploader. Verborgen voor het publiek tot de ronde eindigt.",
+    "comps hold": "vastgehouden voor comps",
+    "withdrawn": "ingetrokken"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Kliknij gwiazdkę przy serwerze, a zostanie na górze tej strony.",
     "Weekly comps": "Cotygodniowe comps",
     "Vote now ->": "Zagłosuj teraz ->",
-    "Most watched player wins": "Najczęściej oglądany gracz wygrywa"
+    "Most watched player wins": "Najczęściej oglądany gracz wygrywa",
+    "A comps entry. Hidden from the public until the round ends.": "Zgłoszenie do comps. Ukryte przed publicznością do końca rundy.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Wycofane z comps przez osobę, która je wysłała. Ukryte przed publicznością do końca rundy.",
+    "comps hold": "wstrzymane przez comps",
+    "withdrawn": "wycofane"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Нажми на звёздочку у сервера, и он останется наверху этой страницы.",
     "Weekly comps": "Еженедельные comps",
     "Vote now ->": "Голосовать ->",
-    "Most watched player wins": "Самый просматриваемый игрок получает"
+    "Most watched player wins": "Самый просматриваемый игрок получает",
+    "A comps entry. Hidden from the public until the round ends.": "Заявка на comps. Скрыта от всех до конца раунда.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Снято с comps тем, кто его загрузил. Скрыто от всех до конца раунда.",
+    "comps hold": "удержано comps",
+    "withdrawn": "снято"
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Klicka på stjärnan vid en server, så stannar den högst upp på sidan.",
     "Weekly comps": "Veckans comps",
     "Vote now ->": "Rösta nu ->",
-    "Most watched player wins": "Spelaren med flest tittartimmar vinner"
+    "Most watched player wins": "Spelaren med flest tittartimmar vinner",
+    "A comps entry. Hidden from the public until the round ends.": "Ett comps-bidrag. Dolt för allmänheten tills rundan är slut.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Borttaget från comps av den som laddade upp det. Dolt för allmänheten tills rundan är slut.",
+    "comps hold": "hålls för comps",
+    "withdrawn": "tillbakadraget"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4214,5 +4214,9 @@
     "Click the star on a server to keep it at the top of this page.": "Натисни зірочку біля сервера, і він лишиться вгорі цієї сторінки.",
     "Weekly comps": "Щотижневі comps",
     "Vote now ->": "Голосувати ->",
-    "Most watched player wins": "Гравець, за яким спостерігали найбільше, отримує"
+    "Most watched player wins": "Гравець, за яким спостерігали найбільше, отримує",
+    "A comps entry. Hidden from the public until the round ends.": "Заявка на comps. Прихована від усіх до кінця раунду.",
+    "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Знято з comps тим, хто його завантажив. Приховано від усіх до кінця раунду.",
+    "comps hold": "утримано comps",
+    "withdrawn": "знято"
 }

--- a/resources/js/Pages/Demos/Index.vue
+++ b/resources/js/Pages/Demos/Index.vue
@@ -2383,6 +2383,22 @@ watch(selectedPhysics, () => {
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                                     </svg>
                                                 </span>
+                                                <!-- A demo comps is holding is missing from the public
+                                                     site on purpose. Only this list and the admin's own
+                                                     show it, so this chip is the only place the reason
+                                                     is ever said. -->
+                                                <span
+                                                    v-if="demo.comps_hold"
+                                                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold cursor-help"
+                                                    :class="demo.comps_hold === 'withdrawn'
+                                                        ? 'bg-gray-500/20 text-gray-300'
+                                                        : 'bg-amber-500/20 text-amber-300'"
+                                                    :title="demo.comps_hold === 'withdrawn'
+                                                        ? $t('Taken out of comps by its uploader. Hidden from the public until the round ends.')
+                                                        : $t('A comps entry. Hidden from the public until the round ends.')"
+                                                >
+                                                    {{ demo.comps_hold === 'withdrawn' ? $t('withdrawn') : $t('comps hold') }}
+                                                </span>
                                                 <span
                                                     v-if="demo.match_method"
                                                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"


### PR DESCRIPTION
Three fixes to how comps treats a held demo.

A demo the parser read but flagged for a cvar was refused as "The demo could not be read." The automatic route already named the cvar; the form did not. Both now use the same sentence.

A run held for a running round still had an offline_records row, so the map page printed its time. The file was safe, the number was not.

A held or withdrawn demo now appears in its uploader's own list and in the admin list, labelled. Download already allowed both; there was nothing left to click.

Needs a re-settle of the existing refused entries after deploy.