### PR TITLE
Comps: fix a framerate rule that never ran, and say what a refusal means

### DIFF
--- a/app/Filament/Pages/CompsRoundReview.php
+++ b/app/Filament/Pages/CompsRoundReview.php
@@ -8,6 +8,7 @@ use App\Models\CompSubmission;
 use App\Models\OfflineRecord;
 use App\Models\UploadedDemo;
 use App\Services\Comps\UploadGuard;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Support\Collection;
 
@@ -22,7 +23,11 @@ use Illuminate\Support\Collection;
  * other physics. Those are invisible everywhere else precisely because they
  * are not entries, and they are what people ask about.
  *
- * Nothing here changes anything. It is a place to look before answering.
+ * Almost nothing here changes anything - it is a place to look before
+ * answering. The one exception is putting a withdrawn run back, which belongs
+ * on this page because this is the only screen a withdrawn run appears on at
+ * all: withdrawing deletes the entry, so the submissions table has no row to
+ * act on.
  */
 class CompsRoundReview extends Page
 {
@@ -137,6 +142,7 @@ class CompsRoundReview extends Page
                     default => 'danger',
                 },
                 'reason' => $entry->invalid_reason,
+                'restorable' => false,
                 'entered' => true,
                 'auto' => (bool) $entry->auto_entered,
                 'online' => (bool) $entry->is_online,
@@ -154,6 +160,10 @@ class CompsRoundReview extends Page
             $rows->push([
                 'user' => $demo->user?->name ?? ('#' . $demo->user_id),
                 'demo_id' => $demo->id,
+                // Only while the round is still taking uploads. Afterwards the
+                // standings are frozen and putting a run back would rewrite a
+                // result everybody has already seen.
+                'restorable' => $kind === 'withdrawn' && $round->acceptsUploads(),
                 'filename' => $demo->original_filename,
                 'physics' => $demo->physics,
                 'time' => $demo->time_ms ?: null,
@@ -253,6 +263,68 @@ class CompsRoundReview extends Page
         }
 
         return $round->status === 'active' ? $guard->noticeKind($demo) : 'not_entered';
+    }
+
+    /**
+     * Put a run somebody withdrew back into the round, on their request.
+     *
+     * Withdrawing is one-way by design: the guard refuses to re-enter a demo
+     * it sees a withdrawal stamp on, so that a re-parse cannot quietly undo
+     * somebody's decision. This is the deliberate exception, and it is an
+     * admin action rather than a button for the player, because a run that
+     * can be pulled and pushed back at will is a way to play with the
+     * standings rather than with the map.
+     *
+     * The stamp comes off and the guard is asked to do the entering, so the
+     * run goes through the same map, physics and window checks as any other.
+     * If the guard still says no, the stamp goes back on and nothing has
+     * changed - the alternative is a demo left in neither state.
+     */
+    public function restore(int $demoId): void
+    {
+        abort_unless(auth()->user()?->isAdmin(), 403);
+
+        $round = $this->round();
+
+        abort_unless($round && $round->acceptsUploads(), 403);
+
+        $demo = UploadedDemo::withUnreleasedComps()->find($demoId);
+
+        if (! $demo || ! $demo->comps_withdrawn_at) {
+            Notification::make()->danger()->title('That demo is not withdrawn.')->send();
+
+            return;
+        }
+
+        $stamp = $demo->comps_withdrawn_at;
+
+        $demo->comps_withdrawn_at = null;
+        $demo->saveQuietly();
+
+        app(UploadGuard::class)->apply($demo->fresh());
+
+        $entry = CompSubmission::where('comp_round_id', $round->id)
+            ->where('uploaded_demo_id', $demo->id)
+            ->first();
+
+        if (! $entry) {
+            $demo->comps_withdrawn_at = $stamp;
+            $demo->saveQuietly();
+
+            Notification::make()
+                ->danger()
+                ->title('The guard would not take it back.')
+                ->body('The run is older than the round, or it is on the wrong map or physics. Nothing was changed.')
+                ->send();
+
+            return;
+        }
+
+        Notification::make()
+            ->success()
+            ->title('Back in the round.')
+            ->body('Entry #' . $entry->id . ': ' . $entry->status . ($entry->invalid_reason ? ' - ' . $entry->invalid_reason : ''))
+            ->send();
     }
 
     /** m:ss.mmm, the way every other comps screen prints a time. */

