### PR TITLE
Tell a wish author when their wish is built

### DIFF
--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -115,6 +115,30 @@ class WishlistController extends Controller
         ]);
     }
 
+    /**
+     * Send somebody to one wish on the list.
+     *
+     * The board defaults to the open tab, so a finished wish is not on the
+     * page a bare /wishlist link opens - which is exactly the wish somebody is
+     * most likely to be sent a link to. This picks the tab the wish is under
+     * now, rather than the one it was under when the link was written, and
+     * marks it so the page can scroll to it and ring it for a moment.
+     *
+     * A redirect rather than a page of its own: one wish alone, out of the
+     * list it is being voted on in, tells you nothing about whether anyone
+     * else wanted it.
+     */
+    public function show(Wish $wish)
+    {
+        return redirect()->route('wishlist.index', array_filter([
+            // Only the closed tabs need naming. The open ones are the default
+            // view, and pinning the tab to `considering` would hide every
+            // other wish for no reason.
+            'status' => in_array($wish->status, Wish::OPEN_STATUSES, true) ? null : $wish->status,
+            'highlight' => $wish->id,
+        ]));
+    }
+
     public function store(Request $request)
     {
         $data = $request->validate([

--- a/app/Models/Wish.php
+++ b/app/Models/Wish.php
@@ -5,10 +5,47 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class Wish extends Model
 {
     use SoftDeletes;
+
+    /**
+     * Tell the author when their wish is built.
+     *
+     * On the model rather than at the admin action, because two places in the
+     * panel set a status - the one-field "Set status" action and the ordinary
+     * edit form - and a third will be added the day somebody wants a bulk one.
+     * Anywhere else, one of them forgets.
+     *
+     * Only `done`, and only when the status actually moves. Saving the same
+     * status again is what an admin does while writing the public answer, and
+     * it must not send the person a second notification each time.
+     */
+    protected static function booted(): void
+    {
+        static::updated(function (Wish $wish) {
+            if (! $wish->user_id || $wish->status !== 'done' || ! $wish->wasChanged('status')) {
+                return;
+            }
+
+            Notification::create([
+                'user_id' => $wish->user_id,
+                'type' => 'wish_done',
+                // The title carries the whole message: the notification list
+                // is a single line per row, and "your wish is done" without
+                // saying which wish is a notification you have to go and
+                // decode.
+                'headline' => Str::limit($wish->title, 90),
+                // /wishlist/<id>, not the list with a tab already chosen. The
+                // wish can move between tabs afterwards, and the redirect
+                // works the tab out at the moment somebody clicks - see
+                // WishlistController::show.
+                'url' => route('wishlist.show', $wish),
+            ]);
+        });
+    }
 
     /**
      * Screenshots go on the local public disk, not the community bucket: they

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Tvůj čas se porovná s nejrychlejším časem jiného hráče a vznikne poměr (reltime).",
     "Your time:": "Tvůj čas:",
     "Your Uploaded Demos": "Tvoje nahraná dema",
+    "Your wish is done:": "Tvoje přání je hotové:",
     "Yours truly,": "S pozdravem,",
     "YouTube": "YouTube",
     "YouTube link": "YouTube odkaz",

--- a/lang/de.json
+++ b/lang/de.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Deine Zeit wird mit der schnellsten Zeit eines anderen Spielers verglichen, um ein Verhältnis (Reltime) zu erhalten.",
     "Your time:": "Deine Zeit:",
     "Your Uploaded Demos": "Deine hochgeladenen Demos",
+    "Your wish is done:": "Dein Wunsch ist erledigt:",
     "Yours truly,": "Mit freundlichen Grüßen,",
     "YouTube": "YouTube",
     "YouTube link": "YouTube-Link",

--- a/lang/es.json
+++ b/lang/es.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Tu tiempo se compara con el tiempo más rápido de otro jugador para obtener una proporción (reltime).",
     "Your time:": "Tu tiempo:",
     "Your Uploaded Demos": "Tus demos subidas",
+    "Your wish is done:": "Tu deseo está hecho:",
     "Yours truly,": "Atentamente,",
     "YouTube": "YouTube",
     "YouTube link": "Enlace de YouTube",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Ton temps est comparé au temps le plus rapide d'un autre joueur pour obtenir un ratio (reltime).",
     "Your time:": "Ton temps :",
     "Your Uploaded Demos": "Tes demos téléversées",
+    "Your wish is done:": "Ton souhait est réalisé :",
     "Yours truly,": "Bien à toi,",
     "YouTube": "YouTube",
     "YouTube link": "Lien YouTube",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Je tijd wordt vergeleken met de snelste tijd van een andere speler om een verhouding te krijgen (reltime).",
     "Your time:": "Je tijd:",
     "Your Uploaded Demos": "Je geüploade demo's",
+    "Your wish is done:": "Je wens is klaar:",
     "Yours truly,": "Met vriendelijke groet,",
     "YouTube": "YouTube",
     "YouTube link": "YouTube-link",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Twój czas porównuje się z najszybszym czasem innego gracza, co daje stosunek (reltime).",
     "Your time:": "Twój czas:",
     "Your Uploaded Demos": "Twoje wysłane dema",
+    "Your wish is done:": "Twoje życzenie jest gotowe:",
     "Yours truly,": "Z pozdrowieniami,",
     "YouTube": "YouTube",
     "YouTube link": "Link do YouTube",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Твое время сравнивается с самым быстрым временем другого игрока для получения отношения (reltime).",
     "Your time:": "Твое время:",
     "Your Uploaded Demos": "Загруженные тобой демки",
+    "Your wish is done:": "Твоё пожелание выполнено:",
     "Yours truly,": "С уважением,",
     "YouTube": "YouTube",
     "YouTube link": "Ссылка на YouTube",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Din tid jämförs med den snabbaste tiden av en annan spelare för att få ett förhållande (reltime).",
     "Your time:": "Din tid:",
     "Your Uploaded Demos": "Dina uppladdade demor",
+    "Your wish is done:": "Din önskan är klar:",
     "Yours truly,": "Vänliga hälsningar,",
     "YouTube": "YouTube",
     "YouTube link": "YouTube-länk",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4105,6 +4105,7 @@
     "Your time is compared to the fastest time by another player to get a ratio (reltime).": "Твій час порівнюється з найшвидшим часом іншого гравця для отримання співвідношення (reltime).",
     "Your time:": "Твій час:",
     "Your Uploaded Demos": "Твої завантажені демки",
+    "Your wish is done:": "Твоє побажання виконано:",
     "Yours truly,": "З повагою,",
     "YouTube": "YouTube",
     "YouTube link": "Посилання на YouTube",

--- a/resources/js/Pages/NotificationsView.vue
+++ b/resources/js/Pages/NotificationsView.vue
@@ -312,6 +312,13 @@
                 borderColor: 'border-amber-500/30',
                 iconColor: 'text-amber-400'
             },
+            'wish_done': {
+                label: 'Wishlist',
+                icon: 'M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z',
+                bgColor: 'bg-fuchsia-500/20',
+                borderColor: 'border-fuchsia-500/30',
+                iconColor: 'text-fuchsia-400'
+            },
             'render_completed': {
                 label: 'Render Done',
                 icon: 'm15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z',
@@ -734,6 +741,10 @@
                                             </svg>
                                             <span v-html="q3tohtml(notification.headline)"></span>
                                         </a>
+                                    </template>
+                                    <template v-else-if="notification.type === 'wish_done'">
+                                        <span class="text-gray-400">{{ $t('Your wish is done:') }}</span>
+                                        <span class="ml-1.5 text-fuchsia-300 group-hover:text-fuchsia-200 group-hover:underline font-bold transition-colors" v-html="q3tohtml(notification.headline)"></span>
                                     </template>
                                     <template v-else>
                                         <span v-if="getNotificationPrefix(notification.type)" class="text-gray-400 mr-1.5">{{ getNotificationPrefix(notification.type) }}</span>

--- a/resources/js/Pages/Wishlist.vue
+++ b/resources/js/Pages/Wishlist.vue
@@ -8,7 +8,7 @@ export default {
 
 <script setup>
 import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
 import { currentLocale, t } from '@/utils/i18n';
 
 import EnglishOnlyNotice from '@/Components/EnglishOnlyNotice.vue';
@@ -97,6 +97,30 @@ const onKeydown = (event) => {
 };
 
 onMounted(() => window.addEventListener('keydown', onKeydown));
+
+// One wish, pointed at. A notification about a finished wish sends people to
+// /wishlist/<id>, which lands here with ?highlight=<id> and the right tab
+// already chosen - see WishlistController::show. Without the scroll and the
+// ring the link drops somebody on a list of three hundred and leaves them to
+// find their own wish, which is the whole reason a link to one was needed.
+//
+// The ring times out rather than staying: it says "here", and a wish left
+// permanently ringed reads as a wish with something wrong with it.
+const highlightId = ref(null);
+
+onMounted(() => {
+    const id = parseInt(new URLSearchParams(window.location.search).get('highlight'));
+
+    if (!id) return;
+
+    highlightId.value = id;
+
+    nextTick(() => {
+        document.getElementById('wish-' + id)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+
+    setTimeout(() => { highlightId.value = null; }, 4000);
+});
 onBeforeUnmount(() => {
     window.removeEventListener('keydown', onKeydown);
     if (imagePreview.value) URL.revokeObjectURL(imagePreview.value);
@@ -358,8 +382,9 @@ const fmtDate = (iso) => iso ? new Date(iso).toLocaleDateString(currentLocale())
             </div>
 
             <div v-else class="space-y-3">
-                <div v-for="wish in wishes" :key="wish.id"
-                    class="bg-black/40 backdrop-blur-sm border border-white/10 rounded-2xl p-4 md:p-5 flex gap-4">
+                <div v-for="wish in wishes" :key="wish.id" :id="'wish-' + wish.id"
+                    class="bg-black/40 backdrop-blur-sm border rounded-2xl p-4 md:p-5 flex gap-4 transition-colors duration-500"
+                    :class="highlightId === wish.id ? 'border-fuchsia-400/60 ring-2 ring-fuchsia-500/40' : 'border-white/10'">
 
                     <!-- Score column. The net number is the big one because it
                          is what the list is sorted by; the split sits under it

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,6 +117,12 @@ Route::get('/wishlist', [\App\Http\Controllers\WishlistController::class, 'index
 Route::post('/wishlist', [\App\Http\Controllers\WishlistController::class, 'store'])
     ->middleware(['auth', 'verified', 'throttle:20,60'])
     ->name('wishlist.store');
+// One wish, by id. Nothing is rendered here: it works out which tab the wish
+// currently sits under and sends the browser to the list with it highlighted.
+// A notification written weeks ago stores only /wishlist/123, so the link
+// still lands on the right tab after the wish has moved between them.
+Route::get('/wishlist/{wish}', [\App\Http\Controllers\WishlistController::class, 'show'])
+    ->name('wishlist.show');
 Route::post('/wishlist/{wish}/vote', [\App\Http\Controllers\WishlistController::class, 'vote'])
     ->middleware(['auth', 'verified', 'throttle:120,60'])
     ->name('wishlist.vote');


### PR DESCRIPTION
The wishlist collected wants and then went quiet. Somebody wrote down what they wanted, other people voted for it, it got built, and the only way to find that out was to go back to the board and look. The board is the one page nobody goes back to: you post to it once.

A wish moving to `done` now writes a notification to its author.

Only `done`, and only when the status actually moves. Saving the same status again is what an admin does while writing the public answer, and each of those saves would otherwise be another notification.

The event lives on the model rather than at the admin action, because two places in the panel set a status - the one-field "Set status" action and the ordinary edit form - and a third will be added the day somebody wants a bulk one. Anywhere else, one of them forgets.

Linking to one wish
-------------------

The notification could not simply point at /wishlist. The board defaults to the open tab, so a finished wish is not on the page that link opens, which is exactly the wish somebody is most likely to be sent a link to. Pinning the tab into the stored link does not work either: the wish can be moved again afterwards, and the link would then open the tab it used to be under.

So /wishlist/{wish} is a redirect and nothing else. It works out the tab the wish is under at the moment somebody clicks, and sends them to the list with ?highlight=<id>. The page scrolls to the wish and rings it for four seconds, the same convention the notifications page already uses for a linked notification.

The ring times out rather than staying. It says "here", and a wish left permanently ringed reads as a wish with something wrong with it.

A redirect rather than a page of its own: one wish alone, out of the list it is being voted on in, says nothing about whether anyone else wanted it, which is the only thing the board is for.