--- a/app/Filament/Pages/CompsRoundReview.php
+++ b/app/Filament/Pages/CompsRoundReview.php
@@ -143,6 +143,10 @@ class CompsRoundReview extends Page
                     default => 'danger',
                 },
                 'reason' => $entry->invalid_reason,
+                // What the parser literally wrote down, for the hover. The
+                // sentence above explains it; this is the raw pair, which is
+                // what somebody comparing two demos actually wants to read.
+                'notes' => $this->rawNotes($demo),
                 'restorable' => false,
                 'entered' => true,
                 'auto' => (bool) $entry->auto_entered,
@@ -185,6 +189,7 @@ class CompsRoundReview extends Page
                     'other_physics' => 'A run on this map in the other physics. Public straight away.',
                     default => $guard->noticeText($kind),
                 },
+                'notes' => $this->rawNotes($demo),
                 'entered' => false,
                 'auto' => false,
                 'online' => ! $demo->is_offline,
@@ -326,6 +331,22 @@ class CompsRoundReview extends Page
             ->title('Back in the round.')
             ->body('Entry #' . $entry->id . ': ' . $entry->status . ($entry->invalid_reason ? ' - ' . $entry->invalid_reason : ''))
             ->send();
+    }
+
+    /** `pmove_fixed=0, com_maxfps=333`, or null when the demo is clean. */
+    private function rawNotes(?UploadedDemo $demo): ?string
+    {
+        $validity = (array) ($demo?->validity ?? []);
+
+        if (! $validity) {
+            return null;
+        }
+
+        return implode(', ', array_map(
+            fn ($key, $value) => $key . '=' . $value,
+            array_keys($validity),
+            $validity
+        ));
     }
 
     /**

--- a/app/Filament/Pages/CompsRoundReview.php
+++ b/app/Filament/Pages/CompsRoundReview.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Filament\Resources\UserResource;
 use App\Models\CompDemoReport;
 use App\Models\CompRound;
 use App\Models\CompSubmission;
@@ -325,6 +326,16 @@ class CompsRoundReview extends Page
             ->title('Back in the round.')
             ->body('Entry #' . $entry->id . ': ' . $entry->status . ($entry->invalid_reason ? ' - ' . $entry->invalid_reason : ''))
             ->send();
+    }
+
+    /**
+     * The nick with its Quake colour codes rendered, the way the rest of the
+     * admin shows a name. Grouping still happens on the raw string, so two
+     * spellings of the same colours never split into two people.
+     */
+    public function nick(string $name): string
+    {
+        return UserResource::q3tohtml($name);
     }
 
     /** m:ss.mmm, the way every other comps screen prints a time. */

--- a/app/Filament/Resources/CompDemoReportResource.php
+++ b/app/Filament/Resources/CompDemoReportResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\CompDemoReportResource\Pages;
+use App\Filament\Resources\UserResource;
 use App\Models\CompDemoReport;
 use App\Services\Comps\ResultsCalculator;
 use Filament\Notifications\Notification;
@@ -64,7 +65,9 @@ class CompDemoReportResource extends Resource
                 Tables\Columns\TextColumn::make('runner')
                     ->label('Run by')
                     ->weight('bold')
-                    ->getStateUsing(fn (CompDemoReport $r) => $r->submission?->user?->name ?? $r->demo?->user?->name ?? '-'),
+                    ->getStateUsing(fn (CompDemoReport $r) => $r->submission?->user?->name ?? $r->demo?->user?->name ?? '-')
+                    ->formatStateUsing(fn (?string $state): string => $state && $state !== '-' ? UserResource::q3tohtml($state) : '-')
+                    ->html(),
 
                 Tables\Columns\TextColumn::make('demo.original_filename')
                     ->label('Demo')
@@ -88,7 +91,9 @@ class CompDemoReportResource extends Resource
 
                 Tables\Columns\TextColumn::make('reporter.name')
                     ->label('Reported by')
-                    ->searchable(),
+                    ->searchable()
+                    ->formatStateUsing(fn (?string $state): string => $state ? UserResource::q3tohtml($state) : '-')
+                    ->html(),
 
                 Tables\Columns\TextColumn::make('reason')
                     ->limit(60)

--- a/app/Filament/Resources/CompMapReportResource.php
+++ b/app/Filament/Resources/CompMapReportResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\CompMapReportResource\Pages;
+use App\Filament\Resources\UserResource;
 use App\Models\CompMapReport;
 use App\Services\Comps\MapEligibilityTagger;
 use Filament\Notifications\Notification;
@@ -62,7 +63,9 @@ class CompMapReportResource extends Resource
 
                 Tables\Columns\TextColumn::make('reporter.name')
                     ->label('Reported by')
-                    ->searchable(),
+                    ->searchable()
+                    ->formatStateUsing(fn (?string $state): string => $state ? UserResource::q3tohtml($state) : '-')
+                    ->html(),
 
                 Tables\Columns\TextColumn::make('round.comp.number')
                     ->label('Comp')

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -149,7 +149,9 @@ class UserResource extends Resource
                     $i++;
                 }
             } else {
-                $colored_name .= '<span class="q3c-' . $color . '">' . $name[$i] . '</span>';
+                // Escaped: a nick is whatever somebody typed, and this now
+                // renders on a dozen admin screens instead of one.
+                $colored_name .= '<span class="q3c-' . $color . '">' . htmlspecialchars($name[$i], ENT_QUOTES, 'UTF-8') . '</span>';
             }
         }
 

--- a/app/Services/Comps/SubmissionValidator.php
+++ b/app/Services/Comps/SubmissionValidator.php
@@ -166,6 +166,29 @@ class SubmissionValidator
     }
 
     /**
+     * What each noted cvar should have been.
+     *
+     * Mirrors the parser's own rules (DemoProcessor/bin/demo.py,
+     * `_check_validity`). Kept here so the refusal can say what the value
+     * should be rather than only that it was wrong - a person who is told
+     * "pmove_fixed" has to go and find out what pmove_fixed is supposed to be,
+     * and most will not.
+     */
+    private const EXPECTED = [
+        'sv_cheats' => '0',
+        'timescale' => '1',
+        'g_speed' => '320',
+        'g_gravity' => '800',
+        'handicap' => '100',
+        'g_knockback' => '1000',
+        'df_mp_interferenceoff' => '3',
+        'sv_fps' => '125',
+        'com_maxfps' => '125',
+        'pmove_msec' => '8',
+        'g_killWallbug' => '1',
+    ];
+
+    /**
      * The refusal a flagged demo carries, naming the cvars that were noted.
      *
      * The note itself is not a cheating verdict - `client_finish` only says the
@@ -179,11 +202,54 @@ class SubmissionValidator
      */
     public function validityReason(UploadedDemo $demo): string
     {
-        $flags = collect((array) $demo->validity)->keys()->implode(', ');
+        $notes = [];
 
-        return $flags === ''
-            ? __('This demo did not pass the validity check, so it does not count in comps.')
-            : __('This demo carries a validity note (:flags), so it does not count in comps.', ['flags' => $flags]);
+        foreach ((array) $demo->validity as $key => $value) {
+            $notes[] = $this->explainNote((string) $key, (string) $value);
+        }
+
+        if (! $notes) {
+            return __('This demo did not pass the validity check, so it does not count in comps.');
+        }
+
+        return __('This demo does not count in comps. :notes', ['notes' => implode(' ', $notes)]);
+    }
+
+    /**
+     * One noted cvar, in a sentence somebody can act on.
+     *
+     * Says the value that was in the demo and the value it should have been,
+     * because the whole point is that the person can go and fix their config.
+     * `pmove_fixed` gets a longer sentence than the rest: it is the only rule
+     * with two legal answers, and being told to set it to 1 while running the
+     * dfcomp ruleset - which deliberately keeps it at 0 - would be wrong.
+     */
+    private function explainNote(string $key, string $value): string
+    {
+        if ($key === 'client_finish') {
+            return __('The finish was not confirmed inside the demo, so the time cannot be read from it.');
+        }
+
+        if ($key === 'tool_assisted') {
+            return __('The run was recorded with tool assistance.');
+        }
+
+        if ($key === 'pmove_fixed') {
+            return __('pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.', ['actual' => $value]);
+        }
+
+        if (isset(self::EXPECTED[$key])) {
+            return __(':cvar was :actual, and it has to be :expected.', [
+                'cvar' => $key,
+                'actual' => $value,
+                'expected' => self::EXPECTED[$key],
+            ]);
+        }
+
+        return __(':cvar was :actual, which is not what comps expects.', [
+            'cvar' => $key,
+            'actual' => $value,
+        ]);
     }
 
     /**

--- a/app/Services/DemoProcessor/bin/raw_info.py
+++ b/app/Services/DemoProcessor/bin/raw_info.py
@@ -103,7 +103,7 @@ class RawInfo:
     # ------------------------------------------------------------------
     def _build_game_info(self) -> GameInfo:
         client_cfg = split_config(self.rawConfig.get(const.Q3_DEMO_CFG_FIELD_CLIENT)) if self.rawConfig.get(const.Q3_DEMO_CFG_FIELD_CLIENT) else {}
-        game_cfg = split_config(self.rawConfig.get(const.Q3_DEMO_CFG_FIELD_GAME)) if self.rawConfig.get(const.Q3_DEMO_CFG_FIELD_GAME) else {}
+        game_cfg = self._split_config_game(self.rawConfig.get(const.Q3_DEMO_CFG_FIELD_GAME)) if self.rawConfig.get(const.Q3_DEMO_CFG_FIELD_GAME) else {}
         additional = self.consoleComandsParser.additionalInfos[-1].toDictionary() if self.consoleComandsParser.additionalInfos else {}
         parameters = Ext.JoinLowercased(client_cfg, game_cfg, additional)
         return GameInfo(parameters, self.client.isCpmInSnapshots)
@@ -147,6 +147,30 @@ class RawInfo:
             if prev.eventStartTime or prev.eventTimeReset:
                 return True
         return False
+
+    # ------------------------------------------------------------------
+    def _split_config_game(self, src: str) -> Dict[str, str]:
+        """The game config, with DeFRaG's own names for two cvars put back.
+
+        DeFRaG does not publish `sv_fps` and `com_maxfps` in the systeminfo -
+        it publishes the same two numbers under `defrag_svfps` and
+        `defrag_clfps`. DemoCleaner3 renames them on the way in
+        (RawInfo.cs split_config_game), and this port did not, so the two
+        validity rules that ask for them found nothing and passed everything.
+
+        They were not entirely dead: DeFRaG also sends the pair inside the
+        `TimerStopped` stats message, and that arrives later in the join, so it
+        still wins where it exists. But plenty of demos carry no TimerStopped
+        at all, and those had their framerate checked against nothing. Somebody
+        running offline at 333 fps went through clean.
+        """
+        split = ListMap(split_config(src))
+        Ext.replaceKeys(split, {
+            'defrag_clfps': 'com_maxfps',
+            'defrag_svfps': 'sv_fps',
+        })
+
+        return split.ToDictionary()
 
     # ------------------------------------------------------------------
     def _split_config_player(self, src: str) -> Dict[str, str]:

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Přihláška do comps. Veřejnost ji neuvidí, dokud kolo neskončí.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Odhlášeno z comps tím, kdo demo nahrál. Veřejnost ho neuvidí, dokud kolo neskončí.",
     "comps hold": "zadrženo comps",
-    "withdrawn": "odhlášeno"
+    "withdrawn": "odhlášeno",
+    "This demo does not count in comps. :notes": "Tohle demo se v comps nepočítá. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "Dojezd není v demu potvrzený, takže z něj čas nejde přečíst.",
+    "The run was recorded with tool assistance.": "Běh byl nahraný s pomocí nástroje.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed bylo :actual. Musí být 1, nebo místo toho musí být 1 v g_synchronousClients. Jedno z toho musí držet krok fyziky pevný, jinak o délce skoku rozhoduje framerate.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar bylo :actual, a musí být :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar bylo :actual, což comps nečeká."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Ein Comps-Beitrag. Bis zum Ende der Runde nicht öffentlich sichtbar.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Vom Uploader aus den Comps genommen. Bis zum Ende der Runde nicht öffentlich sichtbar.",
     "comps hold": "comps-sperre",
-    "withdrawn": "zurückgezogen"
+    "withdrawn": "zurückgezogen",
+    "This demo does not count in comps. :notes": "Dieses Demo zählt nicht in den Comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "Das Ziel ist im Demo nicht bestätigt, daher lässt sich die Zeit nicht daraus lesen.",
+    "The run was recorded with tool assistance.": "Der Lauf wurde mit Werkzeugunterstützung aufgezeichnet.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed war :actual. Es muss 1 sein, oder stattdessen muss g_synchronousClients 1 sein - eines von beiden muss den Physikschritt konstant halten, sonst entscheidet die Bildrate, wie weit du springst.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar war :actual, und es muss :expected sein.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar war :actual, was die Comps nicht erwarten."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Una inscripción de comps. Oculta al público hasta que termine la ronda.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Retirado de comps por quien lo subió. Oculto al público hasta que termine la ronda.",
     "comps hold": "retenido por comps",
-    "withdrawn": "retirado"
+    "withdrawn": "retirado",
+    "This demo does not count in comps. :notes": "Esta demo no cuenta en comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "La meta no está confirmada dentro de la demo, así que el tiempo no se puede leer de ella.",
+    "The run was recorded with tool assistance.": "La carrera se grabó con asistencia de herramientas.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed era :actual. Tiene que ser 1, o en su lugar g_synchronousClients tiene que ser 1: uno de los dos tiene que mantener fijo el paso de la física, o los fotogramas por segundo deciden lo lejos que saltas.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar era :actual, y tiene que ser :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar era :actual, que no es lo que comps espera."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Une participation aux comps. Masquée au public jusqu'à la fin de la manche.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Retiré des comps par la personne qui l'a envoyé. Masqué au public jusqu'à la fin de la manche.",
     "comps hold": "retenu par comps",
-    "withdrawn": "retiré"
+    "withdrawn": "retiré",
+    "This demo does not count in comps. :notes": "Cette démo ne compte pas dans les comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "L'arrivée n'est pas confirmée dans la démo, donc le temps ne peut pas en être lu.",
+    "The run was recorded with tool assistance.": "La course a été enregistrée avec assistance logicielle.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed valait :actual. Il doit être à 1, ou alors g_synchronousClients doit être à 1 - l'un des deux doit garder le pas de la physique constant, sinon le nombre d'images par seconde décide de la longueur de vos sauts.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar valait :actual, et il doit être à :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar valait :actual, ce que les comps n'attendent pas."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Een comps-inzending. Verborgen voor het publiek tot de ronde eindigt.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Uit comps gehaald door de uploader. Verborgen voor het publiek tot de ronde eindigt.",
     "comps hold": "vastgehouden voor comps",
-    "withdrawn": "ingetrokken"
+    "withdrawn": "ingetrokken",
+    "This demo does not count in comps. :notes": "Deze demo telt niet mee in comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "De finish is niet bevestigd in de demo, dus de tijd kan er niet uit gelezen worden.",
+    "The run was recorded with tool assistance.": "De run is opgenomen met hulp van een tool.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed was :actual. Het moet 1 zijn, of anders moet g_synchronousClients 1 zijn - een van de twee moet de physics-stap vast houden, anders bepaalt je framerate hoe ver je springt.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar was :actual, en het moet :expected zijn.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar was :actual, en dat verwacht comps niet."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Zgłoszenie do comps. Ukryte przed publicznością do końca rundy.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Wycofane z comps przez osobę, która je wysłała. Ukryte przed publicznością do końca rundy.",
     "comps hold": "wstrzymane przez comps",
-    "withdrawn": "wycofane"
+    "withdrawn": "wycofane",
+    "This demo does not count in comps. :notes": "To demo nie liczy się w comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "Meta nie jest potwierdzona w demie, więc nie da się z niego odczytać czasu.",
+    "The run was recorded with tool assistance.": "Przebieg nagrano z pomocą narzędzia.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed wynosiło :actual. Musi być 1 albo zamiast tego g_synchronousClients musi być 1 - jedno z nich musi utrzymywać stały krok fizyki, inaczej liczba klatek decyduje o tym, jak daleko skaczesz.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar wynosiło :actual, a musi być :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar wynosiło :actual, czego comps nie oczekuje."
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Заявка на comps. Скрыта от всех до конца раунда.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Снято с comps тем, кто его загрузил. Скрыто от всех до конца раунда.",
     "comps hold": "удержано comps",
-    "withdrawn": "снято"
+    "withdrawn": "снято",
+    "This demo does not count in comps. :notes": "Это демо не засчитывается в comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "Финиш не подтверждён внутри демо, поэтому время из него прочитать нельзя.",
+    "The run was recorded with tool assistance.": "Забег записан с помощью инструмента.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed был :actual. Он должен быть 1, либо вместо этого g_synchronousClients должен быть 1 - одно из двух должно держать шаг физики постоянным, иначе частота кадров решает, как далеко вы прыгнете.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar был :actual, а должен быть :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar был :actual, а comps этого не ожидает."
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Ett comps-bidrag. Dolt för allmänheten tills rundan är slut.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Borttaget från comps av den som laddade upp det. Dolt för allmänheten tills rundan är slut.",
     "comps hold": "hålls för comps",
-    "withdrawn": "tillbakadraget"
+    "withdrawn": "tillbakadraget",
+    "This demo does not count in comps. :notes": "Den här demon räknas inte i comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "Målgången är inte bekräftad i demon, så tiden går inte att läsa ur den.",
+    "The run was recorded with tool assistance.": "Loppet spelades in med hjälp av ett verktyg.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed var :actual. Den måste vara 1, eller så måste g_synchronousClients vara 1 i stället - en av de två måste hålla fysiksteget konstant, annars avgör bildfrekvensen hur långt du hoppar.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar var :actual, och den måste vara :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar var :actual, vilket comps inte förväntar sig."
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4218,5 +4218,11 @@
     "A comps entry. Hidden from the public until the round ends.": "Заявка на comps. Прихована від усіх до кінця раунду.",
     "Taken out of comps by its uploader. Hidden from the public until the round ends.": "Знято з comps тим, хто його завантажив. Приховано від усіх до кінця раунду.",
     "comps hold": "утримано comps",
-    "withdrawn": "знято"
+    "withdrawn": "знято",
+    "This demo does not count in comps. :notes": "Це демо не зараховується в comps. :notes",
+    "The finish was not confirmed inside the demo, so the time cannot be read from it.": "Фініш не підтверджено всередині демо, тож час із нього прочитати не можна.",
+    "The run was recorded with tool assistance.": "Забіг записано з допомогою інструмента.",
+    "pmove_fixed was :actual. It has to be 1, or g_synchronousClients has to be 1 instead - one of the two has to hold the physics step steady, or the framerate decides how far you jump.": "pmove_fixed було :actual. Воно має бути 1, або натомість g_synchronousClients має бути 1 - одне з двох має тримати крок фізики сталим, інакше частота кадрів вирішує, як далеко ви стрибнете.",
+    ":cvar was :actual, and it has to be :expected.": ":cvar було :actual, а має бути :expected.",
+    ":cvar was :actual, which is not what comps expects.": ":cvar було :actual, а comps цього не очікує."
 }

--- a/resources/views/filament/pages/comps-round-review.blade.php
+++ b/resources/views/filament/pages/comps-round-review.blade.php
@@ -52,7 +52,7 @@
         @forelse($players as $player)
             <div class="fi-section rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
                 <div class="flex items-center justify-between px-4 py-3 border-b border-gray-950/5 dark:border-white/10">
-                    <div class="text-sm font-extrabold">{{ $player['user'] }}</div>
+                    <div class="text-sm font-extrabold">{!! $this->nick($player['user']) !!}</div>
                     <div class="text-xs text-gray-500">
                         {{ count($player['rows']) }} {{ count($player['rows']) === 1 ? 'demo' : 'demos' }}
                         @if($player['problems'] > 0)

--- a/resources/views/filament/pages/comps-round-review.blade.php
+++ b/resources/views/filament/pages/comps-round-review.blade.php
@@ -79,7 +79,10 @@
                                     <td class="px-2 py-2">
                                         <div class="text-xs text-gray-700 dark:text-gray-300 break-all">{{ $row['filename'] }}</div>
                                         @if($row['reason'])
-                                            <div class="text-xs text-gray-500 mt-0.5">{{ $row['reason'] }}</div>
+                                            <div
+                                                class="text-xs text-gray-500 mt-0.5 @if($row['notes']) cursor-help @endif"
+                                                @if($row['notes']) title="The parser noted: {{ $row['notes'] }}" @endif
+                                            >{{ $row['reason'] }}</div>
                                         @endif
                                     </td>
 

--- a/resources/views/filament/pages/comps-round-review.blade.php
+++ b/resources/views/filament/pages/comps-round-review.blade.php
@@ -101,6 +101,18 @@
                                         @if($row['demo_id'])
                                             <a href="{{ route('demos.download', $row['demo_id']) }}" target="_blank" class="text-xs text-primary-600 hover:underline">demo</a>
                                         @endif
+
+                                        {{-- The only thing on this page that changes anything, and the
+                                             only screen a withdrawn run shows up on: withdrawing deletes
+                                             the entry, so the submissions table has no row to act on. --}}
+                                        @if($row['restorable'])
+                                            <button
+                                                type="button"
+                                                wire:click="restore({{ $row['demo_id'] }})"
+                                                wire:confirm="Put this run back into the round? Do this when the player has asked for it."
+                                                class="ml-2 text-xs font-semibold text-primary-600 hover:underline"
+                                            >put back</button>
+                                        @endif
                                     </td>
 
                                     <td class="px-4 py-2 w-32 text-right text-xs text-gray-500 whitespace-nowrap">


### PR DESCRIPTION
Four fixes, all found while answering one player's question.

DeFRaG writes the framerate into a demo as defrag_svfps and defrag_clfps. DemoCleaner3 renames those to sv_fps and com_maxfps; this port did not, so both rules looked up names no demo carries and passed everything. Verified against four real demos: values now read, no verdict changed, a synthetic 333 is refused.

A refusal now says the value found and the value needed, instead of only naming the cvar. pmove_fixed gets its own sentence because it has two legal answers.

An admin can put a withdrawn run back into a round on request. Withdrawing is one-way by design and nothing could undo it.

Nicks render their Quake colours on three more admin screens.

Needs a re-settle of refused entries after deploy, to pick up the new wording